### PR TITLE
Use returned error

### DIFF
--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -150,7 +150,7 @@ public final class RDKafkaClient: Sendable {
         }
 
         if error != RD_KAFKA_RESP_ERR_NO_ERROR {
-            throw KafkaError.rdKafkaError(wrapping: rd_kafka_last_error())
+            throw KafkaError.rdKafkaError(wrapping: error)
         }
     }
 


### PR DESCRIPTION
Sometimes it is possible to receive the following error:
```
KafkaError.rdKafkaError: Success
```
The problem is that last error is returned instead of resulting error from method.