### PR TITLE
Add dynamic subscribe, unsubscribe APIs to KafkaConsumer

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -388,7 +388,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// - Returns: An array of topic names or patterns the consumer is currently subscribed to.
     /// - Throws: A ``KafkaError`` if the consumer is closed or the query failed.
-    public func subscription() throws -> [String] {
+    public func subscribedTopics() throws -> [String] {
         let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
         switch action {
         case .client(let client):

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -334,11 +334,73 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
-    /// Subscribe to the given list of `topics`.
-    /// The partition assignment happens automatically using `KafkaConsumer`'s consumer group.
+    // MARK: - Subscription Management
+
+    /// Subscribe to the given list of topics.
+    ///
+    /// This replaces any previous subscription. The partition assignment happens
+    /// automatically using the consumer's consumer group. Topic names prefixed
+    /// with `^` are treated as regular expressions. Passing an empty array is
+    /// equivalent to calling ``unsubscribe()``.
+    ///
     /// - Parameter topics: An array of topic names to subscribe to.
-    /// - Throws: A ``KafkaError`` if subscribing to the topic list failed.
-    private func subscribe(topics: [String]) throws {
+    /// - Throws: A ``KafkaError`` if the consumer is closed or subscribing failed.
+    public func subscribe(topics: [String]) throws {
+        guard !topics.isEmpty else {
+            try self.unsubscribe()
+            return
+        }
+
+        let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
+        switch action {
+        case .client(let client):
+            let subscription = RDKafkaTopicPartitionList()
+            for topic in topics {
+                subscription.add(
+                    topic: topic,
+                    partition: KafkaPartition.unassigned
+                )
+            }
+            try client.subscribe(topicPartitionList: subscription)
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
+    /// Unsubscribe from the current subscription.
+    ///
+    /// Clears all topic subscriptions. The consumer leaves the consumer group
+    /// and stops receiving messages. This triggers a rebalance event.
+    /// Can re-subscribe later with ``subscribe(topics:)``.
+    ///
+    /// - Throws: A ``KafkaError`` if the consumer is closed or unsubscribing failed.
+    public func unsubscribe() throws {
+        let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
+        switch action {
+        case .client(let client):
+            try client.unsubscribe()
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
+    /// Get the current topic subscription.
+    ///
+    /// - Returns: An array of topic names or patterns the consumer is currently subscribed to.
+    /// - Throws: A ``KafkaError`` if the consumer is closed or the query failed.
+    public func subscription() throws -> [String] {
+        let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
+        switch action {
+        case .client(let client):
+            return try client.subscription()
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
+    /// Internal startup subscription that transitions the state machine from `.initializing` to `.running`.
+    /// Called once during `_run()` to set up the initial subscription from `consumptionStrategy`.
+    private func initialSubscribe(topics: [String]) throws {
         let action = self.stateMachine.withLockedValue { $0.setUpConnection() }
         switch action {
         case .setUpConnection(let client):
@@ -389,11 +451,23 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     private func _run() async throws {
-        switch self.config.consumptionStrategy!._internal {
-        case .partition(groupID: _, let topic, let partition, let offset):
-            try self.assign(topic: topic, partition: partition, offset: offset)
-        case .group(groupID: _, let topics):
-            try self.subscribe(topics: topics)
+        if let strategy = self.config.consumptionStrategy?._internal {
+            switch strategy {
+            case .partition(groupID: _, let topic, let partition, let offset):
+                try self.assign(topic: topic, partition: partition, offset: offset)
+            case .group(groupID: _, let topics):
+                try self.initialSubscribe(topics: topics)
+            }
+        } else {
+            // No consumptionStrategy set — user will call subscribe(topics:) manually.
+            // Transition state machine to .running so the event loop can start.
+            let action = self.stateMachine.withLockedValue { $0.setUpConnection() }
+            switch action {
+            case .setUpConnection:
+                break
+            case .consumerClosed:
+                throw KafkaError.connectionClosed(reason: "Consumer closed before run")
+            }
         }
         try await self.eventRunLoop()
     }
@@ -927,6 +1001,25 @@ extension KafkaConsumer {
             }
         }
 
+        /// Get the client for subscription management operations.
+        ///
+        /// Unlike ``withClient()``, this accessor works in both `.initializing` and `.running`
+        /// states, allowing subscribe/unsubscribe to be called at any time after consumer creation.
+        ///
+        /// - Returns: The action to be taken.
+        func withClientForSubscription() -> ClientAction {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .initializing(let client, _):
+                return .client(client)
+            case .running(let client, _):
+                return .client(client)
+            case .finishing, .finished:
+                return .throwClosedError
+            }
+        }
+
         /// Action to be taken when wanting to do close the consumer.
         enum FinishAction {
             /// Shut down the ``KafkaConsumer``.
@@ -944,7 +1037,11 @@ extension KafkaConsumer {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
-                fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
+                // If we haven't started running yet, we haven't polled the consumer queue.
+                // Calling consumerClose() without an active poll loop will hang librdkafka indefinitely.
+                // We can safely transition straight to .finished.
+                self.state = .finished
+                return nil
             case .running(let client, let rebalanceContext):
                 self.state = .finishing(client: client, rebalanceContext: rebalanceContext)
                 return .triggerGracefulShutdown(client: client)

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -334,11 +334,80 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
-    /// Subscribe to the given list of `topics`.
-    /// The partition assignment happens automatically using `KafkaConsumer`'s consumer group.
-    /// - Parameter topics: An array of topic names to subscribe to.
-    /// - Throws: A ``KafkaError`` if subscribing to the topic list failed.
-    private func subscribe(topics: [String]) throws {
+    // MARK: - Subscription Management
+
+    /// Subscribe to the given list of topics.
+    ///
+    /// This replaces any previous subscription. The partition assignment happens
+    /// automatically using the consumer's consumer group. Can be called at any time
+    /// after consumer creation — before or after ``run()``.
+    ///
+    /// This method supports Regex patterns. Topic names prefixed with `^` will be treated
+    /// as regular expressions (e.g. `^my-topic-.*`).
+    ///
+    /// Calling this with an empty array is equivalent to calling ``unsubscribe()``.
+    ///
+    /// - Note: Changing the subscription triggers a rebalance event which will be
+    /// yielded to the consumer's events sequence.
+    ///
+    /// - Parameter topics: An array of topic names or regex patterns to subscribe to.
+    /// - Throws: A ``KafkaError`` if the consumer is closed or subscribing failed.
+    public func subscribe(topics: [String]) throws {
+        guard !topics.isEmpty else {
+            try self.unsubscribe()
+            return
+        }
+
+        let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
+        switch action {
+        case .client(let client):
+            let subscription = RDKafkaTopicPartitionList()
+            for topic in topics {
+                subscription.add(
+                    topic: topic,
+                    partition: KafkaPartition.unassigned
+                )
+            }
+            try client.subscribe(topicPartitionList: subscription)
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
+    /// Unsubscribe from the current subscription.
+    ///
+    /// Clears all topic subscriptions. The consumer leaves the consumer group
+    /// and stops receiving messages. This triggers a rebalance event.
+    /// Can re-subscribe later with ``subscribe(topics:)``.
+    ///
+    /// - Throws: A ``KafkaError`` if the consumer is closed or unsubscribing failed.
+    public func unsubscribe() throws {
+        let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
+        switch action {
+        case .client(let client):
+            try client.unsubscribe()
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
+    /// Get the current topic subscription.
+    ///
+    /// - Returns: An array of topic names or patterns the consumer is currently subscribed to.
+    /// - Throws: A ``KafkaError`` if the consumer is closed or the query failed.
+    public func subscription() throws -> [String] {
+        let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
+        switch action {
+        case .client(let client):
+            return try client.subscription()
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
+    /// Internal startup subscription that transitions the state machine from `.initializing` to `.running`.
+    /// Called once during `_run()` to set up the initial subscription from `consumptionStrategy`.
+    private func initialSubscribe(topics: [String]) throws {
         let action = self.stateMachine.withLockedValue { $0.setUpConnection() }
         switch action {
         case .setUpConnection(let client):
@@ -389,11 +458,23 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     private func _run() async throws {
-        switch self.config.consumptionStrategy!._internal {
-        case .partition(groupID: _, let topic, let partition, let offset):
-            try self.assign(topic: topic, partition: partition, offset: offset)
-        case .group(groupID: _, let topics):
-            try self.subscribe(topics: topics)
+        if let strategy = self.config.consumptionStrategy?._internal {
+            switch strategy {
+            case .partition(groupID: _, let topic, let partition, let offset):
+                try self.assign(topic: topic, partition: partition, offset: offset)
+            case .group(groupID: _, let topics):
+                try self.initialSubscribe(topics: topics)
+            }
+        } else {
+            // No consumptionStrategy set — user will call subscribe(topics:) manually.
+            // Transition state machine to .running so the event loop can start.
+            let action = self.stateMachine.withLockedValue { $0.setUpConnection() }
+            switch action {
+            case .setUpConnection:
+                break
+            case .consumerClosed:
+                throw KafkaError.connectionClosed(reason: "Consumer closed before run")
+            }
         }
         try await self.eventRunLoop()
     }
@@ -920,6 +1001,26 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
+            case .running(let client, _):
+                return .client(client)
+            case .finishing, .finished:
+                return .throwClosedError
+            }
+        }
+
+        /// Get the client for subscription management operations.
+        ///
+        /// Unlike ``withClient()``, this accessor works in both `.initializing` and `.running`
+        /// states — matching the behavior of Rust, Go, Python, and Java Kafka clients where
+        /// subscribe/unsubscribe can be called at any time after consumer creation.
+        ///
+        /// - Returns: The action to be taken.
+        func withClientForSubscription() -> ClientAction {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .initializing(let client, _):
+                return .client(client)
             case .running(let client, _):
                 return .client(client)
             case .finishing, .finished:

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -1037,9 +1037,9 @@ extension KafkaConsumer {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
-                // If we haven't started running yet, we haven't polled the consumer queue.
-                // Calling consumerClose() without an active poll loop will hang librdkafka indefinitely.
-                // We can safely transition straight to .finished.
+                // No poll loop is active in .initializing state. Since consumerClose()
+                // requires an active poll loop to process broker responses, we skip it
+                // and transition straight to .finished.
                 self.state = .finished
                 return nil
             case .running(let client, let rebalanceContext):

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -339,18 +339,11 @@ public final class KafkaConsumer: Sendable, Service {
     /// Subscribe to the given list of topics.
     ///
     /// This replaces any previous subscription. The partition assignment happens
-    /// automatically using the consumer's consumer group. Can be called at any time
-    /// after consumer creation — before or after ``run()``.
+    /// automatically using the consumer's consumer group.
     ///
-    /// This method supports Regex patterns. Topic names prefixed with `^` will be treated
-    /// as regular expressions (e.g. `^my-topic-.*`).
-    ///
-    /// Calling this with an empty array is equivalent to calling ``unsubscribe()``.
-    ///
-    /// - Note: Changing the subscription triggers a rebalance event which will be
-    /// yielded to the consumer's events sequence.
-    ///
-    /// - Parameter topics: An array of topic names or regex patterns to subscribe to.
+    /// - Parameter topics: An array of topic names to subscribe to.
+    ///   Topic names prefixed with `^` are treated as regular expressions.
+    ///   An empty array is equivalent to calling ``unsubscribe()``.
     /// - Throws: A ``KafkaError`` if the consumer is closed or subscribing failed.
     public func subscribe(topics: [String]) throws {
         guard !topics.isEmpty else {
@@ -1044,8 +1037,9 @@ extension KafkaConsumer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .initializing:
-                fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
+            case .initializing(let client, let rebalanceContext):
+                self.state = .finishing(client: client, rebalanceContext: rebalanceContext)
+                return .triggerGracefulShutdown(client: client)
             case .running(let client, let rebalanceContext):
                 self.state = .finishing(client: client, rebalanceContext: rebalanceContext)
                 return .triggerGracefulShutdown(client: client)

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -981,19 +981,13 @@ extension KafkaConsumer {
 
         /// Get the running client for performing an operation that requires an active consumer.
         ///
-        /// This is a general-purpose accessor used by methods that need the underlying
-        /// `RDKafkaClient` while the consumer is running (e.g., commit, storeOffset,
-        /// committed, position, seek, isAssignmentLost).
-        ///
         /// - Returns: The action to be taken.
-        ///
-        /// - Important: This function calls `fatalError` if called while in the `.initializing` state.
         func withClient() -> ClientAction {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
-                fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
+                return .throwClosedError
             case .running(let client, _):
                 return .client(client)
             case .finishing, .finished:
@@ -1028,10 +1022,8 @@ extension KafkaConsumer {
             case triggerGracefulShutdown(client: RDKafkaClient)
         }
 
-        /// Get action to be taken when wanting to do close the consumer.
-        /// - Returns: The action to be taken,  or `nil` if there is no action to be taken.
-        ///
-        /// - Important: This function throws a `fatalError` if called while in the `.initializing` state.
+        /// Get action to be taken when wanting to close the consumer.
+        /// - Returns: The action to be taken, or `nil` if there is no action to be taken.
         mutating func finish() -> FinishAction? {
             switch self.state {
             case .uninitialized:

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -598,6 +598,35 @@ public final class RDKafkaClient: Sendable {
         }
     }
 
+    /// Unsubscribe from the current subscription set.
+    func unsubscribe() throws {
+        let result = rd_kafka_unsubscribe(self.kafkaHandle.pointer)
+        if result != RD_KAFKA_RESP_ERR_NO_ERROR {
+            throw KafkaError.rdKafkaError(wrapping: result)
+        }
+    }
+
+    /// Get the current topic subscription.
+    /// - Returns: An array of topic names the consumer is subscribed to.
+    func subscription() throws -> [String] {
+        var tpl: UnsafeMutablePointer<rd_kafka_topic_partition_list_t>?
+        let result = rd_kafka_subscription(self.kafkaHandle.pointer, &tpl)
+        if result != RD_KAFKA_RESP_ERR_NO_ERROR {
+            throw KafkaError.rdKafkaError(wrapping: result)
+        }
+        defer { rd_kafka_topic_partition_list_destroy(tpl) }
+
+        var topics: [String] = []
+        guard let list = tpl else { return topics }
+        for i in 0..<Int(list.pointee.cnt) {
+            let element = list.pointee.elems[i]
+            if let topicCString = element.topic {
+                topics.append(String(cString: topicCString))
+            }
+        }
+        return topics
+    }
+
     /// Atomic assignment of partitions to consume.
     /// - Parameter topicPartitionList: Pointer to a list of topics + partition pairs.
     func assign(topicPartitionList: RDKafkaTopicPartitionList) throws {

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -614,10 +614,11 @@ public final class RDKafkaClient: Sendable {
         if result != RD_KAFKA_RESP_ERR_NO_ERROR {
             throw KafkaError.rdKafkaError(wrapping: result)
         }
-        defer { rd_kafka_topic_partition_list_destroy(tpl) }
+
+        guard let list = tpl else { return [] }
+        defer { rd_kafka_topic_partition_list_destroy(list) }
 
         var topics: [String] = []
-        guard let list = tpl else { return topics }
         for i in 0..<Int(list.pointee.cnt) {
             let element = list.pointee.elems[i]
             if let topicCString = element.topic {

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -1682,6 +1682,97 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         }
     }
 
+    @Test func dynamicSubscribeAndUnsubscribe() async throws {
+        try await withTestTopic { testTopic in
+            let testMessages = try await self.produceMessages(topic: testTopic, count: 10)
+
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.groupId = UUID().uuidString
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.autoOffsetReset = .earliest  // Make sure we get all produced messages
+            consumerConfig.brokerAddressFamily = .v4
+
+            // Important: we leave `consumptionStrategy` nil to test the dynamic subscribe path.
+            let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
+                config: consumerConfig,
+                logger: .kafkaTest
+            )
+
+            let serviceGroup = ServiceGroup(
+                configuration: ServiceGroupConfiguration(
+                    services: [consumer],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: .kafkaTest
+                )
+            )
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                // 1. Start the service group
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                // 2. Consume events (like rebalances) in background
+                group.addTask {
+                    for await _ in events {}
+                }
+
+                // 3. Wait for the consumer to start running
+                try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+                // 4. Dynamically subscribe (after creation!)
+                try consumer.subscribe(topics: [testTopic])
+
+                // 4. Verify subscription contains our topic
+                let currentSubscription = try consumer.subscription()
+                #expect(
+                    currentSubscription.contains(testTopic),
+                    "Expected subscription to contain \(testTopic), got \(currentSubscription)"
+                )
+
+                // 5. Consume the test messages in a background task to keep consumer alive
+                let consumedCount = ManagedAtomic<Int>(0)
+                group.addTask {
+                    for try await _ in consumer.messages {
+                        consumedCount.wrappingIncrement(ordering: .relaxed)
+                    }
+                }
+
+                // Wait for all messages to be consumed
+                for _ in 0..<100 {
+                    if consumedCount.load(ordering: .relaxed) >= testMessages.count { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+
+                #expect(consumedCount.load(ordering: .relaxed) >= testMessages.count)
+
+                // 6. Dynamically unsubscribe
+                try consumer.unsubscribe()
+
+                // 7. Verify subscription is now empty
+                let emptySubscription = try consumer.subscription()
+                #expect(
+                    emptySubscription.isEmpty,
+                    "Expected empty subscription after unsubscribe, got \(emptySubscription)"
+                )
+
+                // 8. Dynamically subscribe again
+                try consumer.subscribe(topics: [testTopic])
+                #expect(try consumer.subscription().contains(testTopic))
+
+                // 9. Verify passing empty array to subscribe is equivalent to unsubscribe
+                try consumer.subscribe(topics: [])
+                let emptySub = try consumer.subscription()
+                #expect(
+                    emptySub.isEmpty,
+                    "Expected empty subscription after subscribe(topics: []), got \(emptySub)"
+                )
+
+                await serviceGroup.triggerGracefulShutdown()
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     func produceMessages(topic: String, count: UInt) async throws -> [KafkaProducerMessage<String, String>] {
@@ -1745,5 +1836,214 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             messages: messages,
             skipConsistencyCheck: skipConsistencyCheck
         )
+    }
+
+    // MARK: - Subscribe/Unsubscribe Integration Tests
+
+    @Test func subscribeReplacesCurrentSubscription() async throws {
+        var consumerConfig = KafkaConsumerConfig()
+        consumerConfig.groupId = UUID().uuidString
+        consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+        consumerConfig.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            // Subscribe to topic-a
+            try consumer.subscribe(topics: ["topic-a"])
+            let sub1 = try consumer.subscription()
+            #expect(sub1 == ["topic-a"])
+
+            // Re-subscribe to topic-b — should replace, not append
+            try consumer.subscribe(topics: ["topic-b"])
+            let sub2 = try consumer.subscription()
+            #expect(sub2 == ["topic-b"])
+            #expect(!sub2.contains("topic-a"))
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func unsubscribeClearsSubscription() async throws {
+        var consumerConfig = KafkaConsumerConfig()
+        consumerConfig.groupId = UUID().uuidString
+        consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+        consumerConfig.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            try consumer.subscribe(topics: ["topic-a", "topic-b"])
+            let subBefore = try consumer.subscription()
+            #expect(subBefore.count == 2)
+
+            try consumer.unsubscribe()
+            let subAfter = try consumer.subscription()
+            #expect(subAfter.isEmpty)
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func resubscribeAfterUnsubscribeSucceeds() async throws {
+        var consumerConfig = KafkaConsumerConfig()
+        consumerConfig.groupId = UUID().uuidString
+        consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+        consumerConfig.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            // Subscribe → unsubscribe → re-subscribe
+            try consumer.subscribe(topics: ["topic-a"])
+            try consumer.unsubscribe()
+            try consumer.subscribe(topics: ["topic-b"])
+
+            let sub = try consumer.subscription()
+            #expect(sub == ["topic-b"])
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func subscribeWhileRunningWithConsumptionStrategySucceeds() async throws {
+        try await withTestTopic { testTopic in
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.consumptionStrategy = .group(
+                id: UUID().uuidString,
+                topics: [testTopic]
+            )
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.brokerAddressFamily = .v4
+
+            let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+
+            let serviceGroupConfiguration = ServiceGroupConfiguration(
+                services: [consumer],
+                logger: .kafkaTest
+            )
+            let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                // Wait for initial subscription to be established
+                try await Task.sleep(for: .seconds(2), tolerance: .zero)
+
+                // Verify initial subscription
+                let initialSub = try consumer.subscription()
+                #expect(initialSub.contains(testTopic))
+
+                // Re-subscribe to a different topic while running
+                try consumer.subscribe(topics: ["other-topic"])
+                let newSub = try consumer.subscription()
+                #expect(newSub == ["other-topic"])
+                #expect(!newSub.contains(testTopic))
+
+                await serviceGroup.triggerGracefulShutdown()
+            }
+        }
+    }
+
+    @Test func subscribeMultipleTopicsThenConsumeFromAll() async throws {
+        try await withTestTopic { testTopic1 in
+            try await withTestTopic { testTopic2 in
+                // Produce a message to each topic
+                let (producer, events) = try KafkaProducer.makeProducerWithEvents(
+                    config: self.producerConfig,
+                    logger: .kafkaTest
+                )
+
+                let serviceGroupConfiguration = ServiceGroupConfiguration(
+                    services: [producer],
+                    logger: .kafkaTest
+                )
+                let producerServiceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask {
+                        try await producerServiceGroup.run()
+                    }
+
+                    group.addTask {
+                        for await _ in events {}
+                    }
+
+                    let msg1 = KafkaProducerMessage(topic: testTopic1, value: "msg1")
+                    let msg2 = KafkaProducerMessage(topic: testTopic2, value: "msg2")
+                    try producer.send(msg1)
+                    try producer.send(msg2)
+
+                    try await Task.sleep(for: .seconds(1))
+                    await producerServiceGroup.triggerGracefulShutdown()
+                }
+
+                // Now consume from both topics using dynamic subscribe
+                var consumerConfig = KafkaConsumerConfig()
+                consumerConfig.groupId = UUID().uuidString
+                consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+                consumerConfig.autoOffsetReset = .beginning
+                consumerConfig.brokerAddressFamily = .v4
+
+                let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+
+                let consumerServiceGroupConfig = ServiceGroupConfiguration(
+                    services: [consumer],
+                    logger: .kafkaTest
+                )
+                let consumerServiceGroup = ServiceGroup(configuration: consumerServiceGroupConfig)
+
+                try await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask {
+                        try await consumerServiceGroup.run()
+                    }
+
+                    // Subscribe dynamically to both topics
+                    try consumer.subscribe(topics: [testTopic1, testTopic2])
+
+                    var receivedTopics: Set<String> = []
+                    for try await message in consumer.messages {
+                        receivedTopics.insert(message.topic)
+                        if receivedTopics.count >= 2 {
+                            break
+                        }
+                    }
+
+                    #expect(receivedTopics.contains(testTopic1))
+                    #expect(receivedTopics.contains(testTopic2))
+
+                    await consumerServiceGroup.triggerGracefulShutdown()
+                }
+            }
+        }
     }
 }

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -1724,7 +1724,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try consumer.subscribe(topics: [testTopic])
 
                 // 4. Verify subscription contains our topic
-                let currentSubscription = try consumer.subscription()
+                let currentSubscription = try consumer.subscribedTopics()
                 #expect(
                     currentSubscription.contains(testTopic),
                     "Expected subscription to contain \(testTopic), got \(currentSubscription)"
@@ -1750,7 +1750,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try consumer.unsubscribe()
 
                 // 7. Verify subscription is now empty
-                let emptySubscription = try consumer.subscription()
+                let emptySubscription = try consumer.subscribedTopics()
                 #expect(
                     emptySubscription.isEmpty,
                     "Expected empty subscription after unsubscribe, got \(emptySubscription)"
@@ -1758,11 +1758,11 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // 8. Dynamically subscribe again
                 try consumer.subscribe(topics: [testTopic])
-                #expect(try consumer.subscription().contains(testTopic))
+                #expect(try consumer.subscribedTopics().contains(testTopic))
 
                 // 9. Verify passing empty array to subscribe is equivalent to unsubscribe
                 try consumer.subscribe(topics: [])
-                let emptySub = try consumer.subscription()
+                let emptySub = try consumer.subscribedTopics()
                 #expect(
                     emptySub.isEmpty,
                     "Expected empty subscription after subscribe(topics: []), got \(emptySub)"
@@ -1860,12 +1860,12 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
             // Subscribe to topic-a
             try consumer.subscribe(topics: ["topic-a"])
-            let sub1 = try consumer.subscription()
+            let sub1 = try consumer.subscribedTopics()
             #expect(sub1 == ["topic-a"])
 
             // Re-subscribe to topic-b — should replace, not append
             try consumer.subscribe(topics: ["topic-b"])
-            let sub2 = try consumer.subscription()
+            let sub2 = try consumer.subscribedTopics()
             #expect(sub2 == ["topic-b"])
             #expect(!sub2.contains("topic-a"))
 
@@ -1892,11 +1892,11 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
 
             try consumer.subscribe(topics: ["topic-a", "topic-b"])
-            let subBefore = try consumer.subscription()
+            let subBefore = try consumer.subscribedTopics()
             #expect(subBefore.count == 2)
 
             try consumer.unsubscribe()
-            let subAfter = try consumer.subscription()
+            let subAfter = try consumer.subscribedTopics()
             #expect(subAfter.isEmpty)
 
             await serviceGroup.triggerGracefulShutdown()
@@ -1926,7 +1926,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             try consumer.unsubscribe()
             try consumer.subscribe(topics: ["topic-b"])
 
-            let sub = try consumer.subscription()
+            let sub = try consumer.subscribedTopics()
             #expect(sub == ["topic-b"])
 
             await serviceGroup.triggerGracefulShutdown()
@@ -1960,12 +1960,12 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try await Task.sleep(for: .seconds(2), tolerance: .zero)
 
                 // Verify initial subscription
-                let initialSub = try consumer.subscription()
+                let initialSub = try consumer.subscribedTopics()
                 #expect(initialSub.contains(testTopic))
 
                 // Re-subscribe to a different topic while running
                 try consumer.subscribe(topics: ["other-topic"])
-                let newSub = try consumer.subscription()
+                let newSub = try consumer.subscribedTopics()
                 #expect(newSub == ["other-topic"])
                 #expect(!newSub.contains(testTopic))
 

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -464,10 +464,17 @@ import Foundation
                 try await serviceGroup.run()
             }
 
-            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
-
-            let lost = try consumer.isAssignmentLost
-            #expect(lost == false)
+            // Wait until the consumer is in .running state
+            for _ in 0..<20 {
+                do {
+                    let lost = try consumer.isAssignmentLost
+                    #expect(lost == false)
+                    break
+                } catch {
+                    // Consumer not yet running, retry
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+            }
 
             await serviceGroup.triggerGracefulShutdown()
             try await group.waitForAll()

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -184,6 +184,193 @@ import Foundation
         }
     }
 
+    // MARK: - Subscription Management Tests
+
+    @Test func subscriptionFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.subscription()
+        }
+    }
+
+    @Test func subscribeFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.subscribe(topics: ["new-topic"])
+        }
+    }
+
+    @Test func unsubscribeFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.unsubscribe()
+        }
+    }
+
+    @Test func subscribeWithEmptyTopicsCallsUnsubscribe() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            // Empty topics should not crash — delegates to unsubscribe()
+            try consumer.subscribe(topics: [])
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func subscribeBeforeRunSucceeds() throws {
+        // Consumer without consumptionStrategy — user subscribes manually
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // subscribe() in .initializing state should not crash
+        try consumer.subscribe(topics: ["test-topic"])
+    }
+
+    @Test func subscriptionReturnsEmptyBeforeSubscribing() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // No subscription set — should return empty
+        let topics = try consumer.subscription()
+        #expect(topics.isEmpty)
+    }
+
+    @Test func runWithoutConsumptionStrategyDoesNotCrash() async throws {
+        // Consumer with nil consumptionStrategy — should start and shut down cleanly
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+        // No crash = test passes
+    }
+
+    @Test func subscribeBeforeRunThenRunSucceeds() async throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // Subscribe before run
+        try consumer.subscribe(topics: ["test-topic"])
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func unsubscribeBeforeSubscribeDoesNotCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // Unsubscribe when never subscribed — should not crash
+        try consumer.unsubscribe()
+    }
+
+    @Test func subscribeDuplicateTopicsThrows() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // librdkafka rejects duplicate topics with "Invalid argument"
+        #expect(throws: KafkaError.self) {
+            try consumer.subscribe(topics: ["topic-a", "topic-a", "topic-a"])
+        }
+    }
+
+    @Test func subscribeWithRegexPatternDoesNotCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // Regex pattern subscription — librdkafka supports ^-prefixed patterns
+        try consumer.subscribe(topics: ["^test-.*"])
+    }
+
     // MARK: - committed / position Tests
 
     @Test func committedFailsOnClosedConsumer() async throws {

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -450,17 +450,18 @@ import Foundation
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await serviceGroup.run()
             }
 
-            try! await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
 
-            let lost = try! consumer.isAssignmentLost
+            let lost = try consumer.isAssignmentLost
             #expect(lost == false)
 
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
     }
 

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -187,7 +187,7 @@ import Foundation
 
     // MARK: - Subscription Management Tests
 
-    @Test func subscriptionFailsOnClosedConsumer() async throws {
+    @Test func subscribedTopicsFailsOnClosedConsumer() async throws {
         let config = makeConfig()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
@@ -204,7 +204,7 @@ import Foundation
         }
 
         #expect(throws: KafkaError.self) {
-            try consumer.subscription()
+            try consumer.subscribedTopics()
         }
     }
 
@@ -283,7 +283,7 @@ import Foundation
         try consumer.subscribe(topics: ["test-topic"])
     }
 
-    @Test func subscriptionReturnsEmptyBeforeSubscribing() throws {
+    @Test func subscribedTopicsReturnsEmptyBeforeSubscribing() throws {
         var config = KafkaConsumerConfig()
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
@@ -291,7 +291,7 @@ import Foundation
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         // No subscription set — should return empty
-        let topics = try consumer.subscription()
+        let topics = try consumer.subscribedTopics()
         #expect(topics.isEmpty)
     }
 

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -167,13 +167,14 @@ import Foundation
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await serviceGroup.run()
             }
 
-            try! await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
 
         // After shutdown, all withClient()-based methods should throw connectionClosed
@@ -383,13 +384,14 @@ import Foundation
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await serviceGroup.run()
             }
 
-            try! await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
 
         await #expect(throws: KafkaError.self) {
@@ -407,13 +409,14 @@ import Foundation
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await serviceGroup.run()
             }
 
-            try! await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
 
         #expect(throws: KafkaError.self) {
@@ -432,13 +435,14 @@ import Foundation
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await serviceGroup.run()
             }
 
-            try! await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
 
         #expect(throws: KafkaError.self) {
@@ -477,13 +481,14 @@ import Foundation
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await serviceGroup.run()
             }
 
-            try! await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
 
         await #expect(throws: KafkaError.self) {

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -313,6 +313,7 @@ import Foundation
 
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
         // No crash = test passes
     }
@@ -337,6 +338,7 @@ import Foundation
 
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
     }
 
@@ -1093,9 +1095,8 @@ import Foundation
         config.brokerAddressFamily = .v4
 
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
-        
-        // This used to cause a fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
-        // when consumer was in the .initializing state
+
+        // This used to cause a fatalError when consumer was in the .initializing state
         consumer.triggerGracefulShutdown()
     }
 

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -184,6 +184,196 @@ import Foundation
         }
     }
 
+    // MARK: - Subscription Management Tests
+
+    @Test func subscriptionFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.subscription()
+        }
+    }
+
+    @Test func subscribeFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.subscribe(topics: ["new-topic"])
+        }
+    }
+
+    @Test func unsubscribeFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.unsubscribe()
+        }
+    }
+
+    @Test func subscribeWithEmptyTopicsCallsUnsubscribe() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            // Empty topics should not crash — delegates to unsubscribe()
+            try consumer.subscribe(topics: [])
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func subscribeBeforeRunSucceeds() throws {
+        // Consumer without consumptionStrategy — user subscribes manually
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // subscribe() in .initializing state should not crash
+        try consumer.subscribe(topics: ["test-topic"])
+    }
+
+    @Test func subscriptionReturnsEmptyBeforeSubscribing() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // No subscription set — should return empty
+        let topics = try consumer.subscription()
+        #expect(topics.isEmpty)
+    }
+
+    @Test func runWithoutConsumptionStrategyDoesNotCrash() async throws {
+        // Consumer with nil consumptionStrategy — should start and shut down cleanly
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+        // No crash = test passes
+    }
+
+    @Test func subscribeBeforeRunThenRunSucceeds() async throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // Subscribe before run
+        try consumer.subscribe(topics: ["test-topic"])
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func unsubscribeBeforeSubscribeDoesNotCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // Unsubscribe when never subscribed — should not crash
+        try consumer.unsubscribe()
+    }
+
+    @Test func subscribeDuplicateTopicsThrows() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // librdkafka rejects duplicate topics with "Invalid argument"
+        #expect(throws: KafkaError.self) {
+            try consumer.subscribe(topics: ["topic-a", "topic-a", "topic-a"])
+        }
+    }
+
+    @Test func subscribeWithRegexPatternDoesNotCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        // Regex pattern subscription — librdkafka supports ^-prefixed patterns
+        try consumer.subscribe(topics: ["^test-.*"])
+    }
+
     // MARK: - committed / position Tests
 
     @Test func committedFailsOnClosedConsumer() async throws {
@@ -263,17 +453,18 @@ import Foundation
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 try await serviceGroup.run()
             }
 
-            try! await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
 
-            let lost = try! consumer.isAssignmentLost
+            let lost = try consumer.isAssignmentLost
             #expect(lost == false)
 
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
     }
 
@@ -891,4 +1082,25 @@ import Foundation
         #expect(err1 == err2)
     }
 
+    @Test func triggerGracefulShutdownBeforeRunDoesNotCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = "test-group"
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        
+        // This used to cause a fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
+        // when consumer was in the .initializing state
+        consumer.triggerGracefulShutdown()
+    }
+
+    @Test func triggerGracefulShutdownAfterSubscribeButBeforeRunDoesNotCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = "test-group"
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        try consumer.subscribe(topics: ["test-topic"])
+        consumer.triggerGracefulShutdown()
+    }
 }


### PR DESCRIPTION
## Motivation

Topics are locked at initialization time via `consumptionStrategy` with no way to change subscriptions at runtime. The existing private `subscribe()` crashes on re-subscribe (`fatalError`), and `consumptionStrategy` is force-unwrapped in `_run()` which crashes if nil.

Applications that need dynamic topic routing, multi-tenant consumption, or config-driven subscriptions currently cannot use this client without recreating the consumer. This aligns the Swift client with the standard Kafka client contract where subscribe/unsubscribe are runtime operations, not initialization-time configuration.

## Summary

- Add public `subscribe(topics:)`, `unsubscribe()`, and `subscription()` on `KafkaConsumer`
- `subscribe(topics:)` replaces the current subscription, matching librdkafka semantics
- Add `unsubscribe()` and `subscription()` to `RDKafkaClient`
- Fix force-unwrap crash when `consumptionStrategy` is nil
- Consumers can be created without `consumptionStrategy` and subscribe dynamically

## Test plan
- [x] Unit tests: closed consumer, empty topics, subscribe before run, nil strategy, duplicate topics, regex patterns
- [x] Integration tests: subscription replacement, unsubscribe, re-subscribe, dynamic multi-topic consume
- [x] `swift test --skip IntegrationTests` passes
- [x] `make docker-test` passes