### PR TITLE
Introduce `SendableOpaquePointer`

### DIFF
--- a/Sources/Kafka/Utilities/SendableOpaquePointer.swift
+++ b/Sources/Kafka/Utilities/SendableOpaquePointer.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2024 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// A wrapper for the `OpaquePointer` used to represent different handles from `librdkafka`.
+///
+/// This wrapper silences `Sendable` warnings for the pointer introduced in Swift 5.10, and should
+/// only be used for handles from `librdkafka` that are known to be thread-safe.
+internal struct SendableOpaquePointer: @unchecked Sendable {
+    let pointer: OpaquePointer
+
+    init(_ pointer: OpaquePointer) {
+        self.pointer = pointer
+    }
+}

--- a/Sources/Kafka/Utilities/SendableOpaquePointer.swift
+++ b/Sources/Kafka/Utilities/SendableOpaquePointer.swift
@@ -16,7 +16,7 @@
 ///
 /// This wrapper silences `Sendable` warnings for the pointer introduced in Swift 5.10, and should
 /// only be used for handles from `librdkafka` that are known to be thread-safe.
-internal struct SendableOpaquePointer: @unchecked Sendable {
+struct SendableOpaquePointer: @unchecked Sendable {
     let pointer: OpaquePointer
 
     init(_ pointer: OpaquePointer) {


### PR DESCRIPTION
[Unsafe pointers are no longer `Sendable`](https://github.com/swiftlang/swift/issues/70396#issuecomment-1851497237) starting with Swift 5.10, while a warning in earlier versions. This PR introduces `SendableOpaquePointer` to wrap `OpaquePointer` and marks it as `@unchecked Sendable`.

Resolves https://github.com/swift-server/swift-kafka-client/issues/159