### PR TITLE
Fix error test when ignoring RD_KAFKA_RESP_ERR_NO_ERROR in storeMessageOffset

### DIFF
--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -525,7 +525,7 @@ final class RDKafkaClient: Sendable {
             // which can occur during rebalancing or when the consumer is shutting down.
             // See "Upgrade considerations" for more details: https://github.com/confluentinc/librdkafka/releases/tag/v1.9.0
             // Since Kafka Consumers are designed for at-least-once processing, failing to commit here is acceptable.
-            if error != RD_KAFKA_RESP_ERR__STATE {
+            if error == RD_KAFKA_RESP_ERR__STATE {
                 return
             }
             throw KafkaError.rdKafkaError(wrapping: error)


### PR DESCRIPTION
**Motivation**

#129 attempted to ignore `RD_KAFKA_RESP_ERR_NO_ERROR` when executing `storeMessageOffset` func. However, the if test is inverted, it instead ignores all errors but `RD_KAFKA_RESP_ERR_NO_ERROR`. This PR fixes this.

**Modification**

* Fix `storeMessageOffset` error handling, ignore `RD_KAFKA_RESP_ERR_NO_ERROR`, stop ignoring other errors.