### PR TITLE
`KafkaConsumer`: back pressure  + improved read speed

### DIFF
--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -23,6 +23,37 @@ public struct KafkaConsumerConfiguration {
     /// Default: `.milliseconds(100)`
     public var pollInterval: Duration = .milliseconds(100)
 
+    /// A struct representing different back pressure strategies for consuming messages in ``KafkaConsumer``.
+    public struct BackPressureStrategy: Sendable, Hashable {
+        enum _BackPressureStrategy: Sendable, Hashable {
+            case watermark(low: Int, high: Int)
+        }
+
+        let _internal: _BackPressureStrategy
+
+        private init(backPressureStrategy: _BackPressureStrategy) {
+            self._internal = backPressureStrategy
+        }
+
+        /// A back pressure strategy based on high and low watermarks.
+        ///
+        /// The consumer maintains a buffer size between a low watermark and a high watermark
+        /// to control the flow of incoming messages.
+        ///
+        /// - Parameter low: The lower threshold for the buffer size (low watermark).
+        /// - Parameter high: The upper threshold for the buffer size (high watermark).
+        public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
+            return .init(backPressureStrategy: .watermark(low: low, high: high))
+        }
+    }
+
+    /// The backpressure strategy to be used for message consumption.
+    /// See ``KafkaConsumerConfiguration/BackPressureStrategy-swift.struct`` for more information.
+    public var backPressureStrategy: BackPressureStrategy = .watermark(
+        low: 10,
+        high: 50
+    )
+
     /// A struct representing the different Kafka message consumption strategies.
     public struct ConsumptionStrategy: Sendable, Hashable {
         enum _ConsumptionStrategy: Sendable, Hashable {
@@ -63,7 +94,7 @@ public struct KafkaConsumerConfiguration {
     }
 
     /// The strategy used for consuming messages.
-    /// See ``KafkaConfiguration/ConsumptionStrategy`` for more information.
+    /// See ``KafkaConsumerConfiguration/ConsumptionStrategy-swift.struct-swift.struct`` for more information.
     public var consumptionStrategy: ConsumptionStrategy
 
     // MARK: - Consumer-specific Config Properties

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -21,8 +21,6 @@ public enum KafkaConsumerEvent: Sendable, Hashable {
         switch event {
         case .deliveryReport:
             fatalError("Cannot cast \(event) to KafkaConsumerEvent")
-        case .consumerMessages:
-            fatalError("Consumer messages should be handled in the KafkaConsumerMessages asynchronous sequence")
         }
     }
 }

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -23,8 +23,6 @@ public enum KafkaProducerEvent: Sendable, Hashable {
         switch event {
         case .deliveryReport(results: let results):
             self = .deliveryReports(results)
-        case .consumerMessages:
-            fatalError("Cannot cast \(event) to KafkaProducerEvent")
         }
     }
 }

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -44,22 +44,7 @@ final class RDKafkaClient: Sendable {
     ) {
         self.kafkaHandle = kafkaHandle
         self.logger = logger
-
-        if type == .consumer {
-            if let consumerQueue = rd_kafka_queue_get_consumer(self.kafkaHandle) {
-                // (Important)
-                // Polling the queue counts as a consumer poll, and will reset the timer for `max.poll.interval.ms`.
-                self.queue = consumerQueue
-            } else {
-                fatalError("""
-                Internal error: failed to get consumer queue. \
-                A group.id should be set even when the client is not part of a consumer group. \
-                See https://github.com/edenhill/librdkafka/issues/3261 for more information.
-                """)
-            }
-        } else {
-            self.queue = rd_kafka_queue_get_main(self.kafkaHandle)
-        }
+        self.queue = rd_kafka_queue_get_main(self.kafkaHandle)
 
         rd_kafka_set_log_queue(self.kafkaHandle, self.queue)
     }
@@ -310,7 +295,6 @@ final class RDKafkaClient: Sendable {
     /// Swift wrapper for events from `librdkafka`'s event queue.
     enum KafkaEvent {
         case deliveryReport(results: [KafkaDeliveryReport])
-        case consumerMessages(result: Result<KafkaConsumerMessage, Error>)
     }
 
     /// Poll the event `rd_kafka_queue_t` for new events.
@@ -333,10 +317,6 @@ final class RDKafkaClient: Sendable {
             case .deliveryReport:
                 let forwardEvent = self.handleDeliveryReportEvent(event)
                 events.append(forwardEvent)
-            case .fetch:
-                if let forwardEvent = self.handleFetchEvent(event) {
-                    events.append(forwardEvent)
-                }
             case .log:
                 self.handleLogEvent(event)
             case .offsetCommit:
@@ -370,26 +350,6 @@ final class RDKafkaClient: Sendable {
 
         // The returned message(s) MUST NOT be freed with rd_kafka_message_destroy().
         return .deliveryReport(results: deliveryReportResults)
-    }
-
-    /// Handle event of type `RDKafkaEvent.fetch`.
-    ///
-    /// - Parameter event: Pointer to underlying `rd_kafka_event_t`.
-    /// - Returns: `KafkaEvent` to be returned as part of ``KafkaClient.eventPoll()`.
-    private func handleFetchEvent(_ event: OpaquePointer?) -> KafkaEvent? {
-        do {
-            // RD_KAFKA_EVENT_FETCH only returns a single message:
-            // https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a3a855eb7bdf17f5797d4911362a5fc7c
-            if let messagePointer = rd_kafka_event_message_next(event) {
-                let message = try KafkaConsumerMessage(messagePointer: messagePointer)
-                return .consumerMessages(result: .success(message))
-            } else {
-                return nil
-            }
-        } catch {
-            return .consumerMessages(result: .failure(error))
-        }
-        // The returned message(s) MUST NOT be freed with rd_kafka_message_destroy().
     }
 
     /// Handle event of type `RDKafkaEvent.log`.
@@ -451,18 +411,30 @@ final class RDKafkaClient: Sendable {
         actualCallback(.success(()))
     }
 
-    /// Redirect the main ``RDKafkaClient/poll(timeout:)`` queue to the `KafkaConsumer`'s
-    /// queue (``RDKafkaClient/consumerPoll``).
+    /// Request a new message from the Kafka cluster.
     ///
-    /// Events that would be triggered by ``RDKafkaClient/poll(timeout:)``
-    /// are now triggered by ``RDKafkaClient/consumerPoll``.
+    /// - Important: This method should only be invoked from ``KafkaConsumer``.
     ///
-    /// - Warning: It is not allowed to call ``RDKafkaClient/poll(timeout:)`` after ``RDKafkaClient/pollSetConsumer``.
-    func pollSetConsumer() throws {
-        let result = rd_kafka_poll_set_consumer(self.kafkaHandle)
-        if result != RD_KAFKA_RESP_ERR_NO_ERROR {
-            throw KafkaError.rdKafkaError(wrapping: result)
+    /// - Returns: A ``KafkaConsumerMessage`` or `nil` if there are no new messages.
+    /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
+    func consumerPoll() throws -> KafkaConsumerMessage? {
+        guard let messagePointer = rd_kafka_consumer_poll(self.kafkaHandle, 0) else {
+            // No error, there might be no more messages
+            return nil
         }
+
+        defer {
+            // Destroy message otherwise poll() will block forever
+            rd_kafka_message_destroy(messagePointer)
+        }
+
+        // Reached the end of the topic+partition queue on the broker
+        if messagePointer.pointee.err == RD_KAFKA_RESP_ERR__PARTITION_EOF {
+            return nil
+        }
+
+        let message = try KafkaConsumerMessage(messagePointer: messagePointer)
+        return message
     }
 
     /// Subscribe to topic set using balanced consumer groups.

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -599,6 +599,56 @@ final class KafkaTests: XCTestCase {
         }
     }
 
+    // TODO: remove
+    func testDelete() async throws {
+        var consumerConfig = KafkaConsumerConfiguration(
+            consumptionStrategy: .partition(
+                KafkaPartition(rawValue: 0),
+                topic: "test-topic",
+                offset: KafkaOffset(rawValue: 0) // Important: Read from beginning!
+            ),
+            bootstrapBrokerAddresses: [self.bootstrapBrokerAddress]
+        )
+        consumerConfig.pollInterval = .milliseconds(100)
+        consumerConfig.autoOffsetReset = .beginning // Always read topics from beginning
+        consumerConfig.broker.addressFamily = .v4
+
+        let consumer = try KafkaConsumer(
+            configuration: consumerConfig,
+            logger: .kafkaTest
+        )
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            // Run Task
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            // Consumer Task
+            group.addTask {
+                var count = 0
+                for try await message in consumer.messages {
+                    _ = message // drop message
+                    count += 1
+//                    try await Task.sleep(for: .milliseconds(1))
+                    if count % 1000 == 0 {
+                        print(count)
+                    }
+                    if count == 1_000_000 {
+                        break
+                    }
+                }
+            }
+
+            // Wait for Consumer Task to complete
+            try await group.next()
+            // Shutdown the serviceGroup
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
     // MARK: - Helpers
 
     private static func createTestMessages(


### PR DESCRIPTION
### Motivation:

Closes #131.

### Example:

I ran an example consumer reading a topic with approx. `11_000_000` messages:

```swift
var consumerConfig = KafkaConsumerConfiguration(
    consumptionStrategy: .partition(
        KafkaPartition(rawValue: 0),
        topic: "test-topic",
        offset: KafkaOffset(rawValue: 0) // Important: Read from beginning!
    ),
    bootstrapBrokerAddresses: [self.bootstrapBrokerAddress]
)
consumerConfig.pollInterval = .zero
consumerConfig.autoOffsetReset = .beginning // Always read topics from beginning
consumerConfig.broker.addressFamily = .v4

let consumer = try KafkaConsumer(
    configuration: consumerConfig,
    logger: .kafkaTest
)

let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)

try await withThrowingTaskGroup(of: Void.self) { group in
    // Run Task
    group.addTask {
        try await serviceGroup.run()
    }

    // Consumer Task
    group.addTask {
        var count = 0
        for try await message in consumer.messages {
            _ = message // drop message
            count += 1
            try await Task.sleep(for: .milliseconds(1))
            if count % 1000 == 0 {
                print(count)
            }
        }
    }

    // Wait for Consumer Task to complete
    try await group.next()
    // Shutdown the serviceGroup
    await serviceGroup.triggerGracefulShutdown()
}

```

##### Before

(Without back pressure)

<img width="1624" alt="Screenshot 2023-10-11 at 13 23 53" src="https://github.com/swift-server/swift-kafka-client/assets/26013286/24a7703a-cb19-4348-8dc9-13d1a19a07bf">

##### After

(With back pressure)

<img width="1624" alt="Screenshot 2023-10-11 at 20 48 18" src="https://github.com/swift-server/swift-kafka-client/assets/26013286/f16fdb64-cf8e-4ae6-b9d9-7f31d675266f">

This result is tolerable since the `queued.max.messages.kbytes` configuration property defaults to prefetching at max `~65` MegaBytes of messages. Exposing `queued.max.messages.kbytes` will be done in a follow-up PR.

### Modifications:

* re-add `KafkaConsumerConfiguration.backPressureStrategy: BackPressureStrategy`, currently allowing users to add high-low-watermark backpressure to their `KafkaConsumer`s
* `KafkaConsumer`:
    * make `KafkaConsumerMessages` use `NIOAsyncSequenceProducerBackPressureStrategies.HighLowWatermark` as backpressure strategy
    * remove `rd_kafka_poll_set_consumer` -> use two separate queues for consumer events and consumer messages so we can exert backpressure on the consumer message queue
    * remove idle polling mechanism where incoming messages were discarded when `KafkaConsumerMessages` was terminated -> we now have to independent queues
    * rename `.pollForAndYieldMessage` -> `.pollForEventsAndMessages`
    * refactor `State` and add `ConsumerMessagesSequenceState`
* `KafkaProducer`:
    * rename `.consumptionStopped` -> `.eventConsumptionFinished`
* `RDKafkaClient`:
    * bring back `consumerPoll()` * `eventPoll()`: only queue main queue for events since consumer messages are now handled on a different queue