### PR TITLE
`KafkaConsumer.commitAsync`

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -369,7 +369,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// - Parameters:
     ///     - message: Last received message that shall be marked as read.
     /// - Throws: A ``KafkaError`` if committing failed.
-    public func commitAsync(_ message: KafkaConsumerMessage) throws {
+    public func scheduleCommit(_ message: KafkaConsumerMessage) throws {
         let action = self.stateMachine.withLockedValue { $0.commit() }
         switch action {
         case .throwClosedError:
@@ -379,8 +379,13 @@ public final class KafkaConsumer: Sendable, Service {
                 throw KafkaError.config(reason: "Committing manually only works if isAutoCommitEnabled set to false")
             }
 
-            try client.commitAsync(message)
+            try client.scheduleCommit(message)
         }
+    }
+
+    @available(*, deprecated, renamed: "commit")
+    public func commitSync(_ message: KafkaConsumerMessage) async throws {
+        try await self.commit(message)
     }
 
     /// Mark all messages up to the passed message in the topic as read.
@@ -393,7 +398,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// - Parameters:
     ///     - message: Last received message that shall be marked as read.
     /// - Throws: A ``KafkaError`` if committing failed.
-    public func commitSync(_ message: KafkaConsumerMessage) async throws {
+    public func commit(_ message: KafkaConsumerMessage) async throws {
         let action = self.stateMachine.withLockedValue { $0.commit() }
         switch action {
         case .throwClosedError:
@@ -403,7 +408,7 @@ public final class KafkaConsumer: Sendable, Service {
                 throw KafkaError.config(reason: "Committing manually only works if isAutoCommitEnabled set to false")
             }
 
-            try await client.commitSync(message)
+            try await client.commit(message)
         }
     }
 

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -538,7 +538,7 @@ final class RDKafkaClient: Sendable {
     ///
     /// - Parameter message: Last received message that shall be marked as read.
     /// - Throws: A ``KafkaError`` if scheduling the commit failed.
-    func commitAsync(_ message: KafkaConsumerMessage) throws {
+    func scheduleCommit(_ message: KafkaConsumerMessage) throws {
         // The offset committed is always the offset of the next requested message.
         // Thus, we increase the offset of the current message by one before committing it.
         // See: https://github.com/edenhill/librdkafka/issues/2745#issuecomment-598067945
@@ -566,12 +566,12 @@ final class RDKafkaClient: Sendable {
     ///
     /// - Parameter message: Last received message that shall be marked as read.
     /// - Throws: A ``KafkaError`` if the commit failed.
-    func commitSync(_ message: KafkaConsumerMessage) async throws {
+    func commit(_ message: KafkaConsumerMessage) async throws {
         // Declare captured closure outside of withCheckedContinuation.
         // We do that because do an unretained pass of the captured closure to
         // librdkafka which means we have to keep a reference to the closure
         // ourselves to make sure it does not get deallocated before
-        // commitSync returns.
+        // commit returns.
         var capturedClosure: CapturedCommitCallback!
         try await withCheckedThrowingContinuation { continuation in
             capturedClosure = CapturedCommitCallback { result in

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -532,9 +532,40 @@ final class RDKafkaClient: Sendable {
         }
     }
 
-    /// Non-blocking **awaitable** commit of a the `message`'s offset to Kafka.
+    /// Non-blocking "fire-and-forget" commit of a `message`'s offset to Kafka.
+    /// Schedules a commit and returns immediately.
+    /// Any errors encountered after scheduling the commit will be discarded.
     ///
     /// - Parameter message: Last received message that shall be marked as read.
+    /// - Throws: A ``KafkaError`` if scheduling the commit failed.
+    func commitAsync(_ message: KafkaConsumerMessage) throws {
+        // The offset committed is always the offset of the next requested message.
+        // Thus, we increase the offset of the current message by one before committing it.
+        // See: https://github.com/edenhill/librdkafka/issues/2745#issuecomment-598067945
+        let changesList = RDKafkaTopicPartitionList()
+        changesList.setOffset(
+            topic: message.topic,
+            partition: message.partition,
+            offset: Int64(message.offset.rawValue + 1)
+        )
+
+        let error = changesList.withListPointer { listPointer in
+            return rd_kafka_commit(
+                self.kafkaHandle,
+                listPointer,
+                1 // async = true
+            )
+        }
+
+        if error != RD_KAFKA_RESP_ERR_NO_ERROR {
+            throw KafkaError.rdKafkaError(wrapping: error)
+        }
+    }
+
+    /// Non-blocking **awaitable** commit of a `message`'s offset to Kafka.
+    ///
+    /// - Parameter message: Last received message that shall be marked as read.
+    /// - Throws: A ``KafkaError`` if the commit failed.
     func commitSync(_ message: KafkaConsumerMessage) async throws {
         // Declare captured closure outside of withCheckedContinuation.
         // We do that because do an unretained pass of the captured closure to

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -214,7 +214,7 @@ final class KafkaTests: XCTestCase {
         }
     }
 
-    func testProduceAndConsumeWithCommitAsync() async throws {
+    func testProduceAndConsumeWithScheduleCommit() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
         let (producer, events) = try KafkaProducer.makeProducerWithEvents(configuration: self.producerConfig, logger: .kafkaTest)
 
@@ -254,7 +254,7 @@ final class KafkaTests: XCTestCase {
                 var consumedMessages = [KafkaConsumerMessage]()
                 for try await message in consumer.messages {
                     consumedMessages.append(message)
-                    try consumer.commitAsync(message)
+                    try consumer.scheduleCommit(message)
 
                     if consumedMessages.count >= testMessages.count {
                         break
@@ -272,7 +272,7 @@ final class KafkaTests: XCTestCase {
         }
     }
 
-    func testProduceAndConsumeWithCommitSync() async throws {
+    func testProduceAndConsumeWithCommit() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
         let (producer, events) = try KafkaProducer.makeProducerWithEvents(configuration: self.producerConfig, logger: .kafkaTest)
 
@@ -312,7 +312,7 @@ final class KafkaTests: XCTestCase {
                 var consumedMessages = [KafkaConsumerMessage]()
                 for try await message in consumer.messages {
                     consumedMessages.append(message)
-                    try await consumer.commitSync(message)
+                    try await consumer.commit(message)
 
                     if consumedMessages.count >= testMessages.count {
                         break
@@ -381,7 +381,7 @@ final class KafkaTests: XCTestCase {
                         continue
                     }
                     consumedMessages.append(message)
-                    try await consumer.commitSync(message)
+                    try await consumer.commit(message)
 
                     if consumedMessages.count >= testMessages.count {
                         break


### PR DESCRIPTION
### Motivation:

Having `KafkaConsumer.commitSync` be `async` is not always convenient as
it suspends the `KafkaConsumer.messages` read loop and can therefore
lower throughput.

This PR introduces a new method `KafkaConsumer.commitAsync` that allows
users who don't care about the result of the `commit` to commit in a
"fire-and-forget" manner.

### Modifications:

* new method `KafkaConsumer.commitAsync`
* rename `KafkaConsumer.StateMachine.commitSync` to
  `KafkaConsumer.StateMachine.commit` to serve both `commitSync` and
  `commitAsync`
* add new test for `KafkaConsumer.commitAsync`
