### PR TITLE
Defer source.finish()

### DIFF
--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -238,8 +238,10 @@ public final class KafkaProducer: Service, Sendable {
                     0...Int(Int32.max) ~= self.configuration.flushTimeoutMilliseconds,
                     "Flush timeout outside of valid range \(0...Int32.max)"
                 )
+                defer { // we should finish source indefinetely of exception in client.flush()
+                    source?.finish()
+                }
                 try await client.flush(timeoutMilliseconds: Int32(self.configuration.flushTimeoutMilliseconds))
-                source?.finish()
                 return
             case .terminatePollLoop:
                 return


### PR DESCRIPTION
Flush may throw exception thus source will not be finished.
Exception can be e.g. timeout (due to network outage): 
```
Caught exception KafkaError.rdKafkaError: Local: Timed out Kafka/RDKafkaClient.swift...
``` 