### PR TITLE
Add pause/resume partition APIs and message timestamps

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -398,6 +398,45 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
+    /// Pause consumption for the given partitions.
+    ///
+    /// Paused partitions remain in the consumer group and continue heartbeating
+    /// but will not return messages from ``messages``.
+    ///
+    /// - Parameter topicPartitions: The partitions to pause.
+    /// - Throws: A ``KafkaError`` if the consumer is closed or pausing failed.
+    public func pause(topicPartitions: [KafkaTopicPartition]) throws {
+        let action = self.stateMachine.withLockedValue { $0.withClient() }
+        switch action {
+        case .client(let client):
+            let tpl = RDKafkaTopicPartitionList()
+            for tp in topicPartitions {
+                tpl.add(topic: tp.topic, partition: tp.partition)
+            }
+            try client.pausePartitions(topicPartitionList: tpl)
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
+    /// Resume consumption for the given partitions.
+    ///
+    /// - Parameter topicPartitions: The partitions to resume.
+    /// - Throws: A ``KafkaError`` if the consumer is closed or resuming failed.
+    public func resume(topicPartitions: [KafkaTopicPartition]) throws {
+        let action = self.stateMachine.withLockedValue { $0.withClient() }
+        switch action {
+        case .client(let client):
+            let tpl = RDKafkaTopicPartitionList()
+            for tp in topicPartitions {
+                tpl.add(topic: tp.topic, partition: tp.partition)
+            }
+            try client.resumePartitions(topicPartitionList: tpl)
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+        }
+    }
+
     /// Internal startup subscription that transitions the state machine from `.initializing` to `.running`.
     /// Called once during `_run()` to set up the initial subscription from `consumptionStrategy`.
     private func initialSubscribe(topics: [String]) throws {

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -15,6 +15,38 @@
 import Crdkafka
 import NIOCore
 
+/// The type of timestamp on a Kafka message.
+public struct KafkaTimestampType: Hashable, Sendable, CustomStringConvertible {
+    /// The raw value corresponding to the librdkafka timestamp type.
+    public let rawValue: Int32
+
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    /// Timestamp not available.
+    public static let notAvailable = KafkaTimestampType(
+        rawValue: Int32(RD_KAFKA_TIMESTAMP_NOT_AVAILABLE.rawValue)
+    )
+    /// Timestamp set by the producer (message creation time).
+    public static let createTime = KafkaTimestampType(
+        rawValue: Int32(RD_KAFKA_TIMESTAMP_CREATE_TIME.rawValue)
+    )
+    /// Timestamp set by the broker (log append time).
+    public static let logAppendTime = KafkaTimestampType(
+        rawValue: Int32(RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME.rawValue)
+    )
+
+    public var description: String {
+        switch self {
+        case .createTime: return "createTime"
+        case .logAppendTime: return "logAppendTime"
+        case .notAvailable: return "notAvailable"
+        default: return "unknown(\(self.rawValue))"
+        }
+    }
+}
+
 /// A message received from the Kafka cluster.
 public struct KafkaConsumerMessage {
     /// The topic that the message was received from.
@@ -29,6 +61,10 @@ public struct KafkaConsumerMessage {
     public var value: ByteBuffer
     /// The offset of the message in its partition.
     public var offset: KafkaOffset
+    /// The timestamp of the message in milliseconds since epoch, or `nil` if not available.
+    public var timestamp: Int64?
+    /// The type of timestamp on this message.
+    public var timestampType: KafkaTimestampType
 
     /// Initialize ``KafkaConsumerMessage`` from `rd_kafka_message_t` pointer.
     /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
@@ -75,6 +111,12 @@ public struct KafkaConsumerMessage {
         self.value = ByteBuffer(bytes: valueBufferPointer)
 
         self.offset = KafkaOffset(rawValue: Int(rdKafkaMessage.offset))
+
+        // Extract timestamp and type
+        var tsType = rd_kafka_timestamp_type_t(rawValue: 0)
+        let tsValue = rd_kafka_message_timestamp(messagePointer, &tsType)
+        self.timestampType = KafkaTimestampType(rawValue: Int32(tsType.rawValue))
+        self.timestamp = tsValue != -1 ? tsValue : nil
     }
 }
 

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -647,6 +647,9 @@ public final class RDKafkaClient: Sendable {
             if result != RD_KAFKA_RESP_ERR_NO_ERROR {
                 throw KafkaError.rdKafkaError(wrapping: result)
             }
+            if let error = topicPartitionList.firstError() {
+                throw KafkaError.rdKafkaError(wrapping: error)
+            }
         }
     }
 
@@ -657,6 +660,9 @@ public final class RDKafkaClient: Sendable {
             let result = rd_kafka_resume_partitions(self.kafkaHandle.pointer, pointer)
             if result != RD_KAFKA_RESP_ERR_NO_ERROR {
                 throw KafkaError.rdKafkaError(wrapping: result)
+            }
+            if let error = topicPartitionList.firstError() {
+                throw KafkaError.rdKafkaError(wrapping: error)
             }
         }
     }

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -639,6 +639,28 @@ public final class RDKafkaClient: Sendable {
         }
     }
 
+    /// Pause consumption for the given partitions.
+    /// - Parameter topicPartitionList: Partitions to pause.
+    func pausePartitions(topicPartitionList: RDKafkaTopicPartitionList) throws {
+        try topicPartitionList.withListPointer { pointer in
+            let result = rd_kafka_pause_partitions(self.kafkaHandle.pointer, pointer)
+            if result != RD_KAFKA_RESP_ERR_NO_ERROR {
+                throw KafkaError.rdKafkaError(wrapping: result)
+            }
+        }
+    }
+
+    /// Resume consumption for the given partitions.
+    /// - Parameter topicPartitionList: Partitions to resume.
+    func resumePartitions(topicPartitionList: RDKafkaTopicPartitionList) throws {
+        try topicPartitionList.withListPointer { pointer in
+            let result = rd_kafka_resume_partitions(self.kafkaHandle.pointer, pointer)
+            if result != RD_KAFKA_RESP_ERR_NO_ERROR {
+                throw KafkaError.rdKafkaError(wrapping: result)
+            }
+        }
+    }
+
     /// Wraps a Swift closure inside of a class to be able to pass it to `librdkafka` as an `OpaquePointer`.
     /// This is specifically used to pass a Swift closure as a commit callback for the ``KafkaConsumer``.
     final class CapturedCommitCallback {

--- a/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
@@ -74,4 +74,15 @@ final class RDKafkaTopicPartitionList: @unchecked Sendable {
     func withListPointer<T>(_ body: (UnsafeMutablePointer<rd_kafka_topic_partition_list_t>) throws -> T) rethrows -> T {
         try body(self._internal)
     }
+
+    /// Returns the first error encountered in the list of partitions, if any.
+    func firstError() -> rd_kafka_resp_err_t? {
+        for i in 0..<Int(self._internal.pointee.cnt) {
+            let element = self._internal.pointee.elems[i]
+            if element.err != RD_KAFKA_RESP_ERR_NO_ERROR {
+                return element.err
+            }
+        }
+        return nil
+    }
 }

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -2096,7 +2096,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     @Test func pauseAndResumePartitions() async throws {
         try await withTestTopic { testTopic in
-            let _ = try await self.produceMessages(topic: testTopic, count: 3)
+            let _ = try await self.produceMessages(topic: testTopic, count: 5)
 
             var consumerConfig = KafkaConsumerConfig()
             consumerConfig.consumptionStrategy = .group(id: UUID().uuidString, topics: [testTopic])
@@ -2124,30 +2124,46 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     for await _ in events {}
                 }
 
-                // Wait for assignment
-                try await Task.sleep(for: .seconds(2), tolerance: .zero)
+                // Consume messages in a background task, track count atomically
+                let consumedCount = ManagedAtomic<Int>(0)
+                let firstPartition = ManagedAtomic<Int32>(-1)
+                group.addTask {
+                    for try await message in consumer.messages {
+                        if firstPartition.load(ordering: .relaxed) == -1 {
+                            firstPartition.store(
+                                Int32(message.partition.rawValue),
+                                ordering: .relaxed
+                            )
+                        }
+                        consumedCount.wrappingIncrement(ordering: .relaxed)
+                    }
+                }
 
+                // Wait for first message to confirm assignment
+                for _ in 0..<100 {
+                    if consumedCount.load(ordering: .relaxed) >= 1 { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+                #expect(consumedCount.load(ordering: .relaxed) >= 1)
+
+                let partitionId = firstPartition.load(ordering: .relaxed)
                 let partition = KafkaTopicPartition(
                     topic: testTopic,
-                    partition: KafkaPartition(rawValue: 0)
+                    partition: KafkaPartition(rawValue: Int(partitionId))
                 )
 
-                // Pause — should not throw
+                // Pause — should not throw on assigned partition
                 try consumer.pause(topicPartitions: [partition])
 
                 // Resume — should not throw
                 try consumer.resume(topicPartitions: [partition])
 
-                // Consume all messages after resume
-                var consumedCount = 0
-                for try await _ in consumer.messages {
-                    consumedCount += 1
-                    if consumedCount >= 3 {
-                        break
-                    }
+                // Wait for remaining messages
+                for _ in 0..<100 {
+                    if consumedCount.load(ordering: .relaxed) >= 5 { break }
+                    try await Task.sleep(for: .milliseconds(100))
                 }
-
-                #expect(consumedCount >= 3)
+                #expect(consumedCount.load(ordering: .relaxed) >= 5)
 
                 await serviceGroup.triggerGracefulShutdown()
                 try await group.waitForAll()

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -2046,4 +2046,112 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             }
         }
     }
+
+    // MARK: - Timestamp Tests
+
+    @Test func consumedMessageHasTimestamp() async throws {
+        try await withTestTopic { testTopic in
+            let _ = try await self.produceMessages(topic: testTopic, count: 1)
+
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.consumptionStrategy = .group(id: UUID().uuidString, topics: [testTopic])
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.autoOffsetReset = .beginning
+            consumerConfig.brokerAddressFamily = .v4
+
+            let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+
+            let serviceGroupConfiguration = ServiceGroupConfiguration(
+                services: [consumer],
+                logger: .kafkaTest
+            )
+            let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                for try await message in consumer.messages {
+                    // Timestamp should be set (broker assigns it)
+                    #expect(message.timestamp != nil)
+                    #expect(
+                        message.timestampType == .createTime
+                            || message.timestampType == .logAppendTime
+                    )
+                    // Timestamp should be a reasonable epoch (after year 2020)
+                    if let ts = message.timestamp {
+                        #expect(ts > 1_577_836_800_000)  // 2020-01-01 in ms
+                    }
+                    break
+                }
+
+                await serviceGroup.triggerGracefulShutdown()
+                try await group.waitForAll()
+            }
+        }
+    }
+
+    // MARK: - Pause/Resume Tests
+
+    @Test func pauseAndResumePartitions() async throws {
+        try await withTestTopic { testTopic in
+            let _ = try await self.produceMessages(topic: testTopic, count: 3)
+
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.consumptionStrategy = .group(id: UUID().uuidString, topics: [testTopic])
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.autoOffsetReset = .beginning
+            consumerConfig.brokerAddressFamily = .v4
+
+            let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
+                config: consumerConfig,
+                logger: .kafkaTest
+            )
+
+            let serviceGroupConfiguration = ServiceGroupConfiguration(
+                services: [consumer],
+                logger: .kafkaTest
+            )
+            let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                group.addTask {
+                    for await _ in events {}
+                }
+
+                // Wait for assignment
+                try await Task.sleep(for: .seconds(2), tolerance: .zero)
+
+                let partition = KafkaTopicPartition(
+                    topic: testTopic,
+                    partition: KafkaPartition(rawValue: 0)
+                )
+
+                // Pause — should not throw
+                try consumer.pause(topicPartitions: [partition])
+
+                // Resume — should not throw
+                try consumer.resume(topicPartitions: [partition])
+
+                // Consume all messages after resume
+                var consumedCount = 0
+                for try await _ in consumer.messages {
+                    consumedCount += 1
+                    if consumedCount >= 3 {
+                        break
+                    }
+                }
+
+                #expect(consumedCount >= 3)
+
+                await serviceGroup.triggerGracefulShutdown()
+                try await group.waitForAll()
+            }
+        }
+    }
 }

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -391,13 +391,15 @@ import Foundation
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask { try await serviceGroup.run() }
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
-            
+
             #expect(throws: KafkaError.self) {
                 try consumer.pause(
-                    topicPartitions: [KafkaTopicPartition(topic: "nonexistent", partition: KafkaPartition(rawValue: 999))]
+                    topicPartitions: [
+                        KafkaTopicPartition(topic: "nonexistent", partition: KafkaPartition(rawValue: 999))
+                    ]
                 )
             }
-            
+
             await serviceGroup.triggerGracefulShutdown()
         }
     }
@@ -415,7 +417,9 @@ import Foundation
 
             #expect(throws: KafkaError.self) {
                 try consumer.resume(
-                    topicPartitions: [KafkaTopicPartition(topic: "nonexistent", partition: KafkaPartition(rawValue: 999))]
+                    topicPartitions: [
+                        KafkaTopicPartition(topic: "nonexistent", partition: KafkaPartition(rawValue: 999))
+                    ]
                 )
             }
 

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -379,6 +379,73 @@ import Foundation
         try consumer.subscribe(topics: ["^test-.*"])
     }
 
+    // MARK: - Pause/Resume Tests
+
+    @Test func pauseFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.pause(
+                topicPartitions: [KafkaTopicPartition(topic: "test", partition: KafkaPartition(rawValue: 0))]
+            )
+        }
+    }
+
+    @Test func resumeFailsOnClosedConsumer() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.resume(
+                topicPartitions: [KafkaTopicPartition(topic: "test", partition: KafkaPartition(rawValue: 0))]
+            )
+        }
+    }
+
+    // MARK: - KafkaTimestampType Tests
+
+    @Test func timestampTypeStaticConstants() {
+        #expect(KafkaTimestampType.notAvailable.rawValue == 0)
+        #expect(KafkaTimestampType.createTime.rawValue == 1)
+        #expect(KafkaTimestampType.logAppendTime.rawValue == 2)
+    }
+
+    @Test func timestampTypeEquality() {
+        #expect(KafkaTimestampType.createTime == KafkaTimestampType(rawValue: 1))
+        #expect(KafkaTimestampType.createTime != KafkaTimestampType.logAppendTime)
+    }
+
+    @Test func timestampTypeDescription() {
+        #expect(KafkaTimestampType.createTime.description == "createTime")
+        #expect(KafkaTimestampType.logAppendTime.description == "logAppendTime")
+        #expect(KafkaTimestampType.notAvailable.description == "notAvailable")
+    }
+
     // MARK: - committed / position Tests
 
     @Test func committedFailsOnClosedConsumer() async throws {

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -402,6 +402,27 @@ import Foundation
         }
     }
 
+    @Test func resumeFailsOnUnknownPartition() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            #expect(throws: KafkaError.self) {
+                try consumer.resume(
+                    topicPartitions: [KafkaTopicPartition(topic: "nonexistent", partition: KafkaPartition(rawValue: 999))]
+                )
+            }
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
     @Test func pauseFailsOnClosedConsumer() async throws {
         let config = makeConfig()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -381,6 +381,27 @@ import Foundation
 
     // MARK: - Pause/Resume Tests
 
+    @Test func pauseFailsOnUnknownPartition() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            
+            #expect(throws: KafkaError.self) {
+                try consumer.pause(
+                    topicPartitions: [KafkaTopicPartition(topic: "nonexistent", partition: KafkaPartition(rawValue: 999))]
+                )
+            }
+            
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
     @Test func pauseFailsOnClosedConsumer() async throws {
         let config = makeConfig()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)


### PR DESCRIPTION
## Motivation
Pause/resume partition APIs are needed for per-partition flow control. When downstream processing is slow, pausing specific partitions prevents message buildup without stopping the entire consumer. The consumer remains in the group and continues heartbeating while paused.

`KafkaConsumerMessage` has no timestamp field. Timestamps are fundamental to Kafka, they drive time-based windowing, event ordering, and log compaction retention. 

## Summary
- Add `pause(topicPartitions:)` and `resume(topicPartitions:)` on `KafkaConsumer`
- Add `pausePartitions` and `resumePartitions` to `RDKafkaClient`
- Add `timestamp: Int64?` (milliseconds since epoch) and `timestampType: KafkaTimestampType` to `KafkaConsumerMessage` via `rd_kafka_message_timestamp`
- Add `KafkaTimestampType` struct with `.createTime`, `.logAppendTime`, `.notAvailable`

## Test plan
- [x] Unit tests: timestamp type constants/equality/description, pause/resume on closed consumer
- [x] Integration tests: consumed message has timestamp with valid type, pause/resume lifecycle
- [x] `swift test --skip IntegrationTests` passes
- [x] `make docker-test` passes