### PR TITLE
Make triggerGracefulShutdown() public

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -385,7 +385,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// - Note: Invoking this function is not always needed as the ``KafkaConsumer``
     /// will already shut down when consumption of the ``KafkaConsumerMessages`` has ended.
-    private func triggerGracefulShutdown() {
+    public func triggerGracefulShutdown() {
         let action = self.stateMachine.withLockedValue { $0.finish() }
         switch action {
         case .triggerGracefulShutdown(let client):

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -235,7 +235,7 @@ public final class KafkaProducer: Service, Sendable {
     ///
     /// This method flushes any buffered messages and waits until a callback is received for all of them.
     /// Afterwards, it shuts down the connection to Kafka and cleans any remaining state up.
-    private func triggerGracefulShutdown() {
+    public func triggerGracefulShutdown() {
         self.stateMachine.withLockedValue { $0.finish() }
     }
 


### PR DESCRIPTION
Related to https://github.com/swift-server/swift-kafka-client/issues/125

ServiceLifecycle is not always required by end user, though `KafkaConsumer` and `KafkaProducer` can run without it.
However, it is impossible (in good manner) stop either of them without public method `triggerGracefulShutdown()`.

This PR allows makes `triggerGracefulShutdown()` public thus allow to use `KafkaConsumer`/`KafkaProducer` directly.