### PR TITLE
Add CI pipeline for Swift 5.10

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -3,17 +3,16 @@ version: "3"
 services:
 
   runtime-setup:
-    image: swift-kafka-client:22.04-5.9
+    image: swift-kafka-client:22.04-5.10
     build:
       args:
-        ubuntu_version: "jammy"
-        swift_version: "5.9"
+        base_image: "swiftlang/swift:nightly-5.10-jammy"
 
   build:
-    image: swift-kafka-client:22.04-5.9
+    image: swift-kafka-client:22.04-5.10
 
   test:
-    image: swift-kafka-client:22.04-5.9
+    image: swift-kafka-client:22.04-5.10
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
@@ -21,4 +20,4 @@ services:
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:
-    image: swift-kafka-client:22.04-5.9
+    image: swift-kafka-client:22.04-5.10


### PR DESCRIPTION
Motivation:

Now that Swift 5.9 is GM we should update the CI pipelines

Modifications:

* Add a 5.10 nightly docker compose file
* Update the 5.9 compose file to stop using nightlies

Result:

Remove add CI support for 5.10