### PR TITLE
Register error events with typed error codes and surface through consumer/producer event sequences

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -219,7 +219,7 @@ public final class KafkaConsumer: Sendable, Service {
         config: KafkaConsumerConfig,
         logger: Logger
     ) throws {
-        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance, .error]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
         if !isAutoCommitEnabled {
             subscribedEvents.append(.offsetCommit)
@@ -266,7 +266,7 @@ public final class KafkaConsumer: Sendable, Service {
         config: KafkaConsumerConfig,
         logger: Logger
     ) throws -> (KafkaConsumer, KafkaConsumerEvents) {
-        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance, .error]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
         if !isAutoCommitEnabled {
             subscribedEvents.append(.offsetCommit)
@@ -417,6 +417,14 @@ public final class KafkaConsumer: Sendable, Service {
                     switch event {
                     case .statistics(let statistics):
                         self.config.metrics.update(with: statistics)
+                    case .error(let kafkaError):
+                        if let source = self.eventsSource {
+                            _ = source.yield(.error(kafkaError))
+                        }
+                        self.logger.error(
+                            "Kafka client error",
+                            metadata: ["error": "\(kafkaError)"]
+                        )
                     }
                 }
 
@@ -473,7 +481,21 @@ public final class KafkaConsumer: Sendable, Service {
     /// had a chance to poll it. This one last poll+drain ensures that event
     /// is not lost.
     private func finalDrain(client: RDKafkaClient) {
-        let _ = client.consumerEventPoll()
+        let events = client.consumerEventPoll()
+        for event in events {
+            switch event {
+            case .statistics(let statistics):
+                self.config.metrics.update(with: statistics)
+            case .error(let kafkaError):
+                if let source = self.eventsSource {
+                    _ = source.yield(.error(kafkaError))
+                }
+                self.logger.error(
+                    "Kafka client error",
+                    metadata: ["error": "\(kafkaError)"]
+                )
+            }
+        }
 
         let rebalanceEvents = self.rebalanceContext.drainEvents()
         for event in rebalanceEvents {

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -22,6 +22,9 @@ public enum KafkaConsumerEvent: Sendable, Hashable {
     /// or initializing state on assign.
     case rebalance(KafkaConsumerRebalance)
 
+    /// An error reported by the Kafka client (e.g., broker disconnection, authentication failure).
+    case error(KafkaError)
+
     /// - Important: Always provide a `default` case when switching over this `enum`.
     case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
 }

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -14,59 +14,61 @@
 
 import Crdkafka
 
-/// A type-safe wrapper around librdkafka's `rd_kafka_resp_err_t` error codes.
-///
-/// Use the static constants (e.g., `.allBrokersDown`, `.authentication`) to match
-/// against the ``KafkaError/rdKafkaErrorCode`` property without importing Crdkafka.
-public struct RDKafkaErrorCode: Hashable, Sendable, CustomStringConvertible {
-    /// The raw `Int32` value corresponding to the librdkafka error code.
-    public let rawValue: Int32
-
-    public init(rawValue: Int32) {
-        self.rawValue = rawValue
-    }
-
-    // MARK: - Common error codes
-
-    /// All broker connections are down.
-    public static let allBrokersDown = RDKafkaErrorCode(rawValue: -187)
-    /// Authentication failure.
-    public static let authentication = RDKafkaErrorCode(rawValue: -169)
-    /// Broker transport failure.
-    public static let transport = RDKafkaErrorCode(rawValue: -195)
-    /// Operation timed out.
-    public static let timedOut = RDKafkaErrorCode(rawValue: -185)
-    /// SSL error.
-    public static let ssl = RDKafkaErrorCode(rawValue: -181)
-    /// Message timed out.
-    public static let messageTimedOut = RDKafkaErrorCode(rawValue: -192)
-    /// Queue full.
-    public static let queueFull = RDKafkaErrorCode(rawValue: -184)
-    /// Fatal error.
-    public static let fatal = RDKafkaErrorCode(rawValue: -150)
-    /// Maximum poll interval exceeded.
-    public static let maxPollExceeded = RDKafkaErrorCode(rawValue: -147)
-    /// Invalid argument.
-    public static let invalidArgument = RDKafkaErrorCode(rawValue: -186)
-    /// Unknown topic.
-    public static let unknownTopic = RDKafkaErrorCode(rawValue: -188)
-    /// Unknown partition.
-    public static let unknownPartition = RDKafkaErrorCode(rawValue: -190)
-    /// No error.
-    public static let noError = RDKafkaErrorCode(rawValue: 0)
-
-    public var description: String {
-        let name = String(cString: rd_kafka_err2str(rd_kafka_resp_err_t(rawValue: self.rawValue)))
-        return "\(name) (code: \(self.rawValue))"
-    }
-}
-
 /// An error that can occur on `Kafka` operations
 ///
 /// - Note: `Hashable` conformance considers both the ``KafkaError/code``
-///   and the ``KafkaError/rdKafkaErrorCode``.
+///   and the ``KafkaError/rdKafkaCode``.
 public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
     // Note: @unchecked because we use a backing class for storage (copy-on-write).
+
+    // MARK: - RDKafkaCode
+
+    /// A type-safe wrapper around librdkafka's `rd_kafka_resp_err_t` error codes.
+    ///
+    /// Use the static constants (e.g., `.allBrokersDown`, `.authentication`) to match
+    /// against the ``KafkaError/rdKafkaCode`` property without importing Crdkafka.
+    public struct RDKafkaCode: Hashable, Sendable, CustomStringConvertible {
+        /// The raw `Int32` value corresponding to the librdkafka error code.
+        public let rawValue: Int32
+
+        public init(rawValue: Int32) {
+            self.rawValue = rawValue
+        }
+
+        // MARK: - Common error codes
+
+        /// All broker connections are down.
+        public static let allBrokersDown = RDKafkaCode(rawValue: -187)
+        /// Authentication failure.
+        public static let authentication = RDKafkaCode(rawValue: -169)
+        /// Broker transport failure.
+        public static let transport = RDKafkaCode(rawValue: -195)
+        /// Operation timed out.
+        public static let timedOut = RDKafkaCode(rawValue: -185)
+        /// SSL error.
+        public static let ssl = RDKafkaCode(rawValue: -181)
+        /// Message timed out.
+        public static let messageTimedOut = RDKafkaCode(rawValue: -192)
+        /// Queue full.
+        public static let queueFull = RDKafkaCode(rawValue: -184)
+        /// Fatal error.
+        public static let fatal = RDKafkaCode(rawValue: -150)
+        /// Maximum poll interval exceeded.
+        public static let maxPollExceeded = RDKafkaCode(rawValue: -147)
+        /// Invalid argument.
+        public static let invalidArgument = RDKafkaCode(rawValue: -186)
+        /// Unknown topic.
+        public static let unknownTopic = RDKafkaCode(rawValue: -188)
+        /// Unknown partition.
+        public static let unknownPartition = RDKafkaCode(rawValue: -190)
+        /// No error.
+        public static let noError = RDKafkaCode(rawValue: 0)
+
+        public var description: String {
+            let name = String(cString: rd_kafka_err2str(rd_kafka_resp_err_t(rawValue: self.rawValue)))
+            return "\(name) (code: \(self.rawValue))"
+        }
+    }
 
     private var backing: Backing
 
@@ -85,8 +87,8 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
     ///
     /// Returns `nil` for errors that do not wrap a `rd_kafka_resp_err_t`
     /// (e.g., pure configuration or lifecycle errors).
-    public var rdKafkaErrorCode: RDKafkaErrorCode? {
-        self.backing.rdKafkaErrorCode
+    public var rdKafkaCode: RDKafkaCode? {
+        self.backing.rdKafkaCode
     }
 
     private var reason: String {
@@ -123,7 +125,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
                 reason: errorMessage,
                 file: file,
                 line: line,
-                rdKafkaErrorCode: RDKafkaErrorCode(rawValue: error.rawValue)
+                rdKafkaCode: RDKafkaCode(rawValue: error.rawValue)
             )
         )
     }
@@ -140,7 +142,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
                 reason: reason,
                 file: file,
                 line: line,
-                rdKafkaErrorCode: RDKafkaErrorCode(rawValue: error.rawValue)
+                rdKafkaCode: RDKafkaCode(rawValue: error.rawValue)
             )
         )
     }
@@ -310,29 +312,29 @@ extension KafkaError {
 
         let line: UInt
 
-        let rdKafkaErrorCode: RDKafkaErrorCode?
+        let rdKafkaCode: RDKafkaCode?
 
         fileprivate init(
             code: KafkaError.ErrorCode,
             reason: String,
             file: String,
             line: UInt,
-            rdKafkaErrorCode: RDKafkaErrorCode? = nil
+            rdKafkaCode: RDKafkaCode? = nil
         ) {
             self.code = code
             self.reason = reason
             self.file = file
             self.line = line
-            self.rdKafkaErrorCode = rdKafkaErrorCode
+            self.rdKafkaCode = rdKafkaCode
         }
 
         static func == (lhs: Backing, rhs: Backing) -> Bool {
-            lhs.code == rhs.code && lhs.rdKafkaErrorCode == rhs.rdKafkaErrorCode
+            lhs.code == rhs.code && lhs.rdKafkaCode == rhs.rdKafkaCode
         }
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(self.code)
-            hasher.combine(self.rdKafkaErrorCode)
+            hasher.combine(self.rdKafkaCode)
         }
 
         fileprivate func copy() -> Backing {
@@ -341,7 +343,7 @@ extension KafkaError {
                 reason: self.reason,
                 file: self.file,
                 line: self.line,
-                rdKafkaErrorCode: self.rdKafkaErrorCode
+                rdKafkaCode: self.rdKafkaCode
             )
         }
     }

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -14,9 +14,57 @@
 
 import Crdkafka
 
+/// A type-safe wrapper around librdkafka's `rd_kafka_resp_err_t` error codes.
+///
+/// Use the static constants (e.g., `.allBrokersDown`, `.authentication`) to match
+/// against the ``KafkaError/rdKafkaErrorCode`` property without importing Crdkafka.
+public struct RDKafkaErrorCode: Hashable, Sendable, CustomStringConvertible {
+    /// The raw `Int32` value corresponding to the librdkafka error code.
+    public let rawValue: Int32
+
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    // MARK: - Common error codes
+
+    /// All broker connections are down.
+    public static let allBrokersDown = RDKafkaErrorCode(rawValue: -187)
+    /// Authentication failure.
+    public static let authentication = RDKafkaErrorCode(rawValue: -169)
+    /// Broker transport failure.
+    public static let transport = RDKafkaErrorCode(rawValue: -195)
+    /// Operation timed out.
+    public static let timedOut = RDKafkaErrorCode(rawValue: -185)
+    /// SSL error.
+    public static let ssl = RDKafkaErrorCode(rawValue: -181)
+    /// Message timed out.
+    public static let messageTimedOut = RDKafkaErrorCode(rawValue: -192)
+    /// Queue full.
+    public static let queueFull = RDKafkaErrorCode(rawValue: -184)
+    /// Fatal error.
+    public static let fatal = RDKafkaErrorCode(rawValue: -150)
+    /// Maximum poll interval exceeded.
+    public static let maxPollExceeded = RDKafkaErrorCode(rawValue: -147)
+    /// Invalid argument.
+    public static let invalidArgument = RDKafkaErrorCode(rawValue: -186)
+    /// Unknown topic.
+    public static let unknownTopic = RDKafkaErrorCode(rawValue: -188)
+    /// Unknown partition.
+    public static let unknownPartition = RDKafkaErrorCode(rawValue: -190)
+    /// No error.
+    public static let noError = RDKafkaErrorCode(rawValue: 0)
+
+    public var description: String {
+        let name = String(cString: rd_kafka_err2str(rd_kafka_resp_err_t(rawValue: self.rawValue)))
+        return "\(name) (code: \(self.rawValue))"
+    }
+}
+
 /// An error that can occur on `Kafka` operations
 ///
-/// - Note: `Hashable` conformance only considers the ``KafkaError/code``.
+/// - Note: `Hashable` conformance considers both the ``KafkaError/code``
+///   and the ``KafkaError/rdKafkaErrorCode``.
 public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
     // Note: @unchecked because we use a backing class for storage (copy-on-write).
 
@@ -31,6 +79,14 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
             self.makeUnique()
             self.backing.code = newValue
         }
+    }
+
+    /// The underlying librdkafka error code, if this error originated from librdkafka.
+    ///
+    /// Returns `nil` for errors that do not wrap a `rd_kafka_resp_err_t`
+    /// (e.g., pure configuration or lifecycle errors).
+    public var rdKafkaErrorCode: RDKafkaErrorCode? {
+        self.backing.rdKafkaErrorCode
     }
 
     private var reason: String {
@@ -66,7 +122,25 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
                 code: .underlying,
                 reason: errorMessage,
                 file: file,
-                line: line
+                line: line,
+                rdKafkaErrorCode: RDKafkaErrorCode(rawValue: error.rawValue)
+            )
+        )
+    }
+
+    static func rdKafkaError(
+        wrapping error: rd_kafka_resp_err_t,
+        reason: String,
+        file: String = #fileID,
+        line: UInt = #line
+    ) -> KafkaError {
+        KafkaError(
+            backing: .init(
+                code: .underlying,
+                reason: reason,
+                file: file,
+                line: line,
+                rdKafkaErrorCode: RDKafkaErrorCode(rawValue: error.rawValue)
             )
         )
     }
@@ -236,29 +310,39 @@ extension KafkaError {
 
         let line: UInt
 
+        let rdKafkaErrorCode: RDKafkaErrorCode?
+
         fileprivate init(
             code: KafkaError.ErrorCode,
             reason: String,
             file: String,
-            line: UInt
+            line: UInt,
+            rdKafkaErrorCode: RDKafkaErrorCode? = nil
         ) {
             self.code = code
             self.reason = reason
             self.file = file
             self.line = line
+            self.rdKafkaErrorCode = rdKafkaErrorCode
         }
 
-        // Only the error code matters for equality.
         static func == (lhs: Backing, rhs: Backing) -> Bool {
-            lhs.code == rhs.code
+            lhs.code == rhs.code && lhs.rdKafkaErrorCode == rhs.rdKafkaErrorCode
         }
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(self.code)
+            hasher.combine(self.rdKafkaErrorCode)
         }
 
         fileprivate func copy() -> Backing {
-            Backing(code: self.code, reason: self.reason, file: self.file, line: self.line)
+            Backing(
+                code: self.code,
+                reason: self.reason,
+                file: self.file,
+                line: self.line,
+                rdKafkaErrorCode: self.rdKafkaErrorCode
+            )
         }
     }
 }

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -256,6 +256,7 @@ public final class KafkaProducer: Service, Sendable {
                         )
                     }
                 }
+                try await Task.sleep(for: self.config.pollInterval)
             case .pollAndYield(let client, let source):
                 let events = client.producerEventPoll()
                 for event in events {

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -82,6 +82,9 @@ public final class KafkaProducer: Service, Sendable {
     /// The configuration object of the producer client.
     private let config: KafkaProducerConfig
 
+    /// A logger.
+    private let logger: Logger
+
     // Private initializer, use factory method or convenience init to create KafkaProducer
     /// Initialize a new ``KafkaProducer``.
     ///
@@ -91,10 +94,12 @@ public final class KafkaProducer: Service, Sendable {
     /// - Throws: A ``KafkaError`` if initializing the producer failed.
     private init(
         stateMachine: NIOLockedValueBox<KafkaProducer.StateMachine>,
-        config: KafkaProducerConfig
+        config: KafkaProducerConfig,
+        logger: Logger
     ) {
         self.stateMachine = stateMachine
         self.config = config
+        self.logger = logger
     }
 
     /// Initialize a new ``KafkaProducer``.
@@ -111,7 +116,7 @@ public final class KafkaProducer: Service, Sendable {
     ) throws {
         let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
-        var subscribedEvents: [RDKafkaEvent] = [.log]  // No .deliveryReport here!
+        var subscribedEvents: [RDKafkaEvent] = [.log, .error]
 
         if config.metrics.enabled {
             subscribedEvents.append(.statistics)
@@ -133,7 +138,8 @@ public final class KafkaProducer: Service, Sendable {
 
         self.init(
             stateMachine: stateMachine,
-            config: config
+            config: config,
+            logger: logger
         )
     }
 
@@ -156,7 +162,7 @@ public final class KafkaProducer: Service, Sendable {
     ) throws -> (KafkaProducer, KafkaProducerEvents) {
         let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
-        var subscribedEvents: [RDKafkaEvent] = [.log, .deliveryReport]
+        var subscribedEvents: [RDKafkaEvent] = [.log, .deliveryReport, .error]
         // Listen to statistics events when statistics enabled
         if config.metrics.enabled {
             subscribedEvents.append(.statistics)
@@ -171,7 +177,8 @@ public final class KafkaProducer: Service, Sendable {
 
         let producer = KafkaProducer(
             stateMachine: stateMachine,
-            config: config
+            config: config,
+            logger: logger
         )
 
         // Note:
@@ -235,8 +242,20 @@ public final class KafkaProducer: Service, Sendable {
             let nextAction = self.stateMachine.withLockedValue { $0.nextPollLoopAction() }
             switch nextAction {
             case .pollWithoutYield(let client):
-                // Drop any incoming events
-                let _ = client.producerEventPoll()
+                let events = client.producerEventPoll()
+                for event in events {
+                    switch event {
+                    case .statistics(let statistics):
+                        self.config.metrics.update(with: statistics)
+                    case .deliveryReport:
+                        break
+                    case .error(let kafkaError):
+                        self.logger.error(
+                            "Kafka client error",
+                            metadata: ["error": "\(kafkaError)"]
+                        )
+                    }
+                }
             case .pollAndYield(let client, let source):
                 let events = client.producerEventPoll()
                 for event in events {
@@ -245,6 +264,12 @@ public final class KafkaProducer: Service, Sendable {
                         self.config.metrics.update(with: statistics)
                     case .deliveryReport(let reports):
                         _ = source?.yield(.deliveryReports(reports))
+                    case .error(let kafkaError):
+                        _ = source?.yield(.error(kafkaError))
+                        self.logger.error(
+                            "Kafka client error",
+                            metadata: ["error": "\(kafkaError)"]
+                        )
                     }
                 }
                 try await Task.sleep(for: self.config.pollInterval)

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -16,6 +16,8 @@
 public enum KafkaProducerEvent: Sendable, Hashable {
     /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
     case deliveryReports([KafkaDeliveryReport])
+    /// An error reported by the Kafka client (e.g., broker disconnection, authentication failure).
+    case error(KafkaError)
     /// - Important: Always provide a `default` case when switching over this `enum`.
     case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
 
@@ -23,6 +25,8 @@ public enum KafkaProducerEvent: Sendable, Hashable {
         switch event {
         case .deliveryReport(let results):
             self = .deliveryReports(results)
+        case .error(let kafkaError):
+            self = .error(kafkaError)
         case .statistics:
             fatalError("Cannot cast \(event) to KafkaProducerEvent")
         }

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -316,12 +316,14 @@ public final class RDKafkaClient: Sendable {
     enum ProducerPollEvent {
         case deliveryReport(results: [KafkaDeliveryReport])
         case statistics(RDKafkaStatistics)
+        case error(KafkaError)
     }
 
     /// Typed event returned by ``consumerEventPoll(maxEvents:)``.
     /// Contains only events relevant to a Kafka consumer.
     enum ConsumerPollEvent {
         case statistics(RDKafkaStatistics)
+        case error(KafkaError)
     }
 
     /// Poll for producer-relevant events from the `librdkafka` event queue.
@@ -350,6 +352,10 @@ public final class RDKafkaClient: Sendable {
             case .statistics:
                 if let statistics = self.handleStatistics(event) {
                     events.append(.statistics(statistics))
+                }
+            case .error:
+                if let error = self.handleErrorEvent(event) {
+                    events.append(.error(error))
                 }
             case .log:
                 self.handleLogEvent(event)
@@ -389,6 +395,10 @@ public final class RDKafkaClient: Sendable {
             case .statistics:
                 if let statistics = self.handleStatistics(event) {
                     events.append(.statistics(statistics))
+                }
+            case .error:
+                if let error = self.handleErrorEvent(event) {
+                    events.append(.error(error))
                 }
             case .log:
                 self.handleLogEvent(event)
@@ -442,6 +452,22 @@ public final class RDKafkaClient: Sendable {
 
         // The returned message(s) MUST NOT be freed with rd_kafka_message_destroy().
         return deliveryReportResults
+    }
+
+    /// Handle event of type `RDKafkaEvent.error`.
+    ///
+    /// - Parameter event: Pointer to underlying `rd_kafka_event_t`.
+    /// - Returns: A ``KafkaError`` if the event carries a non-zero error code, or `nil` otherwise.
+    private func handleErrorEvent(_ event: OpaquePointer?) -> KafkaError? {
+        let code = rd_kafka_event_error(event)
+        guard code != RD_KAFKA_RESP_ERR_NO_ERROR else {
+            return nil
+        }
+        let reasonCString = rd_kafka_event_error_string(event)
+        let reason =
+            reasonCString.flatMap { String(cString: $0) }
+            ?? String(cString: rd_kafka_err2str(code))
+        return KafkaError.rdKafkaError(wrapping: code, reason: reason)
     }
 
     /// Handle event of type `RDKafkaEvent.statistics`.

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -827,56 +827,56 @@ import Foundation
         #expect(event1 == event2)
     }
 
-    // MARK: - RDKafkaErrorCode Tests
+    // MARK: - KafkaError.RDKafkaCode Tests
 
-    @Test func rdKafkaErrorCodeStaticConstants() {
-        #expect(RDKafkaErrorCode.allBrokersDown.rawValue == -187)
-        #expect(RDKafkaErrorCode.authentication.rawValue == -169)
-        #expect(RDKafkaErrorCode.transport.rawValue == -195)
-        #expect(RDKafkaErrorCode.timedOut.rawValue == -185)
-        #expect(RDKafkaErrorCode.ssl.rawValue == -181)
-        #expect(RDKafkaErrorCode.fatal.rawValue == -150)
-        #expect(RDKafkaErrorCode.noError.rawValue == 0)
+    @Test func rdKafkaCodeStaticConstants() {
+        #expect(KafkaError.RDKafkaCode.allBrokersDown.rawValue == -187)
+        #expect(KafkaError.RDKafkaCode.authentication.rawValue == -169)
+        #expect(KafkaError.RDKafkaCode.transport.rawValue == -195)
+        #expect(KafkaError.RDKafkaCode.timedOut.rawValue == -185)
+        #expect(KafkaError.RDKafkaCode.ssl.rawValue == -181)
+        #expect(KafkaError.RDKafkaCode.fatal.rawValue == -150)
+        #expect(KafkaError.RDKafkaCode.noError.rawValue == 0)
     }
 
-    @Test func rdKafkaErrorCodeEquality() {
-        #expect(RDKafkaErrorCode.allBrokersDown == RDKafkaErrorCode(rawValue: -187))
-        #expect(RDKafkaErrorCode.allBrokersDown != RDKafkaErrorCode.transport)
+    @Test func rdKafkaCodeEquality() {
+        #expect(KafkaError.RDKafkaCode.allBrokersDown == KafkaError.RDKafkaCode(rawValue: -187))
+        #expect(KafkaError.RDKafkaCode.allBrokersDown != KafkaError.RDKafkaCode.transport)
     }
 
-    @Test func rdKafkaErrorCodeHashable() {
-        var set = Set<RDKafkaErrorCode>()
+    @Test func rdKafkaCodeHashable() {
+        var set = Set<KafkaError.RDKafkaCode>()
         set.insert(.allBrokersDown)
-        set.insert(RDKafkaErrorCode(rawValue: -187))
+        set.insert(KafkaError.RDKafkaCode(rawValue: -187))
         set.insert(.authentication)
         #expect(set.count == 2)
     }
 
-    @Test func rdKafkaErrorCodeDescription() {
-        let code = RDKafkaErrorCode.allBrokersDown
+    @Test func rdKafkaCodeDescription() {
+        let code = KafkaError.RDKafkaCode.allBrokersDown
         #expect(code.description.contains("-187"))
         #expect(code.description.contains("broker"))
     }
 
     // MARK: - KafkaError Error Code Preservation Tests
 
-    @Test func kafkaErrorPreservesRDKafkaErrorCode() {
+    @Test func kafkaErrorPreservesRDKafkaCode() {
         let error = KafkaError.rdKafkaError(wrapping: rd_kafka_resp_err_t(rawValue: -187))
-        #expect(error.rdKafkaErrorCode == .allBrokersDown)
+        #expect(error.rdKafkaCode == .allBrokersDown)
         #expect(error.code == .underlying)
     }
 
-    @Test func kafkaErrorPreservesRDKafkaErrorCodeWithReason() {
+    @Test func kafkaErrorPreservesRDKafkaCodeWithReason() {
         let error = KafkaError.rdKafkaError(
             wrapping: rd_kafka_resp_err_t(rawValue: -185),
             reason: "custom reason"
         )
-        #expect(error.rdKafkaErrorCode == .timedOut)
+        #expect(error.rdKafkaCode == .timedOut)
     }
 
     @Test func kafkaErrorNonRDKafkaErrorHasNilCode() {
         let error = KafkaError.config(reason: "bad config")
-        #expect(error.rdKafkaErrorCode == nil)
+        #expect(error.rdKafkaCode == nil)
     }
 
     @Test func kafkaErrorEqualityDistinguishesDifferentRDKafkaCodes() {

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Crdkafka
 import Logging
 import ServiceLifecycle
 import Testing
@@ -799,6 +800,95 @@ import Foundation
                 "Event at index \(index) has partition \(event.partitions[0].partition), expected \(index)"
             )
         }
+    }
+
+    // MARK: - KafkaConsumerEvent.error Tests
+
+    @Test func consumerEventErrorPatternMatch() {
+        let error = KafkaError.config(reason: "All brokers are down")
+        let event = KafkaConsumerEvent.error(error)
+
+        switch event {
+        case .error(let e):
+            #expect(e.description.contains("All brokers are down"))
+        default:
+            Issue.record("Expected .error event")
+        }
+    }
+
+    @Test func consumerEventErrorEquality() {
+        let error1 = KafkaError.config(reason: "All brokers are down")
+        let error2 = KafkaError.config(reason: "Authentication failed")
+
+        let event1 = KafkaConsumerEvent.error(error1)
+        let event2 = KafkaConsumerEvent.error(error2)
+
+        // Same error code (.config), so they are equal per current Equatable (known limitation)
+        #expect(event1 == event2)
+    }
+
+    // MARK: - RDKafkaErrorCode Tests
+
+    @Test func rdKafkaErrorCodeStaticConstants() {
+        #expect(RDKafkaErrorCode.allBrokersDown.rawValue == -187)
+        #expect(RDKafkaErrorCode.authentication.rawValue == -169)
+        #expect(RDKafkaErrorCode.transport.rawValue == -195)
+        #expect(RDKafkaErrorCode.timedOut.rawValue == -185)
+        #expect(RDKafkaErrorCode.ssl.rawValue == -181)
+        #expect(RDKafkaErrorCode.fatal.rawValue == -150)
+        #expect(RDKafkaErrorCode.noError.rawValue == 0)
+    }
+
+    @Test func rdKafkaErrorCodeEquality() {
+        #expect(RDKafkaErrorCode.allBrokersDown == RDKafkaErrorCode(rawValue: -187))
+        #expect(RDKafkaErrorCode.allBrokersDown != RDKafkaErrorCode.transport)
+    }
+
+    @Test func rdKafkaErrorCodeHashable() {
+        var set = Set<RDKafkaErrorCode>()
+        set.insert(.allBrokersDown)
+        set.insert(RDKafkaErrorCode(rawValue: -187))
+        set.insert(.authentication)
+        #expect(set.count == 2)
+    }
+
+    @Test func rdKafkaErrorCodeDescription() {
+        let code = RDKafkaErrorCode.allBrokersDown
+        #expect(code.description.contains("-187"))
+        #expect(code.description.contains("broker"))
+    }
+
+    // MARK: - KafkaError Error Code Preservation Tests
+
+    @Test func kafkaErrorPreservesRDKafkaErrorCode() {
+        let error = KafkaError.rdKafkaError(wrapping: rd_kafka_resp_err_t(rawValue: -187))
+        #expect(error.rdKafkaErrorCode == .allBrokersDown)
+        #expect(error.code == .underlying)
+    }
+
+    @Test func kafkaErrorPreservesRDKafkaErrorCodeWithReason() {
+        let error = KafkaError.rdKafkaError(
+            wrapping: rd_kafka_resp_err_t(rawValue: -185),
+            reason: "custom reason"
+        )
+        #expect(error.rdKafkaErrorCode == .timedOut)
+    }
+
+    @Test func kafkaErrorNonRDKafkaErrorHasNilCode() {
+        let error = KafkaError.config(reason: "bad config")
+        #expect(error.rdKafkaErrorCode == nil)
+    }
+
+    @Test func kafkaErrorEqualityDistinguishesDifferentRDKafkaCodes() {
+        let err1 = KafkaError.rdKafkaError(wrapping: rd_kafka_resp_err_t(rawValue: -187))
+        let err2 = KafkaError.rdKafkaError(wrapping: rd_kafka_resp_err_t(rawValue: -169))
+        #expect(err1 != err2)
+    }
+
+    @Test func kafkaErrorEqualitySameRDKafkaCode() {
+        let err1 = KafkaError.rdKafkaError(wrapping: rd_kafka_resp_err_t(rawValue: -187))
+        let err2 = KafkaError.rdKafkaError(wrapping: rd_kafka_resp_err_t(rawValue: -187))
+        #expect(err1 == err2)
     }
 
 }

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -32,6 +32,8 @@ import Foundation
 @Suite(.serialized)
 final class KafkaMetricsTests {
     var metrics: TestMetrics = TestMetrics()
+    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
+    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
 
     init() async throws {
         MetricsSystem.bootstrapInternal(self.metrics)
@@ -72,7 +74,13 @@ final class KafkaMetricsTests {
     }
 
     @Test func producerStatistics() async throws {
+        let bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
+            host: self.kafkaHost,
+            port: self.kafkaPort
+        )
+
         var config = KafkaProducerConfig()
+        config.bootstrapServers = ["\(bootstrapBrokerAddress)"]
         config.brokerAddressFamily = .v4
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -32,8 +32,6 @@ import Foundation
 @Suite(.serialized)
 final class KafkaMetricsTests {
     var metrics: TestMetrics = TestMetrics()
-    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
-    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
 
     init() async throws {
         MetricsSystem.bootstrapInternal(self.metrics)
@@ -74,13 +72,7 @@ final class KafkaMetricsTests {
     }
 
     @Test func producerStatistics() async throws {
-        let bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
-            host: self.kafkaHost,
-            port: self.kafkaPort
-        )
-
         var config = KafkaProducerConfig()
-        config.bootstrapServers = ["\(bootstrapBrokerAddress)"]
         config.brokerAddressFamily = .v4
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -26,10 +26,20 @@ import Foundation
 #endif
 
 @Suite struct KafkaProducerTests {
+    // Read environment variables to get information about the test Kafka server
+    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
+    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
+    var bootstrapBrokerAddress: KafkaConfiguration.BrokerAddress
     var config: KafkaProducerConfig
 
     init() throws {
+        self.bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
+            host: self.kafkaHost,
+            port: self.kafkaPort
+        )
+
         self.config = KafkaProducerConfig()
+        self.config.bootstrapServers = ["\(self.bootstrapBrokerAddress)"]
         self.config.brokerAddressFamily = .v4
     }
 

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -26,20 +26,10 @@ import Foundation
 #endif
 
 @Suite struct KafkaProducerTests {
-    // Read environment variables to get information about the test Kafka server
-    let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
-    let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
-    var bootstrapBrokerAddress: KafkaConfiguration.BrokerAddress
     var config: KafkaProducerConfig
 
     init() throws {
-        self.bootstrapBrokerAddress = KafkaConfiguration.BrokerAddress(
-            host: self.kafkaHost,
-            port: self.kafkaPort
-        )
-
         self.config = KafkaProducerConfig()
-        self.config.bootstrapServers = ["\(self.bootstrapBrokerAddress)"]
         self.config.brokerAddressFamily = .v4
     }
 
@@ -384,6 +374,20 @@ import Foundation
 
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    // MARK: - KafkaProducerEvent.error Tests
+
+    @Test func producerEventErrorPatternMatch() {
+        let error = KafkaError.config(reason: "Authentication failed")
+        let event = KafkaProducerEvent.error(error)
+
+        switch event {
+        case .error(let e):
+            #expect(e.description.contains("Authentication failed"))
+        default:
+            Issue.record("Expected .error event")
         }
     }
 }

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -1,1 +1,3 @@
 API breakage: enumelement KafkaConsumerEvent.rebalance has been added as a new enum case
+API breakage: enumelement KafkaConsumerEvent.error has been added as a new enum case
+API breakage: enumelement KafkaProducerEvent.error has been added as a new enum case


### PR DESCRIPTION
## Motivation

librdkafka reports errors (authentication failure, broker disconnection, SSL errors) through `RD_KAFKA_EVENT_ERROR`. The Swift client never subscribed to this event type — errors hit `default: break` and were silently dropped. A disconnected client gave no signal to the application.

Additionally, `KafkaError` discarded the original `rd_kafka_resp_err_t` code, making all librdkafka errors compare equal via `Equatable` and forcing applications to string-match error messages.

## Summary

- Subscribe to `RD_KAFKA_EVENT_ERROR` unconditionally in all init paths
- Add `.error(KafkaError)` to `KafkaConsumerEvent` and `KafkaProducerEvent`
- Add `handleErrorEvent()` on `RDKafkaClient` with NULL-safe reason extraction
- Handle errors in consumer `eventRunLoop()`, `finalDrain()`, and both producer poll branches — always log, yield to events source if available
- Add `logger` to `KafkaProducer` (matching consumer pattern)
- Add `KafkaError.RDKafkaCode` nested struct with typed constants (`allBrokersDown`, `authentication`, `transport`, `timedOut`, `ssl`, `fatal`, etc.)
- Add `rdKafkaCode` property on `KafkaError` — preserves the raw code (nil for non-librdkafka errors)
- Fix `Equatable`/`Hashable` to include `rdKafkaCode`

## Test plan
- [x] Build + unit tests pass
- [x] `make docker-test` passes