### PR TITLE
Ship with BoringSSL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
-        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/apple/swift-nio-ssl", .upToNextMajor(from: "2.25.0")),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // The zstd Swift package produces warnings that we cannot resolve:
         // https://github.com/facebook/zstd/issues/3328
@@ -56,7 +57,7 @@ let package = Package(
         .target(
             name: "Crdkafka",
             dependencies: [
-                "COpenSSL",
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "libzstd", package: "zstd"),
             ],
             exclude: rdkafkaExclude,
@@ -65,6 +66,7 @@ let package = Package(
             cSettings: [
                 // dummy folder, because config.h is included as "../config.h" in librdkafka
                 .headerSearchPath("./custom/config/dummy"),
+                .headerSearchPath("./custom/include"),
                 .headerSearchPath("./librdkafka/src"),
             ],
             linkerSettings: [
@@ -86,14 +88,6 @@ let package = Package(
             name: "KafkaFoundationCompat",
             dependencies: [
                 "Kafka",
-            ]
-        ),
-        .systemLibrary(
-            name: "COpenSSL",
-            pkgConfig: "openssl",
-            providers: [
-                .brew(["libressl"]),
-                .apt(["libssl-dev"]),
             ]
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,7 @@ let package = Package(
                 .headerSearchPath("./custom/config/dummy"),
                 .headerSearchPath("./custom/include"),
                 .headerSearchPath("./librdkafka/src"),
+                .define("_GNU_SOURCE", to: "1"), // Fix build error for Swift 5.9 onwards
             ],
             linkerSettings: [
                 .linkedLibrary("curl"),

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl", .upToNextMajor(from: "2.25.0")),
+        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.25.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.1.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // The zstd Swift package produces warnings that we cannot resolve:

--- a/Sources/Crdkafka/custom/include/openssl/err.h
+++ b/Sources/Crdkafka/custom/include/openssl/err.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_err.h"

--- a/Sources/Crdkafka/custom/include/openssl/evp.h
+++ b/Sources/Crdkafka/custom/include/openssl/evp.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_evp.h"

--- a/Sources/Crdkafka/custom/include/openssl/hmac.h
+++ b/Sources/Crdkafka/custom/include/openssl/hmac.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_hmac.h"

--- a/Sources/Crdkafka/custom/include/openssl/pkcs12.h
+++ b/Sources/Crdkafka/custom/include/openssl/pkcs12.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_pkcs12.h"

--- a/Sources/Crdkafka/custom/include/openssl/sha.h
+++ b/Sources/Crdkafka/custom/include/openssl/sha.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_sha.h"

--- a/Sources/Crdkafka/custom/include/openssl/ssl.h
+++ b/Sources/Crdkafka/custom/include/openssl/ssl.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_ssl.h"

--- a/Sources/Crdkafka/custom/include/openssl/x509.h
+++ b/Sources/Crdkafka/custom/include/openssl/x509.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_x509.h"

--- a/Sources/Crdkafka/custom/include/openssl/x509_vfy.h
+++ b/Sources/Crdkafka/custom/include/openssl/x509_vfy.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#include "CNIOBoringSSL_x509_vfy.h"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,6 @@ ENV LANGUAGE en_US.UTF-8
 # Dependencies
 RUN apt-get update
 RUN apt-get install libsasl2-dev -y
-RUN apt-get install libssl-dev -y
 
 # tools
 RUN mkdir -p $HOME/.tools


### PR DESCRIPTION
Closes #123 

### Motivation:

No need to install `libressl` on machine to build project.

### Modifications:

* add dependency to `swift-nio-ssl` to obtain copy of `BoringSSL`
* create bridging headers allowing `librdkafka` to build with `BoringSSL` copy from `swift-nio-ssl`

#### Additional Changes:

* use `swift-service-lifecycle` version `2.1.0` instead of `beta`