### PR TITLE
Poll for messages using `TaskExecutor`

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -73,7 +73,9 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
     public struct AsyncIterator: AsyncIteratorProtocol {
         private let stateMachineHolder: MachineHolder
         let pollInterval: Duration
+        #if swift(>=6.0)
         let queue: NaiveQueueExecutor
+        #endif
 
         private final class MachineHolder: Sendable {  // only for deinit
             let stateMachine: LockedMachine
@@ -90,7 +92,9 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
         init(stateMachine: LockedMachine, pollInterval: Duration) {
             self.stateMachineHolder = .init(stateMachine: stateMachine)
             self.pollInterval = pollInterval
+            #if swift(>=6.0)
             self.queue = NaiveQueueExecutor(DispatchQueue(label: "com.swift-server.swift-kafka.message-consumer"))
+            #endif
         }
 
         public func next() async throws -> Element? {

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -112,7 +112,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
                     }
                     #else
                     // No messages. Sleep a little.
-                    return try await Task.sleep(for: self.pollInterval)
+                    try await Task.sleep(for: self.pollInterval)
                     #endif
                 case .suspendPollLoop:
                     try await Task.sleep(for: self.pollInterval)  // not started yet

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -446,8 +446,8 @@ public final class RDKafkaClient: Sendable {
     ///
     /// - Returns: A ``KafkaConsumerMessage`` or `nil` if there are no new messages.
     /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
-    func consumerPoll() throws -> KafkaConsumerMessage? {
-        guard let messagePointer = rd_kafka_consumer_poll(self.kafkaHandle.pointer, 0) else {
+    func consumerPoll(for pollTimeoutMs: Int32 = 0) throws -> KafkaConsumerMessage? {
+        guard let messagePointer = rd_kafka_consumer_poll(self.kafkaHandle.pointer, pollTimeoutMs) else {
             // No error, there might be no more messages
             return nil
         }

--- a/Sources/Kafka/Utilities/DispatchQueueTaskExecutor.swift
+++ b/Sources/Kafka/Utilities/DispatchQueueTaskExecutor.swift
@@ -15,7 +15,7 @@
 #if swift(>=6.0)
 import Dispatch
 
-final class NaiveQueueExecutor: TaskExecutor {
+final class DispatchQueueTaskExecutor: TaskExecutor {
     let queue: DispatchQueue
 
     init(_ queue: DispatchQueue) {

--- a/Sources/Kafka/Utilities/NaiveQueueExecutor.swift
+++ b/Sources/Kafka/Utilities/NaiveQueueExecutor.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2024 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+
+final class NaiveQueueExecutor: TaskExecutor {
+  let queue: DispatchQueue
+
+  init(_ queue: DispatchQueue) {
+    self.queue = queue
+  }
+
+  public func enqueue(_ _job: consuming ExecutorJob) {
+  let job = UnownedJob(_job)
+  queue.async {
+    job.runSynchronously(
+        on: self.asUnownedTaskExecutor())
+    }
+  }
+
+  @inlinable
+  public func asUnownedTaskExecutor() -> UnownedTaskExecutor {
+    UnownedTaskExecutor(ordinary: self)
+  }
+}

--- a/Sources/Kafka/Utilities/NaiveQueueExecutor.swift
+++ b/Sources/Kafka/Utilities/NaiveQueueExecutor.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if swift(>=6.0)
 import Dispatch
 
 final class NaiveQueueExecutor: TaskExecutor {
@@ -35,3 +36,4 @@ final class NaiveQueueExecutor: TaskExecutor {
         UnownedTaskExecutor(ordinary: self)
     }
 }
+#endif

--- a/Sources/Kafka/Utilities/NaiveQueueExecutor.swift
+++ b/Sources/Kafka/Utilities/NaiveQueueExecutor.swift
@@ -15,22 +15,23 @@
 import Dispatch
 
 final class NaiveQueueExecutor: TaskExecutor {
-  let queue: DispatchQueue
+    let queue: DispatchQueue
 
-  init(_ queue: DispatchQueue) {
-    self.queue = queue
-  }
-
-  public func enqueue(_ _job: consuming ExecutorJob) {
-  let job = UnownedJob(_job)
-  queue.async {
-    job.runSynchronously(
-        on: self.asUnownedTaskExecutor())
+    init(_ queue: DispatchQueue) {
+        self.queue = queue
     }
-  }
 
-  @inlinable
-  public func asUnownedTaskExecutor() -> UnownedTaskExecutor {
-    UnownedTaskExecutor(ordinary: self)
-  }
+    public func enqueue(_ _job: consuming ExecutorJob) {
+        let job = UnownedJob(_job)
+        queue.async {
+            job.runSynchronously(
+                on: self.asUnownedTaskExecutor()
+            )
+        }
+    }
+
+    @inlinable
+    public func asUnownedTaskExecutor() -> UnownedTaskExecutor {
+        UnownedTaskExecutor(ordinary: self)
+    }
 }


### PR DESCRIPTION
We currently sleep for `pollInterval` when no new messages have been polled from the cluster. This leads to unnecessary slowness of the client. Instead of doing that, we now break up the polling of messages into two distinct approaches:

1. Attempt to poll synchronously: if there a message is polled, we return it. If there is no message, we immediately go to step 2.
2. We create a `DispatchQueue` and run the `consumerPoll` on it using `withTaskExecutorPreference`. We make the `consumerPoll` call wait for up to `pollInterval` before bailing.

This prevents us from sleeping on the running thread, and frees up cycles to do other work if required.

Resolves https://github.com/swift-server/swift-kafka-client/issues/165