### PR TITLE
Enable Swift 6 support

### DIFF
--- a/Sources/Kafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/Kafka/KafkaAcknowledgedMessage.swift
@@ -40,9 +40,16 @@ public struct KafkaAcknowledgedMessage {
             throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
         }
 
+        #if swift(<6.0)
         guard let topic = String(validatingUTF8: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
             fatalError("Received topic name that is non-valid UTF-8")
         }
+        #else
+        guard let topic = String(validatingCString: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
+            fatalError("Received topic name that is non-valid UTF-8")
+        }
+        #endif
+
         self.topic = topic
 
         self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -52,9 +52,16 @@ public struct KafkaConsumerMessage {
             }
         }
 
+        #if swift(<6.0)
         guard let topic = String(validatingUTF8: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
             fatalError("Received topic name that is non-valid UTF-8")
         }
+        #else
+        guard let topic = String(validatingCString: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
+            fatalError("Received topic name that is non-valid UTF-8")
+        }
+        #endif
+
         self.topic = topic
 
         self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))


### PR DESCRIPTION
Enable Swift 6 support. `String.init(validatingUTF8:)` is deprecated, and we use `String.init(validatingCString:)` instead.

Closes https://github.com/swift-server/swift-kafka-client/pull/169