### PR TITLE
`storeMessageOffset`: ignore state error

### DIFF
--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -520,6 +520,14 @@ final class RDKafkaClient: Sendable {
         }
 
         if error != RD_KAFKA_RESP_ERR_NO_ERROR {
+            // Ignore RD_KAFKA_RESP_ERR__STATE error.
+            // RD_KAFKA_RESP_ERR__STATE indicates an attempt to commit to an unassigned partition,
+            // which can occur during rebalancing or when the consumer is shutting down.
+            // See "Upgrade considerations" for more details: https://github.com/confluentinc/librdkafka/releases/tag/v1.9.0
+            // Since Kafka Consumers are designed for at-least-once processing, failing to commit here is acceptable.
+            if error != RD_KAFKA_RESP_ERR__STATE {
+                return
+            }
             throw KafkaError.rdKafkaError(wrapping: error)
         }
     }


### PR DESCRIPTION
### Motivation:

Previously, we failed the entire `KafkaConsumer` if storing
a message offset through `RDKafkaClient.storeMessageOffset`
failed because the partition the offset should be committed to
was unassigned (which can happen during rebalance).

We should not fail the consumer when committing during
rebalance.

The worst thing that could happen here is that storing the offset
fails and we re-read a message, which is fine since KafkaConsumers with
automatic commits are designed for at-least-once processing:

https://docs.confluent.io/platform/current/clients/consumer.html#offset-management

### Modifications:

* `RDKafkaClient.storeMessageOffset`: don't throw when receiving
  error
  `RD_KAFKA_RESP_ERR__STATE`
