### PR TITLE
Register error events and surface through consumer/producer event sequences

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -219,7 +219,7 @@ public final class KafkaConsumer: Sendable, Service {
         config: KafkaConsumerConfig,
         logger: Logger
     ) throws {
-        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance, .error]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
         if !isAutoCommitEnabled {
             subscribedEvents.append(.offsetCommit)
@@ -266,7 +266,7 @@ public final class KafkaConsumer: Sendable, Service {
         config: KafkaConsumerConfig,
         logger: Logger
     ) throws -> (KafkaConsumer, KafkaConsumerEvents) {
-        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance, .error]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
         if !isAutoCommitEnabled {
             subscribedEvents.append(.offsetCommit)
@@ -417,6 +417,14 @@ public final class KafkaConsumer: Sendable, Service {
                     switch event {
                     case .statistics(let statistics):
                         self.config.metrics.update(with: statistics)
+                    case .error(let kafkaError):
+                        if let source = self.eventsSource {
+                            _ = source.yield(.error(kafkaError))
+                        }
+                        self.logger.error(
+                            "Kafka client error",
+                            metadata: ["error": "\(kafkaError)"]
+                        )
                     }
                 }
 
@@ -473,7 +481,21 @@ public final class KafkaConsumer: Sendable, Service {
     /// had a chance to poll it. This one last poll+drain ensures that event
     /// is not lost.
     private func finalDrain(client: RDKafkaClient) {
-        let _ = client.consumerEventPoll()
+        let events = client.consumerEventPoll()
+        for event in events {
+            switch event {
+            case .statistics(let statistics):
+                self.config.metrics.update(with: statistics)
+            case .error(let kafkaError):
+                if let source = self.eventsSource {
+                    _ = source.yield(.error(kafkaError))
+                }
+                self.logger.error(
+                    "Kafka client error",
+                    metadata: ["error": "\(kafkaError)"]
+                )
+            }
+        }
 
         let rebalanceEvents = self.rebalanceContext.drainEvents()
         for event in rebalanceEvents {

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -22,6 +22,9 @@ public enum KafkaConsumerEvent: Sendable, Hashable {
     /// or initializing state on assign.
     case rebalance(KafkaConsumerRebalance)
 
+    /// An error reported by the Kafka client (e.g., broker disconnection, authentication failure).
+    case error(KafkaError)
+
     /// - Important: Always provide a `default` case when switching over this `enum`.
     case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
 }

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -71,6 +71,22 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
         )
     }
 
+    static func rdKafkaError(
+        wrapping error: rd_kafka_resp_err_t,
+        reason: String,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> KafkaError {
+        KafkaError(
+            backing: .init(
+                code: .underlying,
+                reason: reason,
+                file: file,
+                line: line
+            )
+        )
+    }
+
     static func config(
         reason: String,
         file: String = #fileID,

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -82,6 +82,9 @@ public final class KafkaProducer: Service, Sendable {
     /// The configuration object of the producer client.
     private let config: KafkaProducerConfig
 
+    /// A logger.
+    private let logger: Logger
+
     // Private initializer, use factory method or convenience init to create KafkaProducer
     /// Initialize a new ``KafkaProducer``.
     ///
@@ -91,10 +94,12 @@ public final class KafkaProducer: Service, Sendable {
     /// - Throws: A ``KafkaError`` if initializing the producer failed.
     private init(
         stateMachine: NIOLockedValueBox<KafkaProducer.StateMachine>,
-        config: KafkaProducerConfig
+        config: KafkaProducerConfig,
+        logger: Logger
     ) {
         self.stateMachine = stateMachine
         self.config = config
+        self.logger = logger
     }
 
     /// Initialize a new ``KafkaProducer``.
@@ -111,7 +116,7 @@ public final class KafkaProducer: Service, Sendable {
     ) throws {
         let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
-        var subscribedEvents: [RDKafkaEvent] = [.log]  // No .deliveryReport here!
+        var subscribedEvents: [RDKafkaEvent] = [.log, .error]
 
         if config.metrics.enabled {
             subscribedEvents.append(.statistics)
@@ -133,7 +138,8 @@ public final class KafkaProducer: Service, Sendable {
 
         self.init(
             stateMachine: stateMachine,
-            config: config
+            config: config,
+            logger: logger
         )
     }
 
@@ -156,7 +162,7 @@ public final class KafkaProducer: Service, Sendable {
     ) throws -> (KafkaProducer, KafkaProducerEvents) {
         let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
-        var subscribedEvents: [RDKafkaEvent] = [.log, .deliveryReport]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .deliveryReport, .error]
         // Listen to statistics events when statistics enabled
         if config.metrics.enabled {
             subscribedEvents.append(.statistics)
@@ -171,7 +177,8 @@ public final class KafkaProducer: Service, Sendable {
 
         let producer = KafkaProducer(
             stateMachine: stateMachine,
-            config: config
+            config: config,
+            logger: logger
         )
 
         // Note:
@@ -235,8 +242,20 @@ public final class KafkaProducer: Service, Sendable {
             let nextAction = self.stateMachine.withLockedValue { $0.nextPollLoopAction() }
             switch nextAction {
             case .pollWithoutYield(let client):
-                // Drop any incoming events
-                let _ = client.producerEventPoll()
+                let events = client.producerEventPoll()
+                for event in events {
+                    switch event {
+                    case .statistics(let statistics):
+                        self.config.metrics.update(with: statistics)
+                    case .deliveryReport:
+                        break
+                    case .error(let kafkaError):
+                        self.logger.error(
+                            "Kafka client error",
+                            metadata: ["error": "\(kafkaError)"]
+                        )
+                    }
+                }
             case .pollAndYield(let client, let source):
                 let events = client.producerEventPoll()
                 for event in events {
@@ -245,6 +264,12 @@ public final class KafkaProducer: Service, Sendable {
                         self.config.metrics.update(with: statistics)
                     case .deliveryReport(let reports):
                         _ = source?.yield(.deliveryReports(reports))
+                    case .error(let kafkaError):
+                        _ = source?.yield(.error(kafkaError))
+                        self.logger.error(
+                            "Kafka client error",
+                            metadata: ["error": "\(kafkaError)"]
+                        )
                     }
                 }
                 try await Task.sleep(for: self.config.pollInterval)

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -16,6 +16,8 @@
 public enum KafkaProducerEvent: Sendable, Hashable {
     /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
     case deliveryReports([KafkaDeliveryReport])
+    /// An error reported by the Kafka client (e.g., broker disconnection, authentication failure).
+    case error(KafkaError)
     /// - Important: Always provide a `default` case when switching over this `enum`.
     case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
 
@@ -23,6 +25,8 @@ public enum KafkaProducerEvent: Sendable, Hashable {
         switch event {
         case .deliveryReport(let results):
             self = .deliveryReports(results)
+        case .error(let kafkaError):
+            self = .error(kafkaError)
         case .statistics:
             fatalError("Cannot cast \(event) to KafkaProducerEvent")
         }

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -316,12 +316,14 @@ public final class RDKafkaClient: Sendable {
     enum ProducerPollEvent {
         case deliveryReport(results: [KafkaDeliveryReport])
         case statistics(RDKafkaStatistics)
+        case error(KafkaError)
     }
 
     /// Typed event returned by ``consumerEventPoll(maxEvents:)``.
     /// Contains only events relevant to a Kafka consumer.
     enum ConsumerPollEvent {
         case statistics(RDKafkaStatistics)
+        case error(KafkaError)
     }
 
     /// Poll for producer-relevant events from the `librdkafka` event queue.
@@ -350,6 +352,10 @@ public final class RDKafkaClient: Sendable {
             case .statistics:
                 if let statistics = self.handleStatistics(event) {
                     events.append(.statistics(statistics))
+                }
+            case .error:
+                if let error = self.handleErrorEvent(event) {
+                    events.append(.error(error))
                 }
             case .log:
                 self.handleLogEvent(event)
@@ -389,6 +395,10 @@ public final class RDKafkaClient: Sendable {
             case .statistics:
                 if let statistics = self.handleStatistics(event) {
                     events.append(.statistics(statistics))
+                }
+            case .error:
+                if let error = self.handleErrorEvent(event) {
+                    events.append(.error(error))
                 }
             case .log:
                 self.handleLogEvent(event)
@@ -442,6 +452,22 @@ public final class RDKafkaClient: Sendable {
 
         // The returned message(s) MUST NOT be freed with rd_kafka_message_destroy().
         return deliveryReportResults
+    }
+
+    /// Handle event of type `RDKafkaEvent.error`.
+    ///
+    /// - Parameter event: Pointer to underlying `rd_kafka_event_t`.
+    /// - Returns: A ``KafkaError`` if the event carries a non-zero error code, or `nil` otherwise.
+    private func handleErrorEvent(_ event: OpaquePointer?) -> KafkaError? {
+        let code = rd_kafka_event_error(event)
+        guard code != RD_KAFKA_RESP_ERR_NO_ERROR else {
+            return nil
+        }
+        let reasonCString = rd_kafka_event_error_string(event)
+        let reason =
+            reasonCString.flatMap { String(cString: $0) }
+            ?? String(cString: rd_kafka_err2str(code))
+        return KafkaError.rdKafkaError(wrapping: code, reason: reason)
     }
 
     /// Handle event of type `RDKafkaEvent.statistics`.

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -801,4 +801,29 @@ import Foundation
         }
     }
 
+    // MARK: - KafkaConsumerEvent.error Tests
+
+    @Test func consumerEventErrorPatternMatch() {
+        let error = KafkaError.config(reason: "All brokers are down")
+        let event = KafkaConsumerEvent.error(error)
+
+        switch event {
+        case .error(let e):
+            #expect(e.description.contains("All brokers are down"))
+        default:
+            Issue.record("Expected .error event")
+        }
+    }
+
+    @Test func consumerEventErrorEquality() {
+        let error1 = KafkaError.config(reason: "All brokers are down")
+        let error2 = KafkaError.config(reason: "Authentication failed")
+
+        let event1 = KafkaConsumerEvent.error(error1)
+        let event2 = KafkaConsumerEvent.error(error2)
+
+        // Same error code (.config), so they are equal per current Equatable (known limitation)
+        #expect(event1 == event2)
+    }
+
 }

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -32,8 +32,6 @@ import Foundation
 @Suite(.serialized)
 final class KafkaMetricsTests {
     var metrics: TestMetrics = TestMetrics()
-    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
-    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
 
     init() async throws {
         MetricsSystem.bootstrapInternal(self.metrics)
@@ -74,13 +72,7 @@ final class KafkaMetricsTests {
     }
 
     @Test func producerStatistics() async throws {
-        let bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
-            host: self.kafkaHost,
-            port: self.kafkaPort
-        )
-
         var config = KafkaProducerConfig()
-        config.bootstrapServers = ["\(bootstrapBrokerAddress)"]
         config.brokerAddressFamily = .v4
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -26,20 +26,10 @@ import Foundation
 #endif
 
 @Suite struct KafkaProducerTests {
-    // Read environment variables to get information about the test Kafka server
-    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
-    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
-    var bootstrapBrokerAddress: KafkaConfiguration.BrokerAddress
     var config: KafkaProducerConfig
 
     init() throws {
-        self.bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
-            host: self.kafkaHost,
-            port: self.kafkaPort
-        )
-
         self.config = KafkaProducerConfig()
-        self.config.bootstrapServers = ["\(self.bootstrapBrokerAddress)"]
         self.config.brokerAddressFamily = .v4
     }
 
@@ -384,6 +374,20 @@ import Foundation
 
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    // MARK: - KafkaProducerEvent.error Tests
+
+    @Test func producerEventErrorPatternMatch() {
+        let error = KafkaError.config(reason: "Authentication failed")
+        let event = KafkaProducerEvent.error(error)
+
+        switch event {
+        case .error(let e):
+            #expect(e.description.contains("Authentication failed"))
+        default:
+            Issue.record("Expected .error event")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Subscribe to `RD_KAFKA_EVENT_ERROR` unconditionally in all consumer and producer init paths
- Add `.error(KafkaError)` case to `KafkaConsumerEvent` and `KafkaProducerEvent`
- Add `handleErrorEvent()` helper on `RDKafkaClient` with NULL-safe reason string extraction
- Handle error events in consumer `eventRunLoop()`, `finalDrain()`, and both producer poll loop branches
- Add `logger` property to `KafkaProducer` (matching consumer pattern) for error logging
- Remove `localhost:9092` default from unit tests to prevent spurious broker connection attempts

## Motivation

librdkafka surfaces fatal errors (authentication failure, all brokers down, SSL handshake failure) through `RD_KAFKA_EVENT_ERROR`. The Swift client never subscribed to this event type — errors hit `default: break` in both poll methods and were silently dropped. A disconnected client gave no signal to the application.

## Test plan
- [x] `swift build -Xswiftc -warnings-as-errors` passes with zero warnings
- [x] Unit tests pass 
- [x] Docker integration tests pass (`make docker-test`)
- [x] Verify error events are delivered when broker goes down (manual testing with Docker)