### PR TITLE
Fix: Kafka consumer leaves group after 5 mins

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -170,8 +170,7 @@ public final class KafkaConsumer: Sendable, Service {
             )
         }
 
-        // Events that would be triggered by ``RDKafkaClient/poll(timeout:)``
-        // are now triggered by ``RDKafkaClient/consumerPoll``.
+        // Forward main queue events to the consumer queue.
         try client.pollSetConsumer()
 
         switch configuration.consumptionStrategy._internal {


### PR DESCRIPTION
### Motivation:

This PR fixes issue #110.

`KakfaConsumer`: by polling the `rd_kafka_queue_get_main` queue instead of the `rd_kafka_queue_get_consumer` queue,
the timer for `max.poll.interval.ms` did not get reset which eventually
resulted in a timeout despite polling. (See [`librdkafka`
documentation](https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#acacdb55ae7cb6abfbde89621e512b078))

### Modifications:

* `RDKafkaClient`:
    * rename `mainQueue` to `queue`
    * use `rd_kafka_queue_get_consumer` instead of
      `rd_kafka_queue_get_main` for `KakfaConsumer` clients
      -> this will reset the timer for `max.poll.interval.ms` so that
         the consumer does not time out despite polling
    * invoke `rd_kafka_queue_destroy(self.queue)` on
      `RDKafkaClient.deinit` to loose reference to queue
