### PR TITLE
Update to latest librdkafka & add a define for RAND_priv_bytes (#138)

### DIFF
--- a/Sources/Crdkafka/custom/include/openssl/ssl.h
+++ b/Sources/Crdkafka/custom/include/openssl/ssl.h
@@ -13,3 +13,5 @@
 //===----------------------------------------------------------------------===//
 
 #include "CNIOBoringSSL_ssl.h"
+
+#define RAND_priv_bytes(buf, num) RAND_bytes((buf), (num))


### PR DESCRIPTION
>Would appreciate a PR for it. I think the solution should be as easy as doing something like this `#define RAND_priv_bytes(x,sz) RAND_bytes((x),(sz))` in a C file where we shim boringssl to openssl.

_Originally posted by @FranzBusch in https://github.com/swift-server/swift-kafka-client/issues/138#issuecomment-1822864000_

As discussed. Let me know if there's a better place for the `#define`.