### PR TITLE
Updates the Dockerfile's Swift version to match the `Package.swift`.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG swift_version=5.9
+ARG swift_version=5.10
 ARG ubuntu_version=jammy
 ARG base_image=swift:$swift_version-$ubuntu_version
 FROM $base_image


### PR DESCRIPTION
Updates the Dockerfile's Swift version to match the `Package.swift` version.

### Motivation:

When running the command `docker-compose -f docker/docker-compose.yaml run test`, the project fails to build because of mismatched Swift versions. 

### Modifications:

Update the Dockerfile to Swift 5.10.

### Result:

Docker test command now runs successfully.
