### PR TITLE
`KafkaProducer.makeProducerWithEvents()` avoid `fatalError`

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -256,6 +256,11 @@ public final class KafkaConsumer: Sendable, Service {
             logger: logger
         )
 
+        // Note:
+        // It's crucial to initialize the `sourceAndSequence` variable AFTER `client`.
+        // This order is important to prevent the accidental triggering of `KafkaConsumerCloseOnTerminate.didTerminate()`.
+        // If this order is not met and `RDKafkaClient.makeClient()` fails,
+        // it leads to a call to `stateMachine.messageSequenceTerminated()` while it's still in the `.uninitialized` state.
         let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
             elementType: KafkaConsumerEvent.self,
             backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure(),

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -95,7 +95,7 @@ public final class KafkaProducer: Service, Sendable {
         stateMachine: NIOLockedValueBox<KafkaProducer.StateMachine>,
         configuration: KafkaProducerConfiguration,
         topicConfiguration: KafkaTopicConfiguration
-    ) throws {
+    ) {
         self.stateMachine = stateMachine
         self.configuration = configuration
         self.topicConfiguration = topicConfiguration
@@ -130,7 +130,7 @@ public final class KafkaProducer: Service, Sendable {
             )
         }
 
-        try self.init(
+        self.init(
             stateMachine: stateMachine,
             configuration: configuration,
             topicConfiguration: configuration.topicConfiguration
@@ -156,13 +156,6 @@ public final class KafkaProducer: Service, Sendable {
     ) throws -> (KafkaProducer, KafkaProducerEvents) {
         let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
-        let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
-            elementType: KafkaProducerEvent.self,
-            backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure(),
-            delegate: KafkaProducerCloseOnTerminate(stateMachine: stateMachine)
-        )
-        let source = sourceAndSequence.source
-
         let client = try RDKafkaClient.makeClient(
             type: .producer,
             configDictionary: configuration.dictionary,
@@ -170,16 +163,27 @@ public final class KafkaProducer: Service, Sendable {
             logger: logger
         )
 
-        let producer = try KafkaProducer(
+        let producer = KafkaProducer(
             stateMachine: stateMachine,
             configuration: configuration,
             topicConfiguration: configuration.topicConfiguration
         )
 
+        // Note:
+        // It's crucial to initialize the `sourceAndSequence` variable AFTER `client`.
+        // This order is important to prevent the accidental triggering of `KafkaProducerCloseOnTerminate.didTerminate()`.
+        // If this order is not met and `RDKafkaClient.makeClient()` fails,
+        // it leads to a call to `stateMachine.stopConsuming()` while it's still in the `.uninitialized` state.
+        let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
+            elementType: KafkaProducerEvent.self,
+            backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure(),
+            delegate: KafkaProducerCloseOnTerminate(stateMachine: stateMachine)
+        )
+
         stateMachine.withLockedValue {
             $0.initialize(
                 client: client,
-                source: source
+                source: sourceAndSequence.source
             )
         }
 


### PR DESCRIPTION
### Motivation:

`KafkaProducer.makeeProducerWithEvents()`: initializing the
`NIOAsyncSequenceProducer` before the `client`and the `client` init throwing an erorr led to `KafkaProducerCloseOnTerminate` getting triggered in an invalid state which in turn resulted in a `fatalError`

### Modifications:

* make designated initializer of `KafkaProducer` non-throwing
* `KafkaProducer.makeProducerWithEvents`:
    * initialize `client` before
      calling `NIOAsyncSequenceProducer.makeSequence`
      -> if initializing `client` fails the appropiate error gets thrown
         instead of triggering a fatalError because
         `KafkaProducerCloseOnTerminate` gets triggered in an invalid state

### Result:

When the initialization `KafkaProducer.makeProducerWithEvents` fails an
error is thrown instead of triggering the `fatalError` in
`KafkaProducerCloseOnTerminate`.
