### PR TITLE
avoid setting default values to topic configuration

### DIFF
--- a/Sources/SwiftKafka/RDKafka/RDKafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaTopicConfig.swift
@@ -37,7 +37,7 @@ struct RDKafkaTopicConfig {
     static func set(configPointer: OpaquePointer, key: String, value: String) throws {
         // librdkafka checks that values were modified from default (even if set to default)
         // that may cause unexpected behaviour, so we should check that values are equal
-        var size = 0
+        var size = RDKafkaClient.stringSize
         let configValue = UnsafeMutablePointer<CChar>.allocate(capacity: size)
         defer { configValue.deallocate() }
 


### PR DESCRIPTION
This is the fix for https://github.com/swift-server/swift-kafka-client/issues/106

Effectively, we should check that values are default and don't modify them. This way librdkafka would use default values from the main configuration.