### PR TITLE
Use in-process mock brokers for unit tests

### DIFF
--- a/Sources/Kafka/Configuration/KafkaConsumerConfig.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfig.swift
@@ -1046,6 +1046,10 @@ public struct KafkaConsumerConfig: Sendable {
     /// librdkafka property name: `"consume.callback.max.messages"`
     public var consumeCallbackMaxMessages: Int?
 
+    /// Additional librdkafka configuration properties not covered by typed properties.
+    /// Keys and values are passed directly to librdkafka.
+    internal var additionalConfig: [String: String] = [:]
+
     public init() {}
 
     internal var config: [String: String] {
@@ -1183,6 +1187,10 @@ public struct KafkaConsumerConfig: Sendable {
             let updateInterval = metrics.updateInterval
         {
             config["statistics.interval.ms"] = String(updateInterval.inMilliseconds)
+        }
+
+        for (key, value) in self.additionalConfig {
+            config[key] = value
         }
 
         return config

--- a/Sources/Kafka/Configuration/KafkaProducerConfig.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfig.swift
@@ -1035,6 +1035,10 @@ public struct KafkaProducerConfig: Sendable {
     /// Default: -1
     public var compressionLevel: Int?
 
+    /// Additional librdkafka configuration properties not covered by typed properties.
+    /// Keys and values are passed directly to librdkafka.
+    internal var additionalConfig: [String: String] = [:]
+
     public init() {}
 
     internal var config: [String: String] {
@@ -1152,6 +1156,10 @@ public struct KafkaProducerConfig: Sendable {
             let updateInterval = metrics.updateInterval
         {
             config["statistics.interval.ms"] = String(updateInterval.inMilliseconds)
+        }
+
+        for (key, value) in self.additionalConfig {
+            config[key] = value
         }
 
         return config

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -47,7 +47,7 @@ import Foundation
         if let enableAutoOffsetStore {
             config.enableAutoOffsetStore = enableAutoOffsetStore
         }
-        MockBrokerConfig.apply(to: &config, brokerCount: 1)
+        config.useMockBroker()
         config.brokerAddressFamily = .v4
         return config
     }

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -47,6 +47,8 @@ import Foundation
         if let enableAutoOffsetStore {
             config.enableAutoOffsetStore = enableAutoOffsetStore
         }
+        MockBrokerConfig.apply(to: &config, brokerCount: 1)
+        config.brokerAddressFamily = .v4
         return config
     }
 

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -49,7 +49,7 @@ final class KafkaMetricsTests {
         )
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")
-        MockBrokerConfig.apply(to: &config, brokerCount: 1)
+        config.useMockBroker()
         config.brokerAddressFamily = .v4
 
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
@@ -75,7 +75,7 @@ final class KafkaMetricsTests {
 
     @Test func producerStatistics() async throws {
         var config = KafkaProducerConfig()
-        MockBrokerConfig.apply(to: &config, brokerCount: 1)
+        config.useMockBroker()
         config.brokerAddressFamily = .v4
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -32,8 +32,6 @@ import Foundation
 @Suite(.serialized)
 final class KafkaMetricsTests {
     var metrics: TestMetrics = TestMetrics()
-    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
-    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
 
     init() async throws {
         MetricsSystem.bootstrapInternal(self.metrics)
@@ -51,6 +49,8 @@ final class KafkaMetricsTests {
         )
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")
+        MockBrokerConfig.apply(to: &config, brokerCount: 1)
+        config.brokerAddressFamily = .v4
 
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
@@ -74,13 +74,8 @@ final class KafkaMetricsTests {
     }
 
     @Test func producerStatistics() async throws {
-        let bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
-            host: self.kafkaHost,
-            port: self.kafkaPort
-        )
-
         var config = KafkaProducerConfig()
-        config.bootstrapServers = ["\(bootstrapBrokerAddress)"]
+        MockBrokerConfig.apply(to: &config, brokerCount: 1)
         config.brokerAddressFamily = .v4
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -30,7 +30,7 @@ import Foundation
 
     init() throws {
         self.config = KafkaProducerConfig()
-        MockBrokerConfig.apply(to: &self.config, brokerCount: 1)
+        self.config.useMockBroker()
         self.config.brokerAddressFamily = .v4
     }
 

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -26,20 +26,11 @@ import Foundation
 #endif
 
 @Suite struct KafkaProducerTests {
-    // Read environment variables to get information about the test Kafka server
-    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
-    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
-    var bootstrapBrokerAddress: KafkaConfiguration.BrokerAddress
     var config: KafkaProducerConfig
 
     init() throws {
-        self.bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
-            host: self.kafkaHost,
-            port: self.kafkaPort
-        )
-
         self.config = KafkaProducerConfig()
-        self.config.bootstrapServers = ["\(self.bootstrapBrokerAddress)"]
+        MockBrokerConfig.apply(to: &self.config, brokerCount: 1)
         self.config.brokerAddressFamily = .v4
     }
 

--- a/Tests/KafkaTests/MockCluster.swift
+++ b/Tests/KafkaTests/MockCluster.swift
@@ -14,19 +14,21 @@
 
 @testable import Kafka
 
-/// Helpers for configuring librdkafka's built-in mock cluster.
+/// Extensions for configuring librdkafka's built-in mock cluster.
 ///
 /// Setting `test.mock.num.brokers` causes librdkafka to create an in-process
 /// mock Kafka cluster, eliminating the need for a real broker in unit tests.
-enum MockBrokerConfig {
 
-    /// Apply mock broker configuration to a ``KafkaProducerConfig``.
-    static func apply(to config: inout KafkaProducerConfig, brokerCount: Int) {
-        config.additionalConfig["test.mock.num.brokers"] = "\(brokerCount)"
+extension KafkaProducerConfig {
+    /// Configure this producer to use librdkafka's in-process mock broker.
+    mutating func useMockBroker(count: Int = 1) {
+        self.additionalConfig["test.mock.num.brokers"] = "\(count)"
     }
+}
 
-    /// Apply mock broker configuration to a ``KafkaConsumerConfig``.
-    static func apply(to config: inout KafkaConsumerConfig, brokerCount: Int) {
-        config.additionalConfig["test.mock.num.brokers"] = "\(brokerCount)"
+extension KafkaConsumerConfig {
+    /// Configure this consumer to use librdkafka's in-process mock broker.
+    mutating func useMockBroker(count: Int = 1) {
+        self.additionalConfig["test.mock.num.brokers"] = "\(count)"
     }
 }

--- a/Tests/KafkaTests/MockCluster.swift
+++ b/Tests/KafkaTests/MockCluster.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import Kafka
+
+/// Helpers for configuring librdkafka's built-in mock cluster.
+///
+/// Setting `test.mock.num.brokers` causes librdkafka to create an in-process
+/// mock Kafka cluster, eliminating the need for a real broker in unit tests.
+enum MockBrokerConfig {
+
+    /// Apply mock broker configuration to a ``KafkaProducerConfig``.
+    static func apply(to config: inout KafkaProducerConfig, brokerCount: Int) {
+        config.additionalConfig["test.mock.num.brokers"] = "\(brokerCount)"
+    }
+
+    /// Apply mock broker configuration to a ``KafkaConsumerConfig``.
+    static func apply(to config: inout KafkaConsumerConfig, brokerCount: Int) {
+        config.additionalConfig["test.mock.num.brokers"] = "\(brokerCount)"
+    }
+}


### PR DESCRIPTION
## Motivation

Unit tests create real librdkafka clients to test producer/consumer lifecycle, metrics, and state machine behavior. These tests relied on `localhost:9092` as the default bootstrap broker, causing librdkafka to attempt real TCP connections during test runs — an external dependency that unit tests should never have. Without a running broker, librdkafka generated connection errors that polluted test output.

librdkafka provides a `test.mock.num.brokers` configuration property that creates in-process mock brokers — supporting producers, consumers, consumer groups with offset commits, and topic auto-creation — without any external dependencies. This is the same approach used by Rust rdkafka for unit testing, where unit tests never set `bootstrap.servers`.

## Summary

- Add `useMockBroker(count:)` extensions on `KafkaProducerConfig` and `KafkaConsumerConfig` that set librdkafka's `test.mock.num.brokers` to create in-process mock brokers for unit testing
- Add `internal var additionalConfig: [String: String]` on `KafkaProducerConfig` and `KafkaConsumerConfig` for passing arbitrary librdkafka configuration properties
- Replace `localhost:9092` defaults in `KafkaProducerTests`, `KafkaConsumerTests`, and `KafkaMetricsTests` with `config.useMockBroker()`

## Test plan
- [x] `swift build --build-tests -Xswiftc -warnings-as-errors` passes
- [x] `swift test --skip IntegrationTests` passes — no broker connection attempts
- [x] `make docker-test` passes — integration tests unchanged