### PR TITLE
CI use 6.1 nightlies, enable more soundness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,5 +14,5 @@ jobs:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,14 +22,26 @@ jobs:
       linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
+  construct-cxx-matrix:
+    name: Construct Cxx interop matrix
+    runs-on: ubuntu-latest
+    outputs:
+      cxx-interop-matrix: '${{ steps.generate-matrix.outputs.cxx-interop-matrix }}'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "cxx-interop-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          MATRIX_LINUX_COMMAND: "curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"
+          MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q curl jq libsasl2-dev"
+
   cxx-interop:
     name: Cxx interop
-    uses: apple/swift-nio/.github/workflows/swift_matrix.yml@main
+    needs: construct-cxx-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
     with:
       name: "Cxx interop"
-      matrix_linux_command: "apt-get update -y -q && apt-get install -y -q jq && apt-get -y install libsasl2-dev && curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"
-      matrix_linux_5_9_enabled: true
-      matrix_linux_5_10_enabled: true
-      matrix_linux_6_0_enabled: true
-      matrix_linux_nightly_6_1_enabled: true
-      matrix_linux_nightly_main_enabled: true
+      matrix_string: '${{ needs.construct-cxx-matrix.outputs.cxx-interop-matrix }}'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,9 +9,8 @@ jobs:
     name: Soundness
     uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
     with:
+      linux_pre_build_command: "apt-get update -y -q && apt-get install -y -q libsasl2-dev"
       license_header_check_project_name: "swift-kafka-client"
-      api_breakage_check_enabled: false  # requires libsasl2-dev
-      docs_check_enabled: false  # requires libsasl2-dev
 
   unit-tests:
     name: Unit tests
@@ -20,7 +19,7 @@ jobs:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_nightly_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:
@@ -32,8 +31,5 @@ jobs:
       matrix_linux_5_9_enabled: true
       matrix_linux_5_10_enabled: true
       matrix_linux_6_0_enabled: true
-      matrix_linux_nightly_6_0_enabled: true
+      matrix_linux_nightly_6_1_enabled: true
       matrix_linux_nightly_main_enabled: true
-      matrix_windows_6_0_enabled: false
-      matrix_windows_nightly_6_0_enabled: false
-      matrix_windows_nightly_main_enabled: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,7 +46,7 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit tests
+    name: Unit tests (${{ matrix.swift.swift_version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,13 +27,13 @@ on:
         type: string
         description: "The arguments passed to swift test in the Linux 6.0 Swift version matrix job."
         default: ""
-      linux_nightly_6_0_enabled:
+      linux_nightly_6_1_enabled:
         type: boolean
-        description: "Boolean to enable the Linux nightly 6.0 Swift version matrix job. Defaults to true."
+        description: "Boolean to enable the Linux nightly 6.1 Swift version matrix job. Defaults to true."
         default: true
-      linux_nightly_6_0_arguments_override:
+      linux_nightly_6_1_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Linux nightly 6.0 Swift version matrix job."
+        description: "The arguments passed to swift test in the Linux nightly 6.1 Swift version matrix job."
         default: ""
       linux_nightly_main_enabled:
         type: boolean
@@ -62,9 +62,9 @@ jobs:
           - image: "swift:6.0-jammy"
             swift_version: "6.0"
             enabled: ${{ inputs.linux_6_0_enabled }}
-          - image: "swiftlang/swift:nightly-6.0-jammy"
-            swift_version: "nightly-6.0"
-            enabled: ${{ inputs.linux_nightly_6_0_enabled }}
+          - image: "swiftlang/swift:nightly-6.1-jammy"
+            swift_version: "nightly-6.1"
+            enabled: ${{ inputs.linux_nightly_6_1_enabled }}
           - image: "swiftlang/swift:nightly-main-jammy"
             swift_version: "nightly-main"
             enabled: ${{ inputs.linux_nightly_main_enabled }}
@@ -87,7 +87,7 @@ jobs:
           COMMAND_OVERRIDE_5_9: "swift test ${{ inputs.linux_5_9_arguments_override }}"
           COMMAND_OVERRIDE_5_10: "swift test ${{ inputs.linux_5_10_arguments_override }}"
           COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
-          COMMAND_OVERRIDE_NIGHTLY_6_0: "swift test ${{ inputs.linux_nightly_6_0_arguments_override }}"
+          COMMAND_OVERRIDE_NIGHTLY_6_1: "swift test ${{ inputs.linux_nightly_6_1_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_MAIN: "swift test ${{ inputs.linux_nightly_main_arguments_override }}"
         run: |
           apt-get -qq update && apt-get -qq -y install curl && apt-get -y install libsasl2-dev

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -134,7 +134,7 @@ extension KafkaConfiguration {
             ///
             /// - Parameters:
             ///     - privateKey: The client's private key (PEM) used for authentication.
-            ///     - certificate: The client's public key (PEM) used for authentication.
+            ///     - certificates: The client's public key (PEM) used for authentication and potentially multiple intermediate certificates.
             public static func keyPair(
                 privateKey: PrivateKey,
                 certificates: LeafAndIntermediates

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -56,7 +56,7 @@ public struct KafkaConsumerConfiguration {
         /// The consumer joins a consumer group identified by a group ID and consumes from multiple topics.
         ///
         /// - Parameters:
-        ///     - id: The ID of the consumer group to join.
+        ///     - groupID: The ID of the consumer group to join.
         ///     - topics: An array of topic names to consume from.
         public static func group(id groupID: String, topics: [String]) -> ConsumptionStrategy {
             .init(consumptionStrategy: .group(groupID: groupID, topics: topics))
@@ -64,7 +64,7 @@ public struct KafkaConsumerConfiguration {
     }
 
     /// The strategy used for consuming messages.
-    /// See ``KafkaConsumerConfiguration/ConsumptionStrategy-swift.struct-swift.struct`` for more information.
+    /// See ``KafkaConsumerConfiguration/ConsumptionStrategy-swift.struct`` for more information.
     public var consumptionStrategy: ConsumptionStrategy
 
     // MARK: - Consumer-specific Config Properties
@@ -144,7 +144,7 @@ public struct KafkaConsumerConfiguration {
         public static let error = AutoOffsetReset(description: "error")
     }
 
-    /// Action to take when there is no initial offset in the offset store or the desired offset is out of range. See ``KafkaConfiguration/AutoOffsetReset`` for more information.
+    /// Action to take when there is no initial offset in the offset store or the desired offset is out of range. See ``KafkaConsumerConfiguration/AutoOffsetReset-swift.struct`` for more information.
     /// Default: `.largest`
     public var autoOffsetReset: AutoOffsetReset = .largest
 

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -72,7 +72,7 @@ public struct KafkaProducerConfiguration {
         public var messageLimit: MessageLimit = .maximumLimit(100_000)
 
         /// Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions.
-        /// This property has higher priority than ``KafkaConfiguration/QueueOptions/messageLimit``.
+        /// This property has higher priority than ``KafkaProducerConfiguration/QueueConfiguration/MessageLimit-swift.struct``.
         /// Default: `1_048_576 * 1024`
         public var maximumMessageBytes: Int = 1_048_576 * 1024
 

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -98,7 +98,7 @@ public struct KafkaTopicConfiguration {
         public static let fnv1aRandom = Partitioner(description: "fnv1a_random")
     }
 
-    /// Partitioner. See ``KafkaConfiguration/Partitioner`` for more information.
+    /// Partitioner. See ``KafkaTopicConfiguration/Partitioner-swift.struct`` for more information.
     /// Default: `.consistentRandom`
     public var partitioner: Partitioner = .consistentRandom
 

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -140,7 +140,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
 
 // MARK: - KafkaConsumer
 
-/// A ``KafkaConsumer `` can be used to consume messages from a Kafka cluster.
+/// Can be used to consume messages from a Kafka cluster.
 public final class KafkaConsumer: Sendable, Service {
     /// The configuration object of the consumer client.
     private let configuration: KafkaConsumerConfiguration
@@ -192,7 +192,6 @@ public final class KafkaConsumer: Sendable, Service {
     /// - Parameters:
     ///     - configuration: The ``KafkaConsumerConfiguration`` for configuring the ``KafkaConsumer``.
     ///     - logger: A logger.
-    /// - Returns: The newly created ``KafkaConsumer``.
     /// - Throws: A ``KafkaError`` if the initialization failed.
     public convenience init(
         configuration: KafkaConsumerConfiguration,

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -108,7 +108,6 @@ public final class KafkaProducer: Service, Sendable {
     /// - Parameters:
     ///     - configuration: The ``KafkaProducerConfiguration`` for configuring the ``KafkaProducer``.
     ///     - logger: A logger.
-    /// - Returns: The newly created ``KafkaProducer``.
     /// - Throws: A ``KafkaError`` if initializing the producer failed.
     public convenience init(
         configuration: KafkaProducerConfiguration,


### PR DESCRIPTION
CI use 6.1 nightlies, enable more soundness checks now that we can specify a pre-build command to set up the dependencies.