### PR TITLE
Replace public-API-reachable fatalErrors with thrown errors

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -926,8 +926,6 @@ extension KafkaConsumer {
 
         /// Returns the next action to be taken when wanting to poll.
         /// - Returns: The next action to be taken when wanting to poll, or `nil` if there is no action to be taken.
-        ///
-        /// - Important: This function throws a `fatalError` if called while in the `.initializing` state.
         mutating func nextConsumerPollLoopAction() -> ConsumerPollLoopAction {
             switch self.state {
             case .uninitialized:
@@ -956,15 +954,13 @@ extension KafkaConsumer {
         mutating func setUpConnection() -> SetUpConnectionAction {
             switch self.state {
             case .uninitialized:
-                fatalError("\(#function) invoked while still in state \(self.state)")
+                return .consumerClosed
             case .initializing(let client, let rebalanceContext):
                 self.state = .running(client: client, rebalanceContext: rebalanceContext)
                 return .setUpConnection(client: client)
-            case .running:
-                fatalError("\(#function) should not be invoked more than once")
-            case .finishing:
-                fatalError("\(#function) should only be invoked when KafkaConsumer is running")
-            case .finished:
+            case .running(let client, _):
+                return .setUpConnection(client: client)
+            case .finishing, .finished:
                 return .consumerClosed
             }
         }
@@ -984,9 +980,7 @@ extension KafkaConsumer {
         /// - Returns: The action to be taken.
         func withClient() -> ClientAction {
             switch self.state {
-            case .uninitialized:
-                fatalError("\(#function) invoked while still in state \(self.state)")
-            case .initializing:
+            case .uninitialized, .initializing:
                 return .throwClosedError
             case .running(let client, _):
                 return .client(client)
@@ -1004,7 +998,7 @@ extension KafkaConsumer {
         func withClientForSubscription() -> ClientAction {
             switch self.state {
             case .uninitialized:
-                fatalError("\(#function) invoked while still in state \(self.state)")
+                return .throwClosedError
             case .initializing(let client, _):
                 return .client(client)
             case .running(let client, _):
@@ -1027,7 +1021,8 @@ extension KafkaConsumer {
         mutating func finish() -> FinishAction? {
             switch self.state {
             case .uninitialized:
-                fatalError("\(#function) invoked while still in state \(self.state)")
+                self.state = .finished
+                return nil
             case .initializing:
                 // No poll loop is active in .initializing state. Since consumerClose()
                 // requires an active poll loop to process broker responses, we skip it

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -500,13 +500,11 @@ extension KafkaProducer {
             return nil
         }
 
-        /// Get action to be taken when wanting to do close the producer.
-        ///
-        /// - Important: This function throws a `fatalError` if called while in the `.initializing` state.
+        /// Get action to be taken when wanting to close the producer.
         mutating func finish() {
             switch self.state {
             case .uninitialized:
-                fatalError("\(#function) invoked while still in state \(self.state)")
+                self.state = .finished
             case .started(let client, _, let source, _):
                 self.state = .finishing(client: client, source: source)
             case .eventConsumptionFinished(let client):

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -2046,4 +2046,41 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             }
         }
     }
+
+    // MARK: - Iterator Drop Shutdown Tests
+
+    @Test func gracefulShutdownAfterIteratorBreak() async throws {
+        try await withTestTopic { testTopic in
+            let _ = try await self.produceMessages(topic: testTopic, count: 3)
+
+            let groupId = UUID().uuidString
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.consumptionStrategy = .group(id: groupId, topics: [testTopic])
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.autoOffsetReset = .beginning
+            consumerConfig.brokerAddressFamily = .v4
+
+            let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+
+            let serviceGroupConfiguration = ServiceGroupConfiguration(
+                services: [consumer],
+                logger: .kafkaTest
+            )
+            let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                // Consume one message then break
+                for try await _ in consumer.messages {
+                    break
+                }
+
+                // Graceful shutdown — this triggers the async close path
+                await serviceGroup.triggerGracefulShutdown()
+            }
+        }
+    }
 }

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -52,6 +52,16 @@ import Foundation
         return config
     }
 
+    /// Create a consumer config without subscription — for tests that only need
+    /// start/stop lifecycle without subscribing to any topic.
+    private func makeConfigWithoutSubscription() -> KafkaConsumerConfig {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.useMockBroker()
+        config.brokerAddressFamily = .v4
+        return config
+    }
+
     // MARK: - Lifecycle Tests
 
     @Test func consumerLog() async throws {
@@ -60,13 +70,11 @@ import Foundation
             _ in MockLogHandler(recorder: recorder)
         }
 
-        // Set no bootstrap servers to trigger librdkafka configuration warning
         let uniqueGroupID = UUID().uuidString
         var config = KafkaConsumerConfig()
-        config.consumptionStrategy = .group(
-            id: uniqueGroupID,
-            topics: ["this-topic-does-not-exist"]
-        )
+        config.groupId = uniqueGroupID
+        config.useMockBroker()
+        config.brokerAddressFamily = .v4
         config.debug = [.all]
 
         let consumer = try KafkaConsumer(config: config, logger: mockLogger)
@@ -104,25 +112,14 @@ import Foundation
     }
 
     @Test func consumerConstructDeinit() async throws {
-        let uniqueGroupID = UUID().uuidString
-        var config = KafkaConsumerConfig()
-        config.groupId = uniqueGroupID
-        config.consumptionStrategy = .group(
-            id: uniqueGroupID,
-            topics: ["this-topic-does-not-exist"]
-        )
+        let config = makeConfigWithoutSubscription()
 
         _ = try KafkaConsumer(config: config, logger: .kafkaTest)  // deinit called before run
         _ = try KafkaConsumer.makeConsumerWithEvents(config: config, logger: .kafkaTest)
     }
 
     @Test func consumerMessagesReadCancelledBeforeRun() async throws {
-        let uniqueGroupID = UUID().uuidString
-        var config = KafkaConsumerConfig()
-        config.consumptionStrategy = .group(
-            id: uniqueGroupID,
-            topics: ["this-topic-does-not-exist"]
-        )
+        let config = makeConfigWithoutSubscription()
 
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
@@ -154,6 +151,66 @@ import Foundation
         }
     }
 
+    // MARK: - Uninitialized Consumer Safety Tests
+    //
+    // These verify that calling public APIs before run() throws instead of crashing.
+
+    @Test func positionBeforeRunThrowsInsteadOfCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        #expect(throws: KafkaError.self) {
+            _ = try consumer.position(
+                topicPartitions: [KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))]
+            )
+        }
+    }
+
+    @Test func committedBeforeRunThrowsInsteadOfCrash() async throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        await #expect(throws: KafkaError.self) {
+            _ = try await consumer.committed(
+                topicPartitions: [KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))]
+            )
+        }
+    }
+
+    @Test func seekBeforeRunThrowsInsteadOfCrash() async throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        await #expect(throws: KafkaError.self) {
+            try await consumer.seek(
+                topicPartitionOffsets: [
+                    KafkaTopicPartitionOffset(topic: "t", partition: KafkaPartition(rawValue: 0), offset: .beginning)
+                ]
+            )
+        }
+    }
+
+    @Test func isAssignmentLostBeforeRunThrowsInsteadOfCrash() throws {
+        var config = KafkaConsumerConfig()
+        config.groupId = UUID().uuidString
+        config.brokerAddressFamily = .v4
+
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        #expect(throws: KafkaError.self) {
+            _ = try consumer.isAssignmentLost
+        }
+    }
+
     // MARK: - Closed Consumer State Machine Tests
     //
     // storeOffset(_:) cannot be unit-tested directly because KafkaConsumerMessage
@@ -163,7 +220,8 @@ import Foundation
     // path through the methods that don't require a KafkaConsumerMessage.
 
     @Test func positionFailsOnClosedConsumerViaStateMachine() async throws {
-        let config = makeConfig(enableAutoOffsetStore: false)
+        var config = makeConfigWithoutSubscription()
+        config.enableAutoOffsetStore = false
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -190,7 +248,7 @@ import Foundation
     // MARK: - Subscription Management Tests
 
     @Test func subscribedTopicsFailsOnClosedConsumer() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -211,7 +269,7 @@ import Foundation
     }
 
     @Test func subscribeFailsOnClosedConsumer() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -232,7 +290,7 @@ import Foundation
     }
 
     @Test func unsubscribeFailsOnClosedConsumer() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -253,7 +311,7 @@ import Foundation
     }
 
     @Test func subscribeWithEmptyTopicsCallsUnsubscribe() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -382,7 +440,7 @@ import Foundation
     // MARK: - committed / position Tests
 
     @Test func committedFailsOnClosedConsumer() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -407,7 +465,7 @@ import Foundation
     }
 
     @Test func positionFailsOnClosedConsumer() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -433,7 +491,7 @@ import Foundation
     // MARK: - isAssignmentLost Tests
 
     @Test func isAssignmentLostFailsOnClosedConsumer() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -455,7 +513,7 @@ import Foundation
     }
 
     @Test func isAssignmentLostReturnsFalseWhenRunning() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -486,7 +544,7 @@ import Foundation
     // MARK: - seek Tests
 
     @Test func seekFailsOnClosedConsumer() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
@@ -522,7 +580,7 @@ import Foundation
     // MARK: - makeConsumerWithEvents Tests
 
     @Test func makeConsumerWithEventsConstructDeinit() async throws {
-        let config = makeConfig()
+        let config = makeConfigWithoutSubscription()
         let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
             config: config,
             logger: .kafkaTest

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -41,12 +41,8 @@ final class KafkaMetricsTests {
         MetricsSystem.bootstrapInternal(NOOPMetricsHandler.instance)
     }
     @Test func consumerStatistics() async throws {
-        let uniqueGroupID = UUID().uuidString
         var config = KafkaConsumerConfig()
-        config.consumptionStrategy = .group(
-            id: uniqueGroupID,
-            topics: ["this-topic-does-not-exist"]
-        )
+        config.groupId = UUID().uuidString
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")
         config.useMockBroker()

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -378,6 +378,16 @@ import Foundation
         }
     }
 
+    // MARK: - Uninitialized Producer Safety Tests
+
+    @Test func triggerGracefulShutdownBeforeRunDoesNotCrash() throws {
+        let config = KafkaProducerConfig()
+        let producer = try KafkaProducer(config: config, logger: .kafkaTest)
+
+        // Should not crash — finish() handles .started state gracefully
+        producer.triggerGracefulShutdown()
+    }
+
     // MARK: - KafkaProducerEvent.error Tests
 
     @Test func producerEventErrorPatternMatch() {


### PR DESCRIPTION
## Motivation

Several state machine methods call `fatalError()` for states reachable from public API — calling `position()` before `run()`, or `triggerGracefulShutdown()` before initialization. A library should never terminate the host process for conditions a user can trigger.

## Summary

- Replace `fatalError` with thrown `KafkaError` in public-API-reachable consumer and producer state machine paths
- Keep internal invariant `fatalError`s for states only reachable through library bugs
- Add unit tests verifying public APIs throw instead of crash
- Fix test noise from unnecessary topic subscriptions in unit tests

## Test plan
- [x] `swift test --skip IntegrationTests` passes
- [ ] `make docker-test` passes