### PR TITLE
`KafkaFoundationCompat`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,10 @@ let package = Package(
             name: "SwiftKafka",
             targets: ["SwiftKafka"]
         ),
+        .library(
+            name: "KafkaFoundationCompat",
+            targets: ["KafkaFoundationCompat"]
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
@@ -76,6 +80,12 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "Logging", package: "swift-log"),
+            ]
+        ),
+        .target(
+            name: "KafkaFoundationCompat",
+            dependencies: [
+                "SwiftKafka",
             ]
         ),
         .systemLibrary(

--- a/Sources/KafkaFoundationCompat/Data+KafkaContiguousBytes.swift
+++ b/Sources/KafkaFoundationCompat/Data+KafkaContiguousBytes.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SwiftKafka
+
+extension Data: KafkaContiguousBytes {}


### PR DESCRIPTION
### Motivation:

Users should be able to use `Data` as key/value of `KakfaProducerMessage`.

### Modifications:

* add new `.library` `"KafkaFoundationCompat"` alongside a new target
* make `Foundation.Data` conform to `KafkaContiguousBytes`
