### PR TITLE
Add commit-all stored offsets API

### DIFF
--- a/Sources/Kafka/Configuration/KafkaConsumerConfig.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfig.swift
@@ -1048,6 +1048,10 @@ public struct KafkaConsumerConfig: Sendable {
 
     /// Additional librdkafka configuration properties not covered by typed properties.
     /// Keys and values are passed directly to librdkafka.
+    ///
+    /// - Warning: Properties set here override typed properties above.
+    /// Intended for testing (e.g. `test.mock.num.brokers`) or advanced configurations
+    /// not explicitly supported by this library.
     internal var additionalConfig: [String: String] = [:]
 
     public init() {}

--- a/Sources/Kafka/Configuration/KafkaProducerConfig.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfig.swift
@@ -1037,6 +1037,10 @@ public struct KafkaProducerConfig: Sendable {
 
     /// Additional librdkafka configuration properties not covered by typed properties.
     /// Keys and values are passed directly to librdkafka.
+    ///
+    /// - Warning: Properties set here override typed properties above.
+    /// Intended for testing (e.g. `test.mock.num.brokers`) or advanced configurations
+    /// not explicitly supported by this library.
     internal var additionalConfig: [String: String] = [:]
 
     public init() {}

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -690,6 +690,44 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
+    /// Schedule an async commit of all stored offsets.
+    /// Returns immediately. Any errors after scheduling are discarded.
+    ///
+    /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
+    /// - Throws: A ``KafkaError`` if scheduling the commit failed or the consumer is closed.
+    public func scheduleCommit() throws {
+        let action = self.stateMachine.withLockedValue { $0.withClient() }
+        switch action {
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Tried to commit offsets on a closed consumer")
+        case .client(let client):
+            guard (self.config.enableAutoCommit ?? true) == false else {
+                throw KafkaError.config(reason: "Committing manually only works if enableAutoCommit is set to false")
+            }
+
+            try client.scheduleCommitAll()
+        }
+    }
+
+    /// Commit all stored offsets to the broker.
+    /// Awaits until the commit succeeds or an error is encountered.
+    ///
+    /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
+    /// - Throws: A ``KafkaError`` if the commit failed or the consumer is closed.
+    public func commit() async throws {
+        let action = self.stateMachine.withLockedValue { $0.withClient() }
+        switch action {
+        case .throwClosedError:
+            throw KafkaError.connectionClosed(reason: "Tried to commit offsets on a closed consumer")
+        case .client(let client):
+            guard (self.config.enableAutoCommit ?? true) == false else {
+                throw KafkaError.config(reason: "Committing manually only works if enableAutoCommit is set to false")
+            }
+
+            try await client.commitAll()
+        }
+    }
+
     /// Retrieve the last-committed offsets for the given topic+partition pairs from the broker.
     ///
     /// This is useful for monitoring consumer lag and verifying that offsets have been

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -401,7 +401,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// Internal startup subscription that transitions the state machine from `.initializing` to `.running`.
     /// Called once during `_run()` to set up the initial subscription from `consumptionStrategy`.
     private func initialSubscribe(topics: [String]) throws {
-        let action = self.stateMachine.withLockedValue { $0.setUpConnection() }
+        let action = self.stateMachine.withLockedValue { $0.transitionToRunning() }
         switch action {
         case .setUpConnection(let client):
             let subscription = RDKafkaTopicPartitionList()
@@ -428,7 +428,7 @@ public final class KafkaConsumer: Sendable, Service {
         partition: KafkaPartition,
         offset: KafkaOffset
     ) throws {
-        let action = self.stateMachine.withLockedValue { $0.setUpConnection() }
+        let action = self.stateMachine.withLockedValue { $0.transitionToRunning() }
         switch action {
         case .setUpConnection(let client):
             let assignment = RDKafkaTopicPartitionList()
@@ -461,7 +461,7 @@ public final class KafkaConsumer: Sendable, Service {
         } else {
             // No consumptionStrategy set — user will call subscribe(topics:) manually.
             // Transition state machine to .running so the event loop can start.
-            let action = self.stateMachine.withLockedValue { $0.setUpConnection() }
+            let action = self.stateMachine.withLockedValue { $0.transitionToRunning() }
             switch action {
             case .setUpConnection:
                 break
@@ -988,10 +988,10 @@ extension KafkaConsumer {
             case consumerClosed
         }
 
-        /// Get action to be taken when wanting to set up the connection through ``subscribe()`` or ``assign()``.
+        /// Transition the state machine from `.initializing` to `.running`.
         ///
         /// - Returns: The action to be taken.
-        mutating func setUpConnection() -> SetUpConnectionAction {
+        mutating func transitionToRunning() -> SetUpConnectionAction {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -715,6 +715,44 @@ public final class RDKafkaClient: Sendable {
         }
     }
 
+    /// Schedule an async commit of all stored offsets.
+    /// Returns immediately. Any errors after scheduling are discarded.
+    ///
+    /// Equivalent to `rd_kafka_commit(rk, NULL, async=1)`.
+    func scheduleCommitAll() throws {
+        let error = rd_kafka_commit(
+            self.kafkaHandle.pointer,
+            nil,
+            1  // async = true
+        )
+
+        if error != RD_KAFKA_RESP_ERR_NO_ERROR {
+            throw KafkaError.rdKafkaError(wrapping: error)
+        }
+    }
+
+    /// Non-blocking **awaitable** commit of all stored offsets.
+    ///
+    /// Equivalent to `rd_kafka_commit_queue(rk, NULL, ...)`.
+    func commitAll() async throws {
+        var capturedClosure: CapturedCommitCallback!
+        try await withCheckedThrowingContinuation { continuation in
+            capturedClosure = CapturedCommitCallback { result in
+                continuation.resume(with: result)
+            }
+
+            let opaquePointer: UnsafeMutableRawPointer? = Unmanaged.passUnretained(capturedClosure).toOpaque()
+
+            rd_kafka_commit_queue(
+                self.kafkaHandle.pointer,
+                nil,  // NULL = commit all stored offsets
+                self.queueHandle.pointer,
+                nil,
+                opaquePointer
+            )
+        }
+    }
+
     /// Non-blocking **awaitable** commit of a `message`'s offset to Kafka.
     ///
     /// - Parameter message: Last received message that shall be marked as read.

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -15,6 +15,7 @@
 import Crdkafka
 import Dispatch
 import Logging
+import NIOConcurrencyHelpers
 import NIOCore
 
 import class Foundation.JSONDecoder
@@ -549,16 +550,15 @@ public final class RDKafkaClient: Sendable {
             }
             return
         }
-        let opaque = Unmanaged<CapturedCommitCallback>.fromOpaque(opaquePointer).takeUnretainedValue()
-        let actualCallback = opaque.closure
+        let promise = Unmanaged<CommitPromise>.fromOpaque(opaquePointer).takeRetainedValue()
 
         let error = rd_kafka_event_error(event)
         guard error == RD_KAFKA_RESP_ERR_NO_ERROR else {
             let kafkaError = KafkaError.rdKafkaError(wrapping: error)
-            actualCallback(.failure(kafkaError))
+            promise.resume(with: .failure(kafkaError))
             return
         }
-        actualCallback(.success(()))
+        promise.resume(with: .success(()))
     }
 
     /// Request a new message from the Kafka cluster.
@@ -639,14 +639,48 @@ public final class RDKafkaClient: Sendable {
         }
     }
 
-    /// Wraps a Swift closure inside of a class to be able to pass it to `librdkafka` as an `OpaquePointer`.
-    /// This is specifically used to pass a Swift closure as a commit callback for the ``KafkaConsumer``.
-    final class CapturedCommitCallback {
-        typealias Closure = (Result<Void, KafkaError>) -> Void
-        let closure: Closure
+    /// A thread-safe promise to bridge `librdkafka`'s async C callbacks with Swift's continuations.
+    /// This prevents Use-After-Free crashes and orphaned continuations on task cancellation.
+    final class CommitPromise: Sendable {
+        private enum State {
+            case initial
+            case waiting(CheckedContinuation<Void, Error>)
+            case completed(Result<Void, Error>)
+        }
+        private let state = NIOLockedValueBox<State>(.initial)
 
-        init(_ closure: @escaping Closure) {
-            self.closure = closure
+        func set(_ continuation: CheckedContinuation<Void, Error>) {
+            let resultToResume: Result<Void, Error>? = self.state.withLockedValue { state in
+                switch state {
+                case .initial:
+                    state = .waiting(continuation)
+                    return nil
+                case .completed(let result):
+                    return result
+                case .waiting:
+                    fatalError("Promise already has a continuation")
+                }
+            }
+            if let result = resultToResume {
+                continuation.resume(with: result)
+            }
+        }
+
+        func resume(with result: Result<Void, Error>) {
+            let cont: CheckedContinuation<Void, Error>? = self.state.withLockedValue { state in
+                switch state {
+                case .initial:
+                    state = .completed(result)
+                    return nil
+                case .waiting(let continuation):
+                    state = .completed(result)
+                    return continuation
+                case .completed:
+                    // Already completed (e.g. cancelled then regular callback)
+                    return nil
+                }
+            }
+            cont?.resume(with: result)
         }
     }
 
@@ -735,21 +769,29 @@ public final class RDKafkaClient: Sendable {
     ///
     /// Equivalent to `rd_kafka_commit_queue(rk, NULL, ...)`.
     func commitAll() async throws {
-        var capturedClosure: CapturedCommitCallback!
-        try await withCheckedThrowingContinuation { continuation in
-            capturedClosure = CapturedCommitCallback { result in
-                continuation.resume(with: result)
+        let promise = CommitPromise()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                promise.set(continuation)
+
+                let opaquePointer: UnsafeMutableRawPointer = Unmanaged.passRetained(promise).toOpaque()
+
+                let error = rd_kafka_commit_queue(
+                    self.kafkaHandle.pointer,
+                    nil,  // NULL = commit all stored offsets
+                    self.queueHandle.pointer,
+                    nil,
+                    opaquePointer
+                )
+
+                if error != RD_KAFKA_RESP_ERR_NO_ERROR {
+                    // librdkafka will NOT enqueue an event, so we must consume the +1 retain count ourselves
+                    Unmanaged<CommitPromise>.fromOpaque(opaquePointer).release()
+                    promise.resume(with: .failure(KafkaError.rdKafkaError(wrapping: error)))
+                }
             }
-
-            let opaquePointer: UnsafeMutableRawPointer? = Unmanaged.passUnretained(capturedClosure).toOpaque()
-
-            rd_kafka_commit_queue(
-                self.kafkaHandle.pointer,
-                nil,  // NULL = commit all stored offsets
-                self.queueHandle.pointer,
-                nil,
-                opaquePointer
-            )
+        } onCancel: {
+            promise.resume(with: .failure(CancellationError()))
         }
     }
 
@@ -758,40 +800,41 @@ public final class RDKafkaClient: Sendable {
     /// - Parameter message: Last received message that shall be marked as read.
     /// - Throws: A ``KafkaError`` if the commit failed.
     func commit(_ message: KafkaConsumerMessage) async throws {
-        // Declare captured closure outside of withCheckedContinuation.
-        // We do that because do an unretained pass of the captured closure to
-        // librdkafka which means we have to keep a reference to the closure
-        // ourselves to make sure it does not get deallocated before
-        // commit returns.
-        var capturedClosure: CapturedCommitCallback!
-        try await withCheckedThrowingContinuation { continuation in
-            capturedClosure = CapturedCommitCallback { result in
-                continuation.resume(with: result)
-            }
+        let promise = CommitPromise()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                promise.set(continuation)
 
-            // The offset committed is always the offset of the next requested message.
-            // Thus, we increase the offset of the current message by one before committing it.
-            // See: https://github.com/edenhill/librdkafka/issues/2745#issuecomment-598067945
-            let changesList = RDKafkaTopicPartitionList()
-            changesList.setOffset(
-                topic: message.topic,
-                partition: message.partition,
-                offset: Int64(message.offset.rawValue + 1)
-            )
-
-            // Unretained pass because the reference that librdkafka holds to capturedClosure
-            // should not be counted in ARC as this can lead to memory leaks.
-            let opaquePointer: UnsafeMutableRawPointer? = Unmanaged.passUnretained(capturedClosure).toOpaque()
-
-            changesList.withListPointer { listPointer in
-                rd_kafka_commit_queue(
-                    self.kafkaHandle.pointer,
-                    listPointer,
-                    self.queueHandle.pointer,
-                    nil,
-                    opaquePointer
+                // The offset committed is always the offset of the next requested message.
+                // Thus, we increase the offset of the current message by one before committing it.
+                // See: https://github.com/edenhill/librdkafka/issues/2745#issuecomment-598067945
+                let changesList = RDKafkaTopicPartitionList()
+                changesList.setOffset(
+                    topic: message.topic,
+                    partition: message.partition,
+                    offset: Int64(message.offset.rawValue + 1)
                 )
+
+                let opaquePointer: UnsafeMutableRawPointer = Unmanaged.passRetained(promise).toOpaque()
+
+                changesList.withListPointer { listPointer in
+                    let error = rd_kafka_commit_queue(
+                        self.kafkaHandle.pointer,
+                        listPointer,
+                        self.queueHandle.pointer,
+                        nil,
+                        opaquePointer
+                    )
+
+                    if error != RD_KAFKA_RESP_ERR_NO_ERROR {
+                        // librdkafka will NOT enqueue an event, so we must consume the +1 retain count ourselves
+                        Unmanaged<CommitPromise>.fromOpaque(opaquePointer).release()
+                        promise.resume(with: .failure(KafkaError.rdKafkaError(wrapping: error)))
+                    }
+                }
             }
+        } onCancel: {
+            promise.resume(with: .failure(CancellationError()))
         }
     }
 

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -1092,6 +1092,161 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         }
     }
 
+    // MARK: - commitAll (commit-all stored offsets) integration
+
+    @Test func commitAllCommitsStoredOffsets() async throws {
+        try await withTestTopic { testTopic in
+            let testMessages = try await self.produceMessages(topic: testTopic, count: 5)
+
+            let uniqueGroupID = UUID().uuidString
+
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.autoOffsetReset = .beginning
+            consumerConfig.brokerAddressFamily = .v4
+            // Manual commit + manual offset store = full at-least-once control
+            consumerConfig.enableAutoCommit = false
+            consumerConfig.enableAutoOffsetStore = false
+
+            let consumer = try KafkaConsumer(
+                config: consumerConfig,
+                logger: .kafkaTest
+            )
+
+            let serviceGroupConfiguration = ServiceGroupConfiguration(
+                services: [consumer],
+                logger: .kafkaTest
+            )
+            let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                group.addTask {
+                    var lastMessage: KafkaConsumerMessage?
+                    var consumedCount = 0
+                    for try await message in consumer.messages {
+                        try consumer.storeOffset(message)
+                        lastMessage = message
+                        consumedCount += 1
+                        if consumedCount >= testMessages.count {
+                            break
+                        }
+                    }
+
+                    let message = try #require(lastMessage)
+                    #expect(consumedCount == testMessages.count)
+
+                    // Commit ALL stored offsets in one call (the method under test)
+                    try await consumer.commit()
+
+                    // Verify the committed offset matches what we stored
+                    let tp = KafkaTopicPartition(
+                        topic: message.topic,
+                        partition: message.partition
+                    )
+                    let committedOffsets = try await consumer.committed(
+                        topicPartitions: [tp],
+                        timeout: .milliseconds(5000)
+                    )
+
+                    let committedOffset = try #require(committedOffsets.first)
+                    #expect(committedOffset.topic == message.topic)
+                    #expect(committedOffset.partition == message.partition)
+                    // storeOffset stores message.offset + 1 internally
+                    let expectedOffset = KafkaOffset(rawValue: message.offset.rawValue + 1)
+                    #expect(committedOffset.offset == expectedOffset)
+                }
+
+                try await group.next()
+                await serviceGroup.triggerGracefulShutdown()
+            }
+        }
+    }
+
+    @Test func scheduleCommitAllCommitsStoredOffsets() async throws {
+        try await withTestTopic { testTopic in
+            let testMessages = try await self.produceMessages(topic: testTopic, count: 5)
+
+            let uniqueGroupID = UUID().uuidString
+
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.consumptionStrategy = .group(
+                id: uniqueGroupID,
+                topics: [testTopic]
+            )
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.autoOffsetReset = .beginning
+            consumerConfig.brokerAddressFamily = .v4
+            consumerConfig.enableAutoCommit = false
+            consumerConfig.enableAutoOffsetStore = false
+
+            let consumer = try KafkaConsumer(
+                config: consumerConfig,
+                logger: .kafkaTest
+            )
+
+            let serviceGroupConfiguration = ServiceGroupConfiguration(
+                services: [consumer],
+                logger: .kafkaTest
+            )
+            let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                group.addTask {
+                    var lastMessage: KafkaConsumerMessage?
+                    var consumedCount = 0
+                    for try await message in consumer.messages {
+                        try consumer.storeOffset(message)
+                        lastMessage = message
+                        consumedCount += 1
+                        if consumedCount >= testMessages.count {
+                            break
+                        }
+                    }
+
+                    let message = try #require(lastMessage)
+                    #expect(consumedCount == testMessages.count)
+
+                    // Fire-and-forget commit of all stored offsets
+                    try consumer.scheduleCommit()
+
+                    // Wait for the async commit to complete on the broker
+                    try await Task.sleep(for: .seconds(2))
+
+                    // Verify the committed offset
+                    let tp = KafkaTopicPartition(
+                        topic: message.topic,
+                        partition: message.partition
+                    )
+                    let committedOffsets = try await consumer.committed(
+                        topicPartitions: [tp],
+                        timeout: .milliseconds(5000)
+                    )
+
+                    let committedOffset = try #require(committedOffsets.first)
+                    #expect(committedOffset.topic == message.topic)
+                    #expect(committedOffset.partition == message.partition)
+                    let expectedOffset = KafkaOffset(rawValue: message.offset.rawValue + 1)
+                    #expect(committedOffset.offset == expectedOffset)
+                }
+
+                try await group.next()
+                await serviceGroup.triggerGracefulShutdown()
+            }
+        }
+    }
+
     // MARK: - Rebalance Event Delivery Tests
 
     @Test func rebalanceEventsDeliveredThroughConsumerEvents() async throws {

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -1129,39 +1129,35 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 }
 
                 group.addTask {
-                    var lastMessage: KafkaConsumerMessage?
                     var consumedCount = 0
                     for try await message in consumer.messages {
                         try consumer.storeOffset(message)
-                        lastMessage = message
                         consumedCount += 1
                         if consumedCount >= testMessages.count {
+                            // Commit and verify BEFORE breaking — breaking drops the
+                            // iterator which triggers consumer shutdown.
+                            try await consumer.commit()
+
+                            let tp = KafkaTopicPartition(
+                                topic: message.topic,
+                                partition: message.partition
+                            )
+                            let committedOffsets = try await consumer.committed(
+                                topicPartitions: [tp],
+                                timeout: .milliseconds(5000)
+                            )
+
+                            let committedOffset = try #require(committedOffsets.first)
+                            #expect(committedOffset.topic == message.topic)
+                            #expect(committedOffset.partition == message.partition)
+                            // storeOffset stores message.offset + 1 internally
+                            let expectedOffset = KafkaOffset(rawValue: message.offset.rawValue + 1)
+                            #expect(committedOffset.offset == expectedOffset)
                             break
                         }
                     }
 
-                    let message = try #require(lastMessage)
                     #expect(consumedCount == testMessages.count)
-
-                    // Commit ALL stored offsets in one call (the method under test)
-                    try await consumer.commit()
-
-                    // Verify the committed offset matches what we stored
-                    let tp = KafkaTopicPartition(
-                        topic: message.topic,
-                        partition: message.partition
-                    )
-                    let committedOffsets = try await consumer.committed(
-                        topicPartitions: [tp],
-                        timeout: .milliseconds(5000)
-                    )
-
-                    let committedOffset = try #require(committedOffsets.first)
-                    #expect(committedOffset.topic == message.topic)
-                    #expect(committedOffset.partition == message.partition)
-                    // storeOffset stores message.offset + 1 internally
-                    let expectedOffset = KafkaOffset(rawValue: message.offset.rawValue + 1)
-                    #expect(committedOffset.offset == expectedOffset)
                 }
 
                 try await group.next()
@@ -1204,41 +1200,37 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 }
 
                 group.addTask {
-                    var lastMessage: KafkaConsumerMessage?
                     var consumedCount = 0
                     for try await message in consumer.messages {
                         try consumer.storeOffset(message)
-                        lastMessage = message
                         consumedCount += 1
                         if consumedCount >= testMessages.count {
+                            // Schedule commit and verify BEFORE breaking — breaking
+                            // drops the iterator which triggers consumer shutdown.
+                            try consumer.scheduleCommit()
+
+                            // Wait for the async commit to complete on the broker
+                            try await Task.sleep(for: .seconds(2))
+
+                            let tp = KafkaTopicPartition(
+                                topic: message.topic,
+                                partition: message.partition
+                            )
+                            let committedOffsets = try await consumer.committed(
+                                topicPartitions: [tp],
+                                timeout: .milliseconds(5000)
+                            )
+
+                            let committedOffset = try #require(committedOffsets.first)
+                            #expect(committedOffset.topic == message.topic)
+                            #expect(committedOffset.partition == message.partition)
+                            let expectedOffset = KafkaOffset(rawValue: message.offset.rawValue + 1)
+                            #expect(committedOffset.offset == expectedOffset)
                             break
                         }
                     }
 
-                    let message = try #require(lastMessage)
                     #expect(consumedCount == testMessages.count)
-
-                    // Fire-and-forget commit of all stored offsets
-                    try consumer.scheduleCommit()
-
-                    // Wait for the async commit to complete on the broker
-                    try await Task.sleep(for: .seconds(2))
-
-                    // Verify the committed offset
-                    let tp = KafkaTopicPartition(
-                        topic: message.topic,
-                        partition: message.partition
-                    )
-                    let committedOffsets = try await consumer.committed(
-                        topicPartitions: [tp],
-                        timeout: .milliseconds(5000)
-                    )
-
-                    let committedOffset = try #require(committedOffsets.first)
-                    #expect(committedOffset.topic == message.topic)
-                    #expect(committedOffset.partition == message.partition)
-                    let expectedOffset = KafkaOffset(rawValue: message.offset.rawValue + 1)
-                    #expect(committedOffset.offset == expectedOffset)
                 }
 
                 try await group.next()

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -467,16 +467,19 @@ import Foundation
             }
 
             // Wait until the consumer is in .running state
+            var success = false
             for _ in 0..<20 {
                 do {
                     let lost = try consumer.isAssignmentLost
                     #expect(lost == false)
+                    success = true
                     break
                 } catch {
-                    // Consumer not yet running, retry
+                    // Consumer not yet running (still initializing), retry
                     try await Task.sleep(for: .milliseconds(100))
                 }
             }
+            #expect(success, "Consumer never entered running state")
 
             await serviceGroup.triggerGracefulShutdown()
             try await group.waitForAll()
@@ -570,6 +573,7 @@ import Foundation
             group.addTask { try await serviceGroup.run() }
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
 
         #expect(throws: KafkaError.self) {
@@ -588,6 +592,7 @@ import Foundation
             group.addTask { try await serviceGroup.run() }
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
             await serviceGroup.triggerGracefulShutdown()
+            try await group.waitForAll()
         }
 
         await #expect(throws: KafkaError.self) {
@@ -1193,5 +1198,23 @@ import Foundation
         let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
         try consumer.subscribe(topics: ["test-topic"])
         consumer.triggerGracefulShutdown()
+    }
+
+    @Test func scheduleCommitAllSucceeds() async throws {
+        let config = self.makeConfig(enableAutoCommit: false)
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            try consumer.scheduleCommit()
+            try await Task.sleep(for: .milliseconds(1000), tolerance: .zero)
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
     }
 }

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -519,6 +519,82 @@ import Foundation
     // throw a config error. The closed-consumer path is the same as other withClient()
     // methods, already tested above.
 
+    // MARK: - Commit All Tests
+
+    @Test func scheduleCommitAllFailsWithAutoCommitEnabled() async throws {
+        let config = makeConfig(enableAutoCommit: true)
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            #expect(throws: KafkaError.self) {
+                try consumer.scheduleCommit()
+            }
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func commitAllFailsWithAutoCommitEnabled() async throws {
+        let config = makeConfig(enableAutoCommit: true)
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            await #expect(throws: KafkaError.self) {
+                try await consumer.commit()
+            }
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test func scheduleCommitAllFailsOnClosedConsumer() async throws {
+        let config = makeConfig(enableAutoCommit: false)
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+
+        #expect(throws: KafkaError.self) {
+            try consumer.scheduleCommit()
+        }
+    }
+
+    @Test func commitAllFailsOnClosedConsumer() async throws {
+        let config = makeConfig(enableAutoCommit: false)
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+            await serviceGroup.triggerGracefulShutdown()
+        }
+
+        await #expect(throws: KafkaError.self) {
+            try await consumer.commit()
+        }
+    }
+
     // MARK: - makeConsumerWithEvents Tests
 
     @Test func makeConsumerWithEventsConstructDeinit() async throws {
@@ -1119,3 +1195,21 @@ import Foundation
         consumer.triggerGracefulShutdown()
     }
 }
+
+    @Test func scheduleCommitAllFailsIfOpaqueIsRebalanceContext() async throws {
+        let config = makeConfig(enableAutoCommit: false)
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask { try await serviceGroup.run() }
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            try consumer.scheduleCommit()
+            try await Task.sleep(for: .milliseconds(1000), tolerance: .zero)
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -1195,21 +1195,3 @@ import Foundation
         consumer.triggerGracefulShutdown()
     }
 }
-
-    @Test func scheduleCommitAllFailsIfOpaqueIsRebalanceContext() async throws {
-        let config = makeConfig(enableAutoCommit: false)
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
-
-        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
-        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
-
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await serviceGroup.run() }
-            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
-
-            try consumer.scheduleCommit()
-            try await Task.sleep(for: .milliseconds(1000), tolerance: .zero)
-
-            await serviceGroup.triggerGracefulShutdown()
-        }
-    }


### PR DESCRIPTION
## Summary

Add `scheduleCommit()` and `commit()` parameterless overloads to `KafkaConsumer` that commit **all stored offsets** to the broker. This is the standard pattern for at-least-once consumers using `storeOffset()` + manual commit, matching the `rd_kafka_commit(rk, NULL, ...)` API available in Rust, Java, Go, and Python Kafka clients.

## New API

```swift
// Fire-and-forget — schedules commit, returns immediately
try consumer.scheduleCommit()

// Awaitable — waits for broker acknowledgement
try await consumer.commit()
```

Both methods:
- Commit all offsets currently in librdkafka's local offset store
- Require `enableAutoCommit = false` (throws config error otherwise)
- Throw `connectionClosed` on a closed consumer

## Fixes (commit safety)

While adding the new API, we identified and fixed safety issues in the existing `commit(_ message:)` that also apply to the new `commit()`:

**CommitPromise** replaces `CapturedCommitCallback`:
- 3-state enum (`initial` → `waiting` → `completed`) with `NIOLockedValueBox` guarantees exactly-one continuation resume
- `withTaskCancellationHandler` ensures cancelled tasks get `CancellationError` instead of leaking the continuation
- `passRetained`/`takeRetainedValue` properly balances ARC across the C callback boundary
- Error check on `rd_kafka_commit_queue` return value with retain count cleanup on the synchronous error path

## Test plan

**Unit tests** (mock broker, no Kafka needed):
- `scheduleCommitAllFailsWithAutoCommitEnabled`
- `commitAllFailsWithAutoCommitEnabled`
- `scheduleCommitAllFailsOnClosedConsumer`
- `commitAllFailsOnClosedConsumer`
- `scheduleCommitAllSucceeds`

**Integration tests** (requires broker):
- `commitAllCommitsStoredOffsets` — produce → consume → storeOffset → `commit()` → verify via `committed()`
- `scheduleCommitAllCommitsStoredOffsets` — same flow with `scheduleCommit()` (fire-and-forget)