### PR TITLE
Enable Swift 6.1 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,5 +14,6 @@ jobs:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,6 +19,7 @@ jobs:
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,13 +27,21 @@ on:
         type: string
         description: "The arguments passed to swift test in the Linux 6.0 Swift version matrix job."
         default: ""
+      linux_6_1_enabled:
+        type: boolean
+        description: "Boolean to enable the Linux 6.1 Swift version matrix job. Defaults to true."
+        default: true
+      linux_6_1_arguments_override:
+        type: string
+        description: "The arguments passed to swift test in the Linux 6.1 Swift version matrix job."
+        default: ""
       linux_nightly_next_enabled:
         type: boolean
-        description: "Boolean to enable the Linux nightly 6.1 Swift version matrix job. Defaults to true."
+        description: "Boolean to enable the Linux nightly next Swift version matrix job. Defaults to true."
         default: true
       linux_nightly_next_arguments_override:
         type: string
-        description: "The arguments passed to swift test in the Linux nightly 6.1 Swift version matrix job."
+        description: "The arguments passed to swift test in the Linux nightly next Swift version matrix job."
         default: ""
       linux_nightly_main_enabled:
         type: boolean
@@ -62,6 +70,9 @@ jobs:
           - image: "swift:6.0-jammy"
             swift_version: "6.0"
             enabled: ${{ inputs.linux_6_0_enabled }}
+          - image: "swift:6.1-jammy"
+            swift_version: "6.1"
+            enabled: ${{ inputs.linux_6_1_enabled }}
           - image: "swiftlang/swift:nightly-6.1-jammy"
             swift_version: "nightly-6.1"
             enabled: ${{ inputs.linux_nightly_next_enabled }}
@@ -87,6 +98,7 @@ jobs:
           COMMAND_OVERRIDE_5_9: "swift test ${{ inputs.linux_5_9_arguments_override }}"
           COMMAND_OVERRIDE_5_10: "swift test ${{ inputs.linux_5_10_arguments_override }}"
           COMMAND_OVERRIDE_6_0: "swift test ${{ inputs.linux_6_0_arguments_override }}"
+          COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_NEXT: "swift test ${{ inputs.linux_nightly_next_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_MAIN: "swift test ${{ inputs.linux_nightly_main_arguments_override }}"
         run: |


### PR DESCRIPTION
Motivation:

Swift 6.1 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.1 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
