### PR TITLE
Add callback-based rebalance handling and offload blocking C calls

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -153,9 +153,17 @@ public final class KafkaConsumer: Sendable, Service {
     /// A logger.
     private let logger: Logger
     /// State of the `KafkaConsumer`.
+    /// - Important: Must be declared BEFORE `rebalanceContext` so that `RDKafkaClient`
+    ///   (held inside the state machine) is destroyed first during deinit. This ensures
+    ///   `rd_kafka_destroy` stops all librdkafka threads before the `RebalanceContext`
+    ///   (which holds the C callback's unretained pointer target) is deallocated.
     private let stateMachine: NIOLockedValueBox<StateMachine>
     /// Source for yielding consumer events (rebalance, etc.). `nil` when created without events.
     private let eventsSource: ConsumerEventsProducer.Source?
+    /// Context for the C rebalance callback. Must outlive the `RDKafkaClient` because the
+    /// C callback holds an unretained pointer to it.
+    /// - Important: Must be declared AFTER `stateMachine` — see ordering note above.
+    private let rebalanceContext: RebalanceContext
 
     /// An asynchronous sequence containing messages from the Kafka cluster.
     public let messages: KafkaConsumerMessages
@@ -169,12 +177,14 @@ public final class KafkaConsumer: Sendable, Service {
     ///     - client: Client used for handling the connection to the Kafka cluster.
     ///     - stateMachine: The state machine containing the state of the ``KafkaConsumer``.
     ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
+    ///     - rebalanceContext: The context for the C rebalance callback.
     ///     - logger: A logger.
     /// - Throws: A ``KafkaError`` if the initialization failed.
     private init(
         client: RDKafkaClient,
         stateMachine: NIOLockedValueBox<StateMachine>,
         config: KafkaConsumerConfig,
+        rebalanceContext: RebalanceContext,
         logger: Logger,
         eventsSource: ConsumerEventsProducer.Source? = nil
     ) throws {
@@ -182,6 +192,7 @@ public final class KafkaConsumer: Sendable, Service {
         self.stateMachine = stateMachine
         self.logger = logger
         self.eventsSource = eventsSource
+        self.rebalanceContext = rebalanceContext
 
         self.messages = KafkaConsumerMessages(
             stateMachine: self.stateMachine,
@@ -190,7 +201,8 @@ public final class KafkaConsumer: Sendable, Service {
 
         self.stateMachine.withLockedValue {
             $0.initialize(
-                client: client
+                client: client,
+                rebalanceContext: rebalanceContext
             )
         }
     }
@@ -207,7 +219,7 @@ public final class KafkaConsumer: Sendable, Service {
         config: KafkaConsumerConfig,
         logger: Logger
     ) throws {
-        var subscribedEvents: [RDKafkaEvent] = [.log]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
         if !isAutoCommitEnabled {
             subscribedEvents.append(.offsetCommit)
@@ -216,11 +228,14 @@ public final class KafkaConsumer: Sendable, Service {
             subscribedEvents.append(.statistics)
         }
 
+        let rebalanceContext = RebalanceContext(logger: logger)
+
         let client = try RDKafkaClient.makeClient(
             type: .consumer,
             configDictionary: config.config,
             events: subscribedEvents,
-            logger: logger
+            logger: logger,
+            rebalanceContext: rebalanceContext
         )
 
         let stateMachine = NIOLockedValueBox(StateMachine())
@@ -229,6 +244,7 @@ public final class KafkaConsumer: Sendable, Service {
             client: client,
             stateMachine: stateMachine,
             config: config,
+            rebalanceContext: rebalanceContext,
             logger: logger
         )
     }
@@ -250,7 +266,7 @@ public final class KafkaConsumer: Sendable, Service {
         config: KafkaConsumerConfig,
         logger: Logger
     ) throws -> (KafkaConsumer, KafkaConsumerEvents) {
-        var subscribedEvents: [RDKafkaEvent] = [.log]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
         if !isAutoCommitEnabled {
             subscribedEvents.append(.offsetCommit)
@@ -259,11 +275,14 @@ public final class KafkaConsumer: Sendable, Service {
             subscribedEvents.append(.statistics)
         }
 
+        let rebalanceContext = RebalanceContext(logger: logger)
+
         let client = try RDKafkaClient.makeClient(
             type: .consumer,
             configDictionary: config.config,
             events: subscribedEvents,
-            logger: logger
+            logger: logger,
+            rebalanceContext: rebalanceContext
         )
 
         let stateMachine = NIOLockedValueBox(StateMachine())
@@ -284,6 +303,7 @@ public final class KafkaConsumer: Sendable, Service {
             client: client,
             stateMachine: stateMachine,
             config: config,
+            rebalanceContext: rebalanceContext,
             logger: logger,
             eventsSource: sourceAndSequence.source
         )
@@ -380,11 +400,18 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Run loop polling Kafka for new events.
     private func eventRunLoop() async throws {
+        defer {
+            // Guarantee the events stream is finished on ALL exit paths:
+            // normal .terminatePollLoop, Task cancellation (CancellationError from Task.sleep),
+            // or any other thrown error. Without this, `for await event in events` hangs forever.
+            self.eventsSource?.finish()
+        }
+
         while !Task.isCancelled {
             let nextAction = self.stateMachine.withLockedValue { $0.nextEventPollLoopAction() }
             switch nextAction {
             case .pollForEvents(let client):
-                // Event poll to serve any events queued inside of `librdkafka`.
+                // Event poll to serve any events queued inside of `librdkafka` (statistics, logs, offset commits).
                 let events = client.consumerEventPoll()
                 for event in events {
                     switch event {
@@ -392,11 +419,91 @@ public final class KafkaConsumer: Sendable, Service {
                         self.config.metrics.update(with: statistics)
                     }
                 }
+
+                // Drain rebalance events from the callback context.
+                // These were buffered by the C rebalance callback during rd_kafka_consumer_poll().
+                let rebalanceEvents = self.rebalanceContext.drainEvents()
+                for event in rebalanceEvents {
+                    let kind: KafkaConsumerRebalance.Kind
+                    switch event.kind {
+                    case .assign:
+                        kind = .assign
+                    case .revoke:
+                        kind = .revoke
+                    case .error(let description):
+                        kind = .error(description)
+                    }
+
+                    let rebalance = KafkaConsumerRebalance(
+                        kind: kind,
+                        partitions: event.partitions.map {
+                            KafkaTopicPartition(topic: $0.topic, partition: KafkaPartition(rawValue: $0.partition))
+                        }
+                    )
+                    if let source = self.eventsSource {
+                        _ = source.yield(.rebalance(rebalance))
+                    }
+                    self.logger.info(
+                        "Consumer rebalance",
+                        metadata: [
+                            "kind": "\(rebalance.kind)",
+                            "partitions": "\(rebalance.partitions.map { "\($0.topic):\($0.partition)" })",
+                        ]
+                    )
+                }
+
                 try await Task.sleep(for: self.config.pollInterval)
             case .terminatePollLoop:
-                self.eventsSource?.finish()
+                // Final drain: the close process may have completed (isConsumerClosed = true)
+                // before we polled the shutdown revoke from mainQueue. Do one last poll+drain
+                // so no rebalance events are lost.
+                self.finalDrain()
                 return
             }
+        }
+    }
+
+    /// Final drain of the event queue and rebalance buffer before shutdown completes.
+    ///
+    /// Called after `isConsumerClosed` returns true. The close process
+    /// (`rd_kafka_consumer_close_queue`) may have enqueued a final revoke on
+    /// mainQueue and completed (`rkcg_terminated = true`) before the event loop
+    /// had a chance to poll it. This one last poll+drain ensures that event
+    /// is not lost.
+    private func finalDrain() {
+        let action = self.stateMachine.withLockedValue { $0.clientForCleanup() }
+        guard let client = action else { return }
+
+        let _ = client.consumerEventPoll()
+
+        let rebalanceEvents = self.rebalanceContext.drainEvents()
+        for event in rebalanceEvents {
+            let kind: KafkaConsumerRebalance.Kind
+            switch event.kind {
+            case .assign:
+                kind = .assign
+            case .revoke:
+                kind = .revoke
+            case .error(let description):
+                kind = .error(description)
+            }
+
+            let rebalance = KafkaConsumerRebalance(
+                kind: kind,
+                partitions: event.partitions.map {
+                    KafkaTopicPartition(topic: $0.topic, partition: KafkaPartition(rawValue: $0.partition))
+                }
+            )
+            if let source = self.eventsSource {
+                _ = source.yield(.rebalance(rebalance))
+            }
+            self.logger.info(
+                "Consumer rebalance",
+                metadata: [
+                    "kind": "\(rebalance.kind)",
+                    "partitions": "\(rebalance.partitions.map { "\($0.topic):\($0.partition)" })",
+                ]
+            )
         }
     }
 
@@ -502,13 +609,13 @@ public final class KafkaConsumer: Sendable, Service {
     public func committed(
         topicPartitions: [KafkaTopicPartition],
         timeout: Duration = .milliseconds(5000)
-    ) throws -> [KafkaTopicPartitionOffset] {
+    ) async throws -> [KafkaTopicPartitionOffset] {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
         switch action {
         case .throwClosedError:
             throw KafkaError.connectionClosed(reason: "Tried to query committed offsets on a closed consumer")
         case .client(let client):
-            return try client.committed(
+            return try await client.committed(
                 topicPartitions: topicPartitions,
                 timeoutMilliseconds: Int32(timeout.inMilliseconds)
             )
@@ -574,13 +681,13 @@ public final class KafkaConsumer: Sendable, Service {
     public func seek(
         topicPartitionOffsets: [KafkaTopicPartitionOffset],
         timeout: Duration = .milliseconds(5000)
-    ) throws {
+    ) async throws {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
         switch action {
         case .throwClosedError:
             throw KafkaError.connectionClosed(reason: "Tried to seek on a closed consumer")
         case .client(let client):
-            try client.seekPartitions(
+            try await client.seekPartitions(
                 topicPartitionOffsets: topicPartitionOffsets,
                 timeoutMilliseconds: Int32(timeout.inMilliseconds)
             )
@@ -634,20 +741,22 @@ extension KafkaConsumer {
             /// though ``subscribe()`` / ``assign()`` have not been invoked.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
-            /// - Parameter source: The source for yielding new messages.
+            /// - Parameter rebalanceContext: The context for the C rebalance callback.
             case initializing(
-                client: RDKafkaClient
+                client: RDKafkaClient,
+                rebalanceContext: RebalanceContext
             )
             /// The ``KafkaConsumer`` is consuming messages.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
-            /// - Parameter state: State of the event loop fetching new consumer messages.
-            case running(client: RDKafkaClient)
+            /// - Parameter rebalanceContext: The context for the C rebalance callback.
+            case running(client: RDKafkaClient, rebalanceContext: RebalanceContext)
             /// The ``KafkaConsumer/triggerGracefulShutdown()`` has been invoked.
             /// We are now in the process of commiting our last state to the broker.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
-            case finishing(client: RDKafkaClient)
+            /// - Parameter rebalanceContext: The context for the C rebalance callback.
+            case finishing(client: RDKafkaClient, rebalanceContext: RebalanceContext)
             /// The ``KafkaConsumer`` is closed.
             case finished
         }
@@ -658,7 +767,8 @@ extension KafkaConsumer {
         /// Delayed initialization of `StateMachine` as the `source` and the `pollClosure` are
         /// not yet available when the normal initialization occurs.
         mutating func initialize(
-            client: RDKafkaClient
+            client: RDKafkaClient,
+            rebalanceContext: RebalanceContext
         ) {
             guard case .uninitialized = self.state else {
                 fatalError(
@@ -666,7 +776,8 @@ extension KafkaConsumer {
                 )
             }
             self.state = .initializing(
-                client: client
+                client: client,
+                rebalanceContext: rebalanceContext
             )
         }
 
@@ -690,9 +801,9 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client):
+            case .running(let client, _):
                 return .pollForEvents(client: client)
-            case .finishing(let client):
+            case .finishing(let client, _):
                 if client.isConsumerClosed {
                     self.state = .finished
                     return .terminatePollLoop
@@ -726,7 +837,7 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 return .suspendPollLoop
-            case .running(let client):
+            case .running(let client, _):
                 return .poll(client: client)
             case .finishing, .finished:
                 return .terminatePollLoop
@@ -749,8 +860,8 @@ extension KafkaConsumer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .initializing(let client):
-                self.state = .running(client: client)
+            case .initializing(let client, let rebalanceContext):
+                self.state = .running(client: client, rebalanceContext: rebalanceContext)
                 return .setUpConnection(client: client)
             case .running:
                 fatalError("\(#function) should not be invoked more than once")
@@ -786,7 +897,7 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client):
+            case .running(let client, _):
                 return .client(client)
             case .finishing, .finished:
                 return .throwClosedError
@@ -811,8 +922,8 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-            case .running(let client):
-                self.state = .finishing(client: client)
+            case .running(let client, let rebalanceContext):
+                self.state = .finishing(client: client, rebalanceContext: rebalanceContext)
                 return .triggerGracefulShutdown(client: client)
             case .finishing, .finished:
                 return nil
@@ -830,6 +941,20 @@ extension KafkaConsumer {
                 self.state = .finished
             case .finishing, .finished:
                 break
+            }
+        }
+
+        /// Returns the client if available, for cleanup purposes (e.g., final event drain).
+        /// Unlike ``withClient()``, this does not fatalError in transitional states —
+        /// it returns `nil` when no client is available.
+        func clientForCleanup() -> RDKafkaClient? {
+            switch self.state {
+            case .uninitialized, .finished:
+                return nil
+            case .initializing(let client, _),
+                .running(let client, _),
+                .finishing(let client, _):
+                return client
             }
         }
     }

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -14,13 +14,14 @@
 
 /// An enumeration representing events that can be received through the ``KafkaConsumerEvents`` asynchronous sequence.
 public enum KafkaConsumerEvent: Sendable, Hashable {
+    /// A consumer group rebalance occurred.
+    ///
+    /// The library has already performed the necessary assign/unassign
+    /// operations — this notification is informational. Use it to perform
+    /// application-level bookkeeping such as committing offsets on revoke
+    /// or initializing state on assign.
+    case rebalance(KafkaConsumerRebalance)
+
     /// - Important: Always provide a `default` case when switching over this `enum`.
     case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
-
-    internal init(_ event: RDKafkaClient.ConsumerPollEvent) {
-        switch event {
-        case .statistics:
-            fatalError("Cannot cast \(event) to KafkaConsumerEvent")
-        }
-    }
 }

--- a/Sources/Kafka/KafkaConsumerRebalance.swift
+++ b/Sources/Kafka/KafkaConsumerRebalance.swift
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Describes a consumer group rebalance event.
+///
+/// When a consumer joins or leaves a consumer group, Kafka redistributes
+/// partitions among the group members. The library handles the assign/unassign
+/// operations automatically — this event is informational only.
+public struct KafkaConsumerRebalance: Sendable, Hashable {
+    /// The kind of rebalance that occurred.
+    public enum Kind: Sendable, Hashable {
+        /// New partitions have been assigned to this consumer.
+        case assign
+        /// Partitions have been revoked from this consumer.
+        case revoke
+        /// An unexpected error occurred during rebalance. All partitions have been
+        /// unassigned as a recovery measure. The associated string describes the error.
+        case error(String)
+    }
+
+    /// Whether this is an assignment, revocation, or error.
+    public let kind: Kind
+
+    /// The partitions involved in this rebalance.
+    ///
+    /// For ``Kind/assign``: the partitions newly assigned to this consumer.
+    /// For ``Kind/revoke``: the partitions being revoked from this consumer.
+    /// For ``Kind/error(_:)``: empty.
+    public let partitions: [KafkaTopicPartition]
+
+    /// Create a rebalance event description.
+    /// - Parameters:
+    ///   - kind: Whether this is an assignment, revocation, or error.
+    ///   - partitions: The partitions involved in this rebalance.
+    public init(kind: Kind, partitions: [KafkaTopicPartition]) {
+        self.kind = kind
+        self.partitions = partitions
+    }
+}

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -26,6 +26,14 @@ public final class RDKafkaClient: Sendable {
     // Default size for Strings returned from C API
     static let stringSize = 1024
 
+    /// Shared concurrent queue for offloading blocking C calls (e.g., `rd_kafka_committed`,
+    /// `rd_kafka_seek_partitions`, `rd_kafka_flush`) so they don't block Swift Concurrency's
+    /// cooperative thread pool. Concurrent so independent operations can run in parallel.
+    private static let blockingQueue = DispatchQueue(
+        label: "com.swift-server.swift-kafka.blocking",
+        attributes: .concurrent
+    )
+
     /// Determines if client is a producer or a consumer.
     enum ClientType {
         case producer
@@ -64,13 +72,24 @@ public final class RDKafkaClient: Sendable {
         type: ClientType,
         configDictionary: [String: String],
         events: [RDKafkaEvent],
-        logger: Logger
+        logger: Logger,
+        rebalanceContext: RebalanceContext? = nil
     ) throws -> RDKafkaClient {
         let rdConfig = try RDKafkaConfig.createFrom(configDictionary: configDictionary)
         // Manually override some of the configuration options
         // Handle logs in event queue
         try RDKafkaConfig.set(configPointer: rdConfig, key: "log.queue", value: "true")
         RDKafkaConfig.setEvents(configPointer: rdConfig, events: events)
+
+        // Register rebalance callback for consumer clients.
+        // This handles rebalance events synchronously inside rd_kafka_consumer_poll(),
+        // which is the correct queue for these events (consumer group queue, not main queue).
+        if let rebalanceContext {
+            RDKafkaConfig.setRebalanceCallback(
+                configPointer: rdConfig,
+                context: rebalanceContext
+            )
+        }
 
         let errorChars = UnsafeMutablePointer<CChar>.allocate(capacity: RDKafkaClient.stringSize)
         defer { errorChars.deallocate() }
@@ -378,6 +397,23 @@ public final class RDKafkaClient: Sendable {
             case .deliveryReport:
                 // Should never occur on a consumer queue, but handle defensively.
                 _ = self.handleDeliveryReportEvent(event)
+            case .rebalance:
+                // Rebalance events arrive here when polled from the main queue
+                // (e.g., during shutdown after rd_kafka_consumer_close_queue forwards
+                // the consumer queue to the main queue). Dispatch through the
+                // rebalance callback so assign/unassign is performed and the cgrp
+                // subsystem is acknowledged — otherwise the close process hangs.
+                let err = rd_kafka_event_error(event)
+                let tpl = rd_kafka_event_topic_partition_list(event)
+                let opaque = rd_kafka_opaque(self.kafkaHandle.pointer)
+                if let opaque {
+                    let context = Unmanaged<RebalanceContext>.fromOpaque(opaque).takeUnretainedValue()
+                    context.handleRebalance(
+                        kafkaHandle: self.kafkaHandle.pointer,
+                        error: err,
+                        partitions: tpl
+                    )
+                }
             case .none:
                 return events
             default:
@@ -673,9 +709,8 @@ public final class RDKafkaClient: Sendable {
         // rd_kafka_flush is blocking and there is no convenient way to make it non-blocking.
         // We therefore execute rd_kafka_flush on a DispatchQueue to ensure it gets executed
         // on a separate thread that is not part of Swift Concurrency's cooperative thread pool.
-        let queue = DispatchQueue(label: "com.swift-server.swift-kafka.flush")
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            queue.async {
+            Self.blockingQueue.async {
                 let error = rd_kafka_flush(self.kafkaHandle.pointer, timeoutMilliseconds)
                 if error != RD_KAFKA_RESP_ERR_NO_ERROR {
                     continuation.resume(throwing: KafkaError.rdKafkaError(wrapping: error))
@@ -713,26 +748,34 @@ public final class RDKafkaClient: Sendable {
     func committed(
         topicPartitions: [KafkaTopicPartition],
         timeoutMilliseconds: Int32
-    ) throws -> [KafkaTopicPartitionOffset] {
+    ) async throws -> [KafkaTopicPartitionOffset] {
         let tpl = RDKafkaTopicPartitionList(size: Int32(topicPartitions.count))
         for tp in topicPartitions {
             tpl.add(topic: tp.topic, partition: tp.partition)
         }
 
-        let error = tpl.withListPointer { listPointer in
-            rd_kafka_committed(
-                self.kafkaHandle.pointer,
-                listPointer,
-                timeoutMilliseconds
-            )
-        }
+        // rd_kafka_committed is blocking — offload to a DispatchQueue so it does not
+        // block Swift Concurrency's cooperative thread pool.
+        let kafkaHandle = self.kafkaHandle
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[KafkaTopicPartitionOffset], Error>) in
+            Self.blockingQueue.async {
+                let error = tpl.withListPointer { listPointer in
+                    rd_kafka_committed(
+                        kafkaHandle.pointer,
+                        listPointer,
+                        timeoutMilliseconds
+                    )
+                }
 
-        if error != RD_KAFKA_RESP_ERR_NO_ERROR {
-            throw KafkaError.rdKafkaError(wrapping: error)
-        }
-
-        return tpl.withListPointer { listPointer in
-            Self.extractOffsetsFromList(listPointer)
+                if error != RD_KAFKA_RESP_ERR_NO_ERROR {
+                    continuation.resume(throwing: KafkaError.rdKafkaError(wrapping: error))
+                } else {
+                    let results = tpl.withListPointer { listPointer in
+                        Self.extractOffsetsFromList(listPointer)
+                    }
+                    continuation.resume(returning: results)
+                }
+            }
         }
     }
 
@@ -821,7 +864,7 @@ public final class RDKafkaClient: Sendable {
     func seekPartitions(
         topicPartitionOffsets: [KafkaTopicPartitionOffset],
         timeoutMilliseconds: Int32
-    ) throws {
+    ) async throws {
         let tpl = RDKafkaTopicPartitionList(size: Int32(topicPartitionOffsets.count))
         for tpo in topicPartitionOffsets {
             guard let offset = tpo.offset else {
@@ -834,19 +877,30 @@ public final class RDKafkaClient: Sendable {
             )
         }
 
-        let error = tpl.withListPointer { listPointer in
-            rd_kafka_seek_partitions(
-                self.kafkaHandle.pointer,
-                listPointer,
-                timeoutMilliseconds
-            )
-        }
+        // rd_kafka_seek_partitions is blocking — offload to a DispatchQueue so it does not
+        // block Swift Concurrency's cooperative thread pool.
+        let kafkaHandle = self.kafkaHandle
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            Self.blockingQueue.async {
+                let error = tpl.withListPointer { listPointer in
+                    rd_kafka_seek_partitions(
+                        kafkaHandle.pointer,
+                        listPointer,
+                        timeoutMilliseconds
+                    )
+                }
 
-        if let error {
-            let code = rd_kafka_error_code(error)
-            rd_kafka_error_destroy(error)
-            if code != RD_KAFKA_RESP_ERR_NO_ERROR {
-                throw KafkaError.rdKafkaError(wrapping: code)
+                if let error {
+                    let code = rd_kafka_error_code(error)
+                    rd_kafka_error_destroy(error)
+                    if code != RD_KAFKA_RESP_ERR_NO_ERROR {
+                        continuation.resume(throwing: KafkaError.rdKafkaError(wrapping: code))
+                    } else {
+                        continuation.resume()
+                    }
+                } else {
+                    continuation.resume()
+                }
             }
         }
     }

--- a/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
@@ -15,7 +15,12 @@
 import Crdkafka
 
 /// Swift wrapper type for `rd_kafka_topic_partition_list_t`.
-final class RDKafkaTopicPartitionList {
+///
+/// Marked `@unchecked Sendable` because it wraps a C heap allocation
+/// (`rd_kafka_topic_partition_list_t*`). Callers are responsible for
+/// ensuring the list is not accessed concurrently — the typical pattern
+/// is single-owner (create → populate → pass to blocking C call → read result).
+final class RDKafkaTopicPartitionList: @unchecked Sendable {
     private let _internal: UnsafeMutablePointer<rd_kafka_topic_partition_list_t>
 
     /// Create a new topic+partition list.

--- a/Sources/Kafka/RDKafka/RebalanceContext.swift
+++ b/Sources/Kafka/RDKafka/RebalanceContext.swift
@@ -1,0 +1,268 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2026 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+import Logging
+import NIOConcurrencyHelpers
+
+/// C-compatible rebalance callback passed to `rd_kafka_conf_set_rebalance_cb`.
+///
+/// Invoked **synchronously** inside `rd_kafka_consumer_poll()` when a consumer
+/// group rebalance occurs. The callback must call `rd_kafka_assign` /
+/// `rd_kafka_incremental_assign` / `rd_kafka_incremental_unassign` before
+/// returning — librdkafka blocks the consumer group protocol until it does.
+///
+/// The `opaque` parameter is the value set via `rd_kafka_conf_set_opaque`,
+/// which we set to an `Unmanaged<RebalanceContext>`.
+///
+/// - Important: The parameter types must exactly match the C import of
+///   `rd_kafka_conf_set_rebalance_cb`'s function pointer typedef.
+private func rebalanceCallback(
+    _ rk: OpaquePointer?,
+    _ err: rd_kafka_resp_err_t,
+    _ partitions: UnsafeMutablePointer<rd_kafka_topic_partition_list_t>?,
+    _ opaque: UnsafeMutableRawPointer?
+) {
+    guard let opaque else { return }
+    let context = Unmanaged<RebalanceContext>.fromOpaque(opaque).takeUnretainedValue()
+    context.handleRebalance(kafkaHandle: rk, error: err, partitions: partitions)
+}
+
+/// Holds the state needed by the C rebalance callback.
+///
+/// This object is set as the config opaque pointer via `rd_kafka_conf_set_opaque`
+/// and lives for the lifetime of the `KafkaConsumer`. The C callback receives it
+/// as the `void* opaque` parameter and calls ``handleRebalance(kafkaHandle:error:partitions:)``.
+///
+/// Marked `@unchecked Sendable` because all mutable state (`pendingEvents`) is
+/// protected by `NIOLockedValueBox`. The class must be a reference type because
+/// it is passed to C via `Unmanaged` as the config opaque pointer.
+///
+/// Thread safety: The rebalance callback fires synchronously inside
+/// `rd_kafka_consumer_poll()`, which in our architecture runs on either the
+/// cooperative thread pool or a GCD thread. The pending events buffer is
+/// protected by `NIOLockedValueBox`. The `logger` is `Sendable`.
+final class RebalanceContext: @unchecked Sendable {
+    /// Buffer of rebalance events not yet consumed by the Swift event loop.
+    private let pendingEvents: NIOLockedValueBox<[ConsumerRebalanceEvent]>
+    /// Logger for rebalance operations. Used from the C callback thread.
+    private let logger: Logger
+
+    init(logger: Logger) {
+        self.pendingEvents = NIOLockedValueBox([])
+        self.logger = logger
+    }
+
+    /// Called from the C rebalance callback (synchronously inside `rd_kafka_consumer_poll`).
+    ///
+    /// Performs the assign/unassign operation and buffers the event for the Swift event loop.
+    func handleRebalance(
+        kafkaHandle rk: OpaquePointer?,
+        error err: rd_kafka_resp_err_t,
+        partitions: UnsafeMutablePointer<rd_kafka_topic_partition_list_t>?
+    ) {
+        guard let rk else { return }
+
+        let proto = Self.rebalanceProtocol(kafkaHandle: rk)
+
+        switch err {
+        case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
+            let extracted = partitions.map { Self.extractPartitions(from: $0) } ?? []
+            Self.performAssign(kafkaHandle: rk, protocol: proto, list: partitions, logger: self.logger)
+            self.pendingEvents.withLockedValue {
+                $0.append(ConsumerRebalanceEvent(kind: .assign, partitions: extracted))
+            }
+
+        case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
+            let extracted = partitions.map { Self.extractPartitions(from: $0) } ?? []
+            Self.performRevoke(kafkaHandle: rk, protocol: proto, list: partitions, logger: self.logger)
+            self.pendingEvents.withLockedValue {
+                $0.append(ConsumerRebalanceEvent(kind: .revoke, partitions: extracted))
+            }
+
+        default:
+            // Unexpected error during rebalance — sync state by unassigning all partitions.
+            let errorStr = String(cString: rd_kafka_err2str(err))
+            self.logger.warning(
+                "Unexpected rebalance error",
+                metadata: ["error": "\(errorStr)"]
+            )
+            let result = rd_kafka_assign(rk, nil)
+            if result != RD_KAFKA_RESP_ERR_NO_ERROR {
+                self.logger.warning(
+                    "Failed to unassign during rebalance error recovery",
+                    metadata: ["error": "\(String(cString: rd_kafka_err2str(result)))"]
+                )
+            }
+            self.pendingEvents.withLockedValue {
+                $0.append(ConsumerRebalanceEvent(kind: .error(errorStr), partitions: []))
+            }
+        }
+    }
+
+    /// Drain all buffered rebalance events.
+    ///
+    /// Called by the Swift event loop to retrieve rebalance events that were
+    /// buffered by the C callback. Returns an empty array if no events are pending.
+    func drainEvents() -> [ConsumerRebalanceEvent] {
+        self.pendingEvents.withLockedValue { events in
+            let drained = events
+            events.removeAll()
+            return drained
+        }
+    }
+
+    /// Inject a rebalance event directly into the buffer for testing.
+    /// This simulates what the C rebalance callback does without needing a real `rd_kafka_t` handle.
+    ///
+    /// - Important: For testing only. Production code should never call this.
+    func _testInjectEvent(_ event: ConsumerRebalanceEvent) {
+        self.pendingEvents.withLockedValue {
+            $0.append(event)
+        }
+    }
+
+    // MARK: - Internal bridge type
+
+    /// Internal bridge type for rebalance events.
+    /// Uses raw tuples to avoid referencing public API types from the bridge layer.
+    struct ConsumerRebalanceEvent {
+        enum Kind {
+            case assign
+            case revoke
+            /// An unexpected error during rebalance. All partitions have been unassigned.
+            case error(String)
+        }
+
+        let kind: Kind
+        /// Partitions as raw (topic, partition) pairs — converted to public types at Layer 3.
+        let partitions: [(topic: String, partition: Int)]
+    }
+
+    // MARK: - Private helpers
+
+    private enum RebalanceProtocol {
+        case eager
+        case cooperative
+        case none
+    }
+
+    private static func rebalanceProtocol(kafkaHandle rk: OpaquePointer) -> RebalanceProtocol {
+        guard let protocolStr = rd_kafka_rebalance_protocol(rk) else {
+            return .none
+        }
+        let proto = String(cString: protocolStr)
+        if proto == "COOPERATIVE" {
+            return .cooperative
+        }
+        return .eager
+    }
+
+    private static func extractPartitions(
+        from listPointer: UnsafeMutablePointer<rd_kafka_topic_partition_list_t>
+    ) -> [(topic: String, partition: Int)] {
+        let count = Int(listPointer.pointee.cnt)
+        var results: [(topic: String, partition: Int)] = []
+        results.reserveCapacity(count)
+        for i in 0..<count {
+            let element = listPointer.pointee.elems[i]
+            let topic = String(cString: element.topic)
+            let partition = Int(element.partition)
+            results.append((topic: topic, partition: partition))
+        }
+        return results
+    }
+
+    private static func performAssign(
+        kafkaHandle rk: OpaquePointer,
+        protocol proto: RebalanceProtocol,
+        list: UnsafeMutablePointer<rd_kafka_topic_partition_list_t>?,
+        logger: Logger
+    ) {
+        switch proto {
+        case .cooperative:
+            if let list {
+                let error = rd_kafka_incremental_assign(rk, list)
+                if let error {
+                    logger.warning(
+                        "Incremental assign failed",
+                        metadata: ["error": "\(String(cString: rd_kafka_error_string(error)))"]
+                    )
+                    rd_kafka_error_destroy(error)
+                }
+            }
+        case .eager, .none:
+            let result = rd_kafka_assign(rk, list)
+            if result != RD_KAFKA_RESP_ERR_NO_ERROR {
+                logger.warning(
+                    "Assign failed",
+                    metadata: ["error": "\(String(cString: rd_kafka_err2str(result)))"]
+                )
+            }
+        }
+    }
+
+    private static func performRevoke(
+        kafkaHandle rk: OpaquePointer,
+        protocol proto: RebalanceProtocol,
+        list: UnsafeMutablePointer<rd_kafka_topic_partition_list_t>?,
+        logger: Logger
+    ) {
+        switch proto {
+        case .cooperative:
+            if let list {
+                let error = rd_kafka_incremental_unassign(rk, list)
+                if let error {
+                    logger.warning(
+                        "Incremental unassign failed",
+                        metadata: ["error": "\(String(cString: rd_kafka_error_string(error)))"]
+                    )
+                    rd_kafka_error_destroy(error)
+                }
+            }
+        case .eager, .none:
+            let result = rd_kafka_assign(rk, nil)
+            if result != RD_KAFKA_RESP_ERR_NO_ERROR {
+                logger.warning(
+                    "Unassign failed",
+                    metadata: ["error": "\(String(cString: rd_kafka_err2str(result)))"]
+                )
+            }
+        }
+    }
+}
+
+// MARK: - RDKafkaConfig extension
+
+extension RDKafkaConfig {
+    /// Register the rebalance callback and opaque pointer on a config.
+    ///
+    /// - Important: `rd_kafka_conf_set_opaque` sets a **single** opaque pointer per config.
+    ///   All C callbacks that receive `void* opaque` (rebalance, offset commit, error, etc.)
+    ///   share this one slot. Currently only the rebalance callback uses it. If a future
+    ///   callback also needs the opaque, introduce a wrapper struct that multiplexes
+    ///   (e.g., a context holding both rebalance and other callback contexts).
+    ///
+    /// - Parameters:
+    ///   - configPointer: The `rd_kafka_conf_t` to configure.
+    ///   - context: The `RebalanceContext` that will receive callbacks.
+    static func setRebalanceCallback(
+        configPointer: OpaquePointer,
+        context: RebalanceContext
+    ) {
+        let opaque = Unmanaged.passUnretained(context).toOpaque()
+        rd_kafka_conf_set_opaque(configPointer, opaque)
+        rd_kafka_conf_set_rebalance_cb(configPointer, rebalanceCallback)
+    }
+}

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -858,7 +858,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                                 topic: message.topic,
                                 partition: message.partition
                             )
-                            let committedOffsets = try consumer.committed(
+                            let committedOffsets = try await consumer.committed(
                                 topicPartitions: [tp],
                                 timeout: .milliseconds(5000)
                             )
@@ -990,7 +990,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                         partition: firstPassMessages[0].partition,
                         offset: .beginning
                     )
-                    try consumer.seek(topicPartitionOffsets: [seekTarget])
+                    try await consumer.seek(topicPartitionOffsets: [seekTarget])
 
                     // Consume again — should replay the same messages
                     var replayedMessages = [KafkaConsumerMessage]()
@@ -1068,7 +1068,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                                 topic: message.topic,
                                 partition: message.partition
                             )
-                            let committedOffsets = try consumer.committed(
+                            let committedOffsets = try await consumer.committed(
                                 topicPartitions: [tp],
                                 timeout: .milliseconds(5000)
                             )
@@ -1089,6 +1089,596 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try await group.next()
                 await serviceGroup.triggerGracefulShutdown()
             }
+        }
+    }
+
+    // MARK: - Rebalance Event Delivery Tests
+
+    @Test func rebalanceEventsDeliveredThroughConsumerEvents() async throws {
+        try await withTestTopic(partitions: 4) { testTopic in
+            let uniqueGroupID = UUID().uuidString
+
+            // Consumer 1 — created with events to receive rebalance notifications
+            var consumer1Config = KafkaConsumerConfig()
+            consumer1Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer1Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer1Config.autoOffsetReset = .beginning
+            consumer1Config.brokerAddressFamily = .v4
+            consumer1Config.pollInterval = .milliseconds(1)
+
+            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
+                config: consumer1Config,
+                logger: .kafkaTest
+            )
+
+            // Consumer 2 — plain consumer, joins later to trigger rebalance
+            var consumer2Config = KafkaConsumerConfig()
+            consumer2Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer2Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer2Config.autoOffsetReset = .beginning
+            consumer2Config.brokerAddressFamily = .v4
+            consumer2Config.pollInterval = .milliseconds(1)
+
+            let consumer2 = try KafkaConsumer(
+                config: consumer2Config,
+                logger: .kafkaTest
+            )
+
+            let serviceGroup1 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer1],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+            let serviceGroup2 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer2],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+
+            let receivedRebalanceEvents = ManagedAtomic(0)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { try await serviceGroup1.run() }
+
+                group.addTask {
+                    for try await _ in consumer1.messages {}
+                }
+
+                group.addTask {
+                    for await event in events1 {
+                        switch event {
+                        case .rebalance:
+                            receivedRebalanceEvents.wrappingIncrement(ordering: .relaxed)
+                        default:
+                            break
+                        }
+                    }
+                }
+
+                // Poll until consumer 1 receives its initial assign (bounded: 30s)
+                for _ in 0..<300 {
+                    if receivedRebalanceEvents.load(ordering: .relaxed) >= 1 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+                #expect(
+                    receivedRebalanceEvents.load(ordering: .relaxed) >= 1,
+                    "Timed out waiting for initial assign"
+                )
+
+                // Start consumer 2 — triggers a second rebalance
+                group.addTask { try await serviceGroup2.run() }
+                group.addTask {
+                    for try await _ in consumer2.messages {}
+                }
+
+                // Poll until consumer 1 receives the rebalance triggered by consumer 2 joining (bounded: 30s)
+                for _ in 0..<300 {
+                    if receivedRebalanceEvents.load(ordering: .relaxed) >= 2 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+
+                let count = receivedRebalanceEvents.load(ordering: .relaxed)
+                #expect(count >= 2, "Expected at least 2 rebalance events (initial + rebalance), got \(count)")
+
+                await serviceGroup1.triggerGracefulShutdown()
+                await serviceGroup2.triggerGracefulShutdown()
+            }
+        }
+    }
+
+    @Test func messagesAndRebalanceEventsFlowConcurrently() async throws {
+        try await withTestTopic(partitions: 4) { testTopic in
+            let numMessages: UInt = 50
+            let _ = try await self.produceMessages(topic: testTopic, count: numMessages)
+
+            let uniqueGroupID = UUID().uuidString
+
+            var consumer1Config = KafkaConsumerConfig()
+            consumer1Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer1Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer1Config.autoOffsetReset = .beginning
+            consumer1Config.brokerAddressFamily = .v4
+            consumer1Config.pollInterval = .milliseconds(1)
+            consumer1Config.enableAutoCommit = false
+
+            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
+                config: consumer1Config,
+                logger: .kafkaTest
+            )
+
+            var consumer2Config = KafkaConsumerConfig()
+            consumer2Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer2Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer2Config.autoOffsetReset = .beginning
+            consumer2Config.brokerAddressFamily = .v4
+            consumer2Config.pollInterval = .milliseconds(1)
+            consumer2Config.enableAutoCommit = false
+
+            let consumer2 = try KafkaConsumer(
+                config: consumer2Config,
+                logger: .kafkaTest
+            )
+
+            let serviceGroup1 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer1],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+            let serviceGroup2 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer2],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+
+            let c1Messages = ManagedAtomic(0)
+            let c2Messages = ManagedAtomic(0)
+            let rebalanceEventCount = ManagedAtomic(0)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { try await serviceGroup1.run() }
+
+                group.addTask {
+                    for try await record in consumer1.messages {
+                        c1Messages.wrappingIncrement(ordering: .relaxed)
+                        try consumer1.scheduleCommit(record)
+                        if c2Messages.load(ordering: .relaxed) == 0 {
+                            try await Task.sleep(for: .milliseconds(50))
+                        }
+                    }
+                }
+
+                group.addTask {
+                    for await event in events1 {
+                        switch event {
+                        case .rebalance:
+                            rebalanceEventCount.wrappingIncrement(ordering: .relaxed)
+                        default:
+                            break
+                        }
+                    }
+                }
+
+                // Wait for consumer 1 to start consuming — bounded: 30s
+                for _ in 0..<600 {
+                    if c1Messages.load(ordering: .relaxed) >= 2 { break }
+                    try await Task.sleep(for: .milliseconds(50))
+                }
+                #expect(
+                    c1Messages.load(ordering: .relaxed) >= 2,
+                    "Timed out waiting for consumer 1 to consume messages"
+                )
+
+                // Start consumer 2 — triggers rebalance while messages are flowing
+                group.addTask { try await serviceGroup2.run() }
+                group.addTask {
+                    for try await record in consumer2.messages {
+                        c2Messages.wrappingIncrement(ordering: .relaxed)
+                        try consumer2.scheduleCommit(record)
+                    }
+                }
+
+                // Wait for all messages to be consumed (bounded: 60s)
+                group.addTask {
+                    for _ in 0..<600 {
+                        let total = c1Messages.load(ordering: .relaxed) + c2Messages.load(ordering: .relaxed)
+                        if total >= numMessages {
+                            try await Task.sleep(for: .milliseconds(200))
+                            await serviceGroup1.triggerGracefulShutdown()
+                            await serviceGroup2.triggerGracefulShutdown()
+                            return
+                        }
+                        try await Task.sleep(for: .milliseconds(100))
+                    }
+                    // Timed out — shut down anyway to avoid hanging
+                    await serviceGroup1.triggerGracefulShutdown()
+                    await serviceGroup2.triggerGracefulShutdown()
+                }
+
+                try await group.waitForAll()
+
+                // Verify messages were consumed (at least by consumer 1)
+                let c1Total = c1Messages.load(ordering: .relaxed)
+                let c2Total = c2Messages.load(ordering: .relaxed)
+                #expect(c1Total + c2Total >= Int(numMessages), "Total consumed should be at least \(numMessages)")
+
+                // Verify rebalance events were delivered through the events sequence.
+                // This is the core assertion: both message consumption (consumer queue)
+                // and rebalance events (callback → buffer → event loop drain) worked concurrently.
+                let rebalances = rebalanceEventCount.load(ordering: .relaxed)
+                #expect(rebalances >= 1, "Expected at least 1 rebalance event, got \(rebalances)")
+            }
+        }
+    }
+
+    @Test func atLeastOnceNoMessageLossAcrossRebalance() async throws {
+        try await withTestTopic(partitions: 4) { testTopic in
+            let uniqueGroupID = UUID().uuidString
+            let preRebalanceCount: UInt = 20
+            let postRebalanceCount: UInt = 30
+            let totalProduced = preRebalanceCount + postRebalanceCount
+
+            // Produce first batch BEFORE consumers start
+            let _ = try await self.produceMessages(topic: testTopic, count: preRebalanceCount)
+
+            // Consumer 1 — at-least-once config with events
+            var consumer1Config = KafkaConsumerConfig()
+            consumer1Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer1Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer1Config.autoOffsetReset = .beginning
+            consumer1Config.brokerAddressFamily = .v4
+            consumer1Config.pollInterval = .milliseconds(1)
+            consumer1Config.enableAutoOffsetStore = false
+            // Auto-commit ON (default) + auto-offset-store OFF = at-least-once
+            consumer1Config.autoCommitIntervalMs = 500
+
+            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
+                config: consumer1Config,
+                logger: .kafkaTest
+            )
+
+            // Consumer 2 — same at-least-once config, joins later
+            var consumer2Config = KafkaConsumerConfig()
+            consumer2Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer2Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer2Config.autoOffsetReset = .beginning
+            consumer2Config.brokerAddressFamily = .v4
+            consumer2Config.pollInterval = .milliseconds(1)
+            consumer2Config.enableAutoOffsetStore = false
+            consumer2Config.autoCommitIntervalMs = 500
+
+            let consumer2 = try KafkaConsumer(
+                config: consumer2Config,
+                logger: .kafkaTest
+            )
+
+            let serviceGroup1 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer1],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+            let serviceGroup2 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer2],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+
+            let c1Messages = ManagedAtomic(0)
+            let c2Messages = ManagedAtomic(0)
+            let rebalanceCount = ManagedAtomic(0)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // Run consumer 1
+                group.addTask { try await serviceGroup1.run() }
+
+                // Consumer 1 — consume + storeOffset (at-least-once)
+                group.addTask {
+                    for try await message in consumer1.messages {
+                        try consumer1.storeOffset(message)
+                        c1Messages.wrappingIncrement(ordering: .relaxed)
+                        // Slow down so consumer 2 can join mid-consumption
+                        if c2Messages.load(ordering: .relaxed) == 0 {
+                            try await Task.sleep(for: .milliseconds(50))
+                        }
+                    }
+                }
+
+                // Track rebalance events
+                group.addTask {
+                    for await event in events1 {
+                        if case .rebalance = event {
+                            rebalanceCount.wrappingIncrement(ordering: .relaxed)
+                        }
+                    }
+                }
+
+                // Wait for consumer 1 to start consuming some pre-rebalance messages
+                for _ in 0..<300 {
+                    if c1Messages.load(ordering: .relaxed) >= 2 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+                #expect(
+                    c1Messages.load(ordering: .relaxed) >= 2,
+                    "Timed out waiting for consumer 1 to start consuming"
+                )
+
+                // Start consumer 2 — triggers rebalance
+                group.addTask { try await serviceGroup2.run() }
+                group.addTask {
+                    for try await message in consumer2.messages {
+                        try consumer2.storeOffset(message)
+                        c2Messages.wrappingIncrement(ordering: .relaxed)
+                    }
+                }
+
+                // Wait for rebalance to complete (consumer 2 has partitions)
+                for _ in 0..<300 {
+                    if rebalanceCount.load(ordering: .relaxed) >= 2 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+                #expect(
+                    rebalanceCount.load(ordering: .relaxed) >= 2,
+                    "Timed out waiting for rebalance to complete"
+                )
+
+                // Produce SECOND batch AFTER rebalance — both consumers have partitions now
+                let _ = try await self.produceMessages(topic: testTopic, count: postRebalanceCount)
+
+                // Wait for all messages to be consumed (bounded: 60s)
+                group.addTask {
+                    for _ in 0..<600 {
+                        let total = c1Messages.load(ordering: .relaxed) + c2Messages.load(ordering: .relaxed)
+                        // At-least-once: total may EXCEED totalProduced due to re-delivery
+                        if total >= totalProduced {
+                            try await Task.sleep(for: .milliseconds(500))
+                            await serviceGroup1.triggerGracefulShutdown()
+                            await serviceGroup2.triggerGracefulShutdown()
+                            return
+                        }
+                        try await Task.sleep(for: .milliseconds(100))
+                    }
+                    await serviceGroup1.triggerGracefulShutdown()
+                    await serviceGroup2.triggerGracefulShutdown()
+                }
+
+                try await group.waitForAll()
+
+                let c1Total = c1Messages.load(ordering: .relaxed)
+                let c2Total = c2Messages.load(ordering: .relaxed)
+                let totalConsumed = c1Total + c2Total
+
+                // At-least-once guarantee: every produced message must be consumed
+                // at least once. Duplicates are acceptable (re-delivery after rebalance).
+                #expect(
+                    totalConsumed >= Int(totalProduced),
+                    "At-least-once violated: consumed \(totalConsumed) but produced \(totalProduced)"
+                )
+
+                // Consumer 2 MUST have consumed messages — proves partition reassignment worked.
+                // Post-rebalance batch was produced AFTER consumer 2 had partitions.
+                #expect(c2Total > 0, "Consumer 2 should have consumed messages after rebalance")
+
+                // Consumer 1 also consumed
+                #expect(c1Total > 0, "Consumer 1 should have consumed messages")
+
+                // Rebalance events were delivered
+                let rebalances = rebalanceCount.load(ordering: .relaxed)
+                #expect(rebalances >= 2, "Expected at least 2 rebalance events, got \(rebalances)")
+            }
+        }
+    }
+
+    @Test func cooperativeRebalanceUsesIncrementalAssign() async throws {
+        try await withTestTopic(partitions: 4) { testTopic in
+            let uniqueGroupID = UUID().uuidString
+
+            var consumer1Config = KafkaConsumerConfig()
+            consumer1Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer1Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer1Config.autoOffsetReset = .beginning
+            consumer1Config.brokerAddressFamily = .v4
+            consumer1Config.pollInterval = .milliseconds(1)
+            consumer1Config.partitionAssignmentStrategy = "cooperative-sticky"
+
+            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
+                config: consumer1Config,
+                logger: .kafkaTest
+            )
+
+            var consumer2Config = KafkaConsumerConfig()
+            consumer2Config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumer2Config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumer2Config.autoOffsetReset = .beginning
+            consumer2Config.brokerAddressFamily = .v4
+            consumer2Config.pollInterval = .milliseconds(1)
+            consumer2Config.partitionAssignmentStrategy = "cooperative-sticky"
+
+            let consumer2 = try KafkaConsumer(
+                config: consumer2Config,
+                logger: .kafkaTest
+            )
+
+            let serviceGroup1 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer1],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+            let serviceGroup2 = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer2],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+
+            let assignEvents = ManagedAtomic(0)
+            let revokeEvents = ManagedAtomic(0)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { try await serviceGroup1.run() }
+                group.addTask {
+                    for try await _ in consumer1.messages {}
+                }
+
+                group.addTask {
+                    for await event in events1 {
+                        switch event {
+                        case .rebalance(let r):
+                            switch r.kind {
+                            case .assign:
+                                assignEvents.wrappingIncrement(ordering: .relaxed)
+                            case .revoke:
+                                revokeEvents.wrappingIncrement(ordering: .relaxed)
+                            default:
+                                break
+                            }
+                        default:
+                            break
+                        }
+                    }
+                }
+
+                // Poll until consumer 1 receives initial assign (bounded: 30s)
+                for _ in 0..<300 {
+                    if assignEvents.load(ordering: .relaxed) >= 1 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+                #expect(
+                    assignEvents.load(ordering: .relaxed) >= 1,
+                    "Timed out waiting for initial assign with cooperative protocol"
+                )
+
+                // Start consumer 2 — triggers cooperative rebalance
+                group.addTask { try await serviceGroup2.run() }
+                group.addTask {
+                    for try await _ in consumer2.messages {}
+                }
+
+                // Poll until consumer 1 receives a revoke (bounded: 30s)
+                for _ in 0..<300 {
+                    if revokeEvents.load(ordering: .relaxed) >= 1 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+
+                let assigns = assignEvents.load(ordering: .relaxed)
+                let revokes = revokeEvents.load(ordering: .relaxed)
+                #expect(assigns >= 1, "Expected at least 1 assign event, got \(assigns)")
+                #expect(revokes >= 1, "Expected at least 1 revoke event with cooperative protocol, got \(revokes)")
+
+                await serviceGroup1.triggerGracefulShutdown()
+                await serviceGroup2.triggerGracefulShutdown()
+            }
+        }
+    }
+
+    @Test func shutdownRevokeEventDelivered() async throws {
+        try await withTestTopic(partitions: 2) { testTopic in
+            let uniqueGroupID = UUID().uuidString
+
+            var config = KafkaConsumerConfig()
+            config.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            config.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            config.autoOffsetReset = .beginning
+            config.brokerAddressFamily = .v4
+            config.pollInterval = .milliseconds(1)
+
+            let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
+                config: config,
+                logger: .kafkaTest
+            )
+
+            let serviceGroup = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+
+            let assignCount = ManagedAtomic(0)
+            let revokeCount = ManagedAtomic(0)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask { try await serviceGroup.run() }
+
+                group.addTask {
+                    for try await _ in consumer.messages {}
+                }
+
+                group.addTask {
+                    for await event in events {
+                        switch event {
+                        case .rebalance(let r):
+                            switch r.kind {
+                            case .assign:
+                                assignCount.wrappingIncrement(ordering: .relaxed)
+                            case .revoke:
+                                revokeCount.wrappingIncrement(ordering: .relaxed)
+                            default:
+                                break
+                            }
+                        default:
+                            break
+                        }
+                    }
+                }
+
+                // Poll until consumer receives initial assign — proves it fully joined (bounded: 30s)
+                for _ in 0..<300 {
+                    if assignCount.load(ordering: .relaxed) >= 1 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+                #expect(
+                    assignCount.load(ordering: .relaxed) >= 1,
+                    "Timed out waiting for initial assign before shutdown"
+                )
+
+                // Trigger graceful shutdown — rd_kafka_consumer_close_queue triggers final revoke
+                await serviceGroup.triggerGracefulShutdown()
+            }
+
+            let revokes = revokeCount.load(ordering: .relaxed)
+            #expect(revokes >= 1, "Expected shutdown revoke event, got \(revokes) revoke events")
         }
     }
 

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -201,8 +201,8 @@ import Foundation
             await serviceGroup.triggerGracefulShutdown()
         }
 
-        #expect(throws: KafkaError.self) {
-            _ = try consumer.committed(
+        await #expect(throws: KafkaError.self) {
+            _ = try await consumer.committed(
                 topicPartitions: [KafkaTopicPartition(topic: "test", partition: KafkaPartition(rawValue: 0))],
                 timeout: .milliseconds(1000)
             )
@@ -294,8 +294,8 @@ import Foundation
             await serviceGroup.triggerGracefulShutdown()
         }
 
-        #expect(throws: KafkaError.self) {
-            try consumer.seek(
+        await #expect(throws: KafkaError.self) {
+            try await consumer.seek(
                 topicPartitionOffsets: [
                     KafkaTopicPartitionOffset(topic: "test", partition: KafkaPartition(rawValue: 0), offset: .beginning)
                 ]
@@ -455,6 +455,347 @@ import Foundation
         set.insert(tpo2)
         set.insert(tpo3)
         #expect(set.count == 2)
+    }
+
+    // MARK: - KafkaConsumerRebalance Tests
+
+    @Test func rebalanceAssignConstruction() {
+        let partitions = [
+            KafkaTopicPartition(topic: "topic-a", partition: KafkaPartition(rawValue: 0)),
+            KafkaTopicPartition(topic: "topic-a", partition: KafkaPartition(rawValue: 1)),
+        ]
+        let rebalance = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
+        #expect(rebalance.kind == .assign)
+        #expect(rebalance.partitions.count == 2)
+        #expect(rebalance.partitions[0].topic == "topic-a")
+        #expect(rebalance.partitions[0].partition == KafkaPartition(rawValue: 0))
+        #expect(rebalance.partitions[1].partition == KafkaPartition(rawValue: 1))
+    }
+
+    @Test func rebalanceRevokeConstruction() {
+        let rebalance = KafkaConsumerRebalance(kind: .revoke, partitions: [])
+        #expect(rebalance.kind == .revoke)
+        #expect(rebalance.partitions.isEmpty)
+    }
+
+    @Test func rebalanceEquality() {
+        let partitions = [
+            KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))
+        ]
+        let r1 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
+        let r2 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
+        let r3 = KafkaConsumerRebalance(kind: .revoke, partitions: partitions)
+        let r4 = KafkaConsumerRebalance(kind: .assign, partitions: [])
+
+        #expect(r1 == r2)
+        #expect(r1 != r3)
+        #expect(r1 != r4)
+    }
+
+    @Test func rebalanceHashable() {
+        let partitions = [
+            KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))
+        ]
+        let r1 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
+        let r2 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
+        let r3 = KafkaConsumerRebalance(kind: .revoke, partitions: partitions)
+
+        var set: Set<KafkaConsumerRebalance> = []
+        set.insert(r1)
+        set.insert(r2)
+        set.insert(r3)
+        #expect(set.count == 2)
+    }
+
+    @Test func rebalanceKindEquality() {
+        #expect(KafkaConsumerRebalance.Kind.assign == KafkaConsumerRebalance.Kind.assign)
+        #expect(KafkaConsumerRebalance.Kind.revoke == KafkaConsumerRebalance.Kind.revoke)
+        #expect(KafkaConsumerRebalance.Kind.assign != KafkaConsumerRebalance.Kind.revoke)
+    }
+
+    // MARK: - KafkaConsumerEvent Rebalance Tests
+
+    @Test func consumerEventRebalancePatternMatch() {
+        let rebalance = KafkaConsumerRebalance(
+            kind: .assign,
+            partitions: [KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))]
+        )
+        let event = KafkaConsumerEvent.rebalance(rebalance)
+
+        switch event {
+        case .rebalance(let r):
+            #expect(r.kind == .assign)
+            #expect(r.partitions.count == 1)
+        default:
+            Issue.record("Expected .rebalance event")
+        }
+    }
+
+    @Test func consumerEventFromConsumerPollEvent() {
+        let rebalance = KafkaConsumerRebalance(
+            kind: .revoke,
+            partitions: [
+                KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0)),
+                KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 1)),
+            ]
+        )
+        let event = KafkaConsumerEvent.rebalance(rebalance)
+
+        switch event {
+        case .rebalance(let r):
+            #expect(r.kind == .revoke)
+            #expect(r.partitions.count == 2)
+        default:
+            Issue.record("Expected .rebalance event")
+        }
+    }
+
+    // MARK: - KafkaConsumerRebalance.Kind.error Tests
+
+    @Test func rebalanceErrorConstruction() {
+        let rebalance = KafkaConsumerRebalance(kind: .error("broker unavailable"), partitions: [])
+        #expect(rebalance.partitions.isEmpty)
+        if case .error(let description) = rebalance.kind {
+            #expect(description == "broker unavailable")
+        } else {
+            Issue.record("Expected .error kind")
+        }
+    }
+
+    @Test func rebalanceErrorEquality() {
+        let r1 = KafkaConsumerRebalance(kind: .error("err1"), partitions: [])
+        let r2 = KafkaConsumerRebalance(kind: .error("err1"), partitions: [])
+        let r3 = KafkaConsumerRebalance(kind: .error("err2"), partitions: [])
+        let r4 = KafkaConsumerRebalance(kind: .assign, partitions: [])
+
+        #expect(r1 == r2)
+        #expect(r1 != r3)
+        #expect(r1 != r4)
+    }
+
+    @Test func rebalanceErrorHashable() {
+        let r1 = KafkaConsumerRebalance(kind: .error("err"), partitions: [])
+        let r2 = KafkaConsumerRebalance(kind: .error("err"), partitions: [])
+        let r3 = KafkaConsumerRebalance(kind: .assign, partitions: [])
+
+        var set: Set<KafkaConsumerRebalance> = []
+        set.insert(r1)
+        set.insert(r2)
+        set.insert(r3)
+        #expect(set.count == 2)
+    }
+
+    @Test func rebalanceErrorEventPatternMatch() {
+        let rebalance = KafkaConsumerRebalance(kind: .error("group coordinator not available"), partitions: [])
+        let event = KafkaConsumerEvent.rebalance(rebalance)
+
+        switch event {
+        case .rebalance(let r):
+            if case .error(let desc) = r.kind {
+                #expect(desc == "group coordinator not available")
+            } else {
+                Issue.record("Expected .error kind")
+            }
+            #expect(r.partitions.isEmpty)
+        default:
+            Issue.record("Expected .rebalance event")
+        }
+    }
+
+    // MARK: - RebalanceContext Tests
+
+    @Test func rebalanceContextDrainEventsEmpty() {
+        let context = RebalanceContext(logger: .kafkaTest)
+        let events = context.drainEvents()
+        #expect(events.isEmpty)
+    }
+
+    @Test func rebalanceContextInjectAndDrain() {
+        let context = RebalanceContext(logger: .kafkaTest)
+
+        context._testInjectEvent(
+            RebalanceContext.ConsumerRebalanceEvent(
+                kind: .assign,
+                partitions: [("topic-a", 0), ("topic-a", 1)]
+            )
+        )
+        context._testInjectEvent(
+            RebalanceContext.ConsumerRebalanceEvent(
+                kind: .revoke,
+                partitions: [("topic-a", 1)]
+            )
+        )
+
+        let events = context.drainEvents()
+        #expect(events.count == 2)
+
+        // Verify FIFO ordering
+        if case .assign = events[0].kind {
+            #expect(events[0].partitions.count == 2)
+        } else {
+            Issue.record("Expected first event to be .assign")
+        }
+
+        if case .revoke = events[1].kind {
+            #expect(events[1].partitions.count == 1)
+        } else {
+            Issue.record("Expected second event to be .revoke")
+        }
+    }
+
+    @Test func rebalanceContextDrainClearsBuffer() {
+        let context = RebalanceContext(logger: .kafkaTest)
+
+        context._testInjectEvent(
+            RebalanceContext.ConsumerRebalanceEvent(kind: .assign, partitions: [("t", 0)])
+        )
+
+        let first = context.drainEvents()
+        #expect(first.count == 1)
+
+        let second = context.drainEvents()
+        #expect(second.isEmpty, "Second drain should return empty after first drain consumed the event")
+    }
+
+    @Test func rebalanceContextErrorEventInjection() {
+        let context = RebalanceContext(logger: .kafkaTest)
+
+        context._testInjectEvent(
+            RebalanceContext.ConsumerRebalanceEvent(kind: .error("coordinator not available"), partitions: [])
+        )
+
+        let events = context.drainEvents()
+        #expect(events.count == 1)
+        if case .error(let desc) = events[0].kind {
+            #expect(desc == "coordinator not available")
+        } else {
+            Issue.record("Expected .error kind")
+        }
+        #expect(events[0].partitions.isEmpty)
+    }
+
+    @Test func rebalanceContextConcurrentInjectAndDrain() async {
+        // This tests the core race condition: the C callback thread appends events
+        // while the Swift event loop drains them concurrently.
+        let context = RebalanceContext(logger: .kafkaTest)
+
+        // Use an actor to safely count drained events across tasks
+        actor Counter {
+            var value = 0
+            func add(_ n: Int) { value += n }
+            func get() -> Int { value }
+        }
+        let drainCounter = Counter()
+
+        await withTaskGroup(of: Void.self) { group in
+            // Simulate C callback thread: rapidly inject events
+            group.addTask {
+                for i in 0..<200 {
+                    context._testInjectEvent(
+                        RebalanceContext.ConsumerRebalanceEvent(
+                            kind: i % 2 == 0 ? .assign : .revoke,
+                            partitions: [("topic", i)]
+                        )
+                    )
+                }
+            }
+
+            // Simulate event loop: drain repeatedly
+            group.addTask {
+                for _ in 0..<500 {
+                    let events = context.drainEvents()
+                    await drainCounter.add(events.count)
+                    await Task.yield()
+                }
+            }
+
+            await group.waitForAll()
+        }
+
+        // Drain any remaining events after both tasks complete
+        let remaining = context.drainEvents()
+        await drainCounter.add(remaining.count)
+
+        // Every injected event must be drained exactly once — no loss, no duplication
+        let finalDrained = await drainCounter.get()
+        #expect(finalDrained == 200, "Expected 200 drained events, got \(finalDrained)")
+    }
+
+    @Test func rebalanceContextConcurrentMultipleInjectersAndDrain() async {
+        // Multiple "C callback threads" appending simultaneously while event loop drains
+        let context = RebalanceContext(logger: .kafkaTest)
+        let injectersCount = 5
+        let eventsPerInjecter = 50
+
+        actor Counter {
+            var value = 0
+            func add(_ n: Int) { value += n }
+            func get() -> Int { value }
+        }
+        let drainCounter = Counter()
+
+        await withTaskGroup(of: Void.self) { group in
+            // Multiple concurrent injecters
+            for t in 0..<injectersCount {
+                group.addTask {
+                    for i in 0..<eventsPerInjecter {
+                        context._testInjectEvent(
+                            RebalanceContext.ConsumerRebalanceEvent(
+                                kind: .assign,
+                                partitions: [("topic-\(t)", i)]
+                            )
+                        )
+                    }
+                }
+            }
+
+            // Single drain loop
+            group.addTask {
+                for _ in 0..<1000 {
+                    let events = context.drainEvents()
+                    await drainCounter.add(events.count)
+                    await Task.yield()
+                }
+            }
+
+            await group.waitForAll()
+        }
+
+        let remaining = context.drainEvents()
+        await drainCounter.add(remaining.count)
+        let finalDrained = await drainCounter.get()
+        let expected = injectersCount * eventsPerInjecter
+        #expect(finalDrained == expected, "Expected \(expected) drained events, got \(finalDrained)")
+    }
+
+    @Test func rebalanceContextFIFOOrderingPreservedUnderConcurrency() async {
+        // Verify events from a single injecter maintain FIFO order
+        let context = RebalanceContext(logger: .kafkaTest)
+        var allDrained: [RebalanceContext.ConsumerRebalanceEvent] = []
+
+        // Inject 100 events with sequential partition IDs
+        for i in 0..<100 {
+            context._testInjectEvent(
+                RebalanceContext.ConsumerRebalanceEvent(
+                    kind: .assign,
+                    partitions: [("topic", i)]
+                )
+            )
+        }
+
+        // Drain in batches
+        while true {
+            let batch = context.drainEvents()
+            if batch.isEmpty { break }
+            allDrained.append(contentsOf: batch)
+        }
+
+        #expect(allDrained.count == 100)
+
+        // Verify ordering: partition IDs should be 0, 1, 2, ... 99
+        for (index, event) in allDrained.enumerated() {
+            #expect(event.partitions[0].partition == index, "Event at index \(index) has partition \(event.partitions[0].partition), expected \(index)")
+        }
     }
 
 }


### PR DESCRIPTION
## Motivation

1. **No rebalance event delivery**: `rd_kafka_conf_set_rebalance_cb` was never called, so consumers received no notification of partition assignment or revocation. Without this, applications cannot implement commit-on-revoke, flush in-memory state on partition loss, or clean up per-partition resources during consumer group rebalancing. All major Kafka clients (Java, Rust, Python, Go) expose rebalance callbacks.

2. **Blocking C calls on cooperative thread pool**: `committed()` and `seekPartitions()` called blocking C functions (`rd_kafka_committed`, `rd_kafka_seek_partitions`) directly on Swift Concurrency's cooperative thread pool. If the broker is slow or unreachable, these calls block for the full timeout (default 5 seconds), preventing `Task.isCancelled` checks, starving other async tasks, and causing `.timeLimit` to fail to enforce timeouts.

## Modifications

- Add `RebalanceContext` class with C rebalance callback that handles assign/unassign synchronously inside `rd_kafka_consumer_poll()`, supporting both **eager** (`rd_kafka_assign`) and **cooperative** (`rd_kafka_incremental_assign`/`rd_kafka_incremental_unassign`) protocols. Rebalance events are buffered in a thread-safe `NIOLockedValueBox` and drained by the Swift event loop.
- Add `.rebalance` case in `consumerEventPoll` to handle shutdown revoke events that arrive on the main queue (after `rd_kafka_consumer_close_queue` forwards the consumer queue). Both dispatch paths (C callback during normal operation, event poll during shutdown) route through the same `RebalanceContext.handleRebalance` method.
- Add `KafkaConsumerRebalance` public struct with `Kind` enum (`.assign`, `.revoke`, `.error`) and `KafkaConsumerEvent.rebalance` case for user-facing event delivery through `KafkaConsumerEvents` async sequence.
- Store `RebalanceContext` in state machine alongside `RDKafkaClient` in `.initializing`/`.running`/`.finishing` states to prevent use-after-free if the message iterator outlives `KafkaConsumer`.
- Add `defer { eventsSource?.finish() }` in `eventRunLoop` to guarantee the events stream ends on all exit paths (normal, cancellation, error).
- Add `finalDrain()` method called on `.terminatePollLoop` to poll+drain one last time after `isConsumerClosed` returns true, closing the race window where the close process completes before the event loop polls the shutdown revoke.
- Offload `committed()` and `seekPartitions()` to a shared concurrent `DispatchQueue` via `withCheckedThrowingContinuation`, matching the existing `flush()` pattern.
- Move `flush()` to the same shared concurrent `DispatchQueue`, eliminating per-call queue allocation.
- Add `RDKafkaTopicPartitionList` `@unchecked Sendable` conformance with safety documentation for capture in `@Sendable` closures.
- Remove dead `KafkaConsumerEvent.init(_ event:)` that always `fatalError`'d.

## API Changes

Two public method signatures changed from `throws` to `async throws`:

| Method | Before | After |
|--------|--------|-------|
| `KafkaConsumer.committed(topicPartitions:timeout:)` | `throws -> [KafkaTopicPartitionOffset]` | `async throws -> [KafkaTopicPartitionOffset]` |
| `KafkaConsumer.seek(topicPartitionOffsets:timeout:)` | `throws` | `async throws` |

**Note**: Both methods were added in PR #217 (merged to `main` but not yet included in any tagged release — the latest release is `1.0.0-alpha.9`). This signature change has zero migration impact for downstream users on a released version.

**Why `async throws`**: Both methods call blocking C functions that can block for up to `timeout` (default 5 seconds) waiting for a broker response. The `async throws` signature ensures the Swift task suspends at `await` while the blocking call runs on a separate GCD thread, freeing the cooperative thread pool. This matches the pattern already used by `flush()`.

**Migration** (for code on `main`): Add `await` at call sites:
```swift
// Before:
let offsets = try consumer.committed(topicPartitions: partitions)
try consumer.seek(topicPartitionOffsets: targets)

// After:
let offsets = try await consumer.committed(topicPartitions: partitions)
try await consumer.seek(topicPartitionOffsets: targets)
```

## Result

Consumers receive rebalance events (`.assign`, `.revoke`, `.error`) through the `KafkaConsumerEvents` async sequence. Both eager and cooperative rebalance protocols are supported. The library handles assign/unassign automatically — events are informational for application-level bookkeeping. Blocking C calls no longer starve the cooperative thread pool. Graceful shutdown completes cleanly with all events drained. At-least-once delivery semantics preserved across rebalances.

## Tests & Verification

- 41 unit tests (RebalanceContext buffer mechanics with concurrent inject+drain, KafkaConsumerRebalance equality/hashable/error, closed-consumer guards for async committed/seek)
- 19 integration tests including 5 new: rebalance event delivery, concurrent message+rebalance flow, cooperative protocol, shutdown revoke delivery, at-least-once with no message loss across rebalance
- All existing tests updated for async `committed()`/`seek()` signatures
- Successful completion of new/existing tests via `make docker-test`