### PR TITLE
Fix rd_kafka_last_error() race in headerless produce path

### DIFF
--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -135,34 +135,18 @@ public final class RDKafkaClient: Sendable {
             topic: message.topic
         ) { topicHandle in
             try Self.withMessageKeyAndValueBuffer(for: message) { keyBuffer, valueBuffer in
-                if message.headers.isEmpty {
-                    // No message headers set, normal produce method can be used.
-                    rd_kafka_produce(
-                        topicHandle,
-                        Int32(message.partition.rawValue),
-                        RD_KAFKA_MSG_F_COPY,
-                        UnsafeMutableRawPointer(mutating: valueBuffer.baseAddress),
-                        valueBuffer.count,
-                        keyBuffer?.baseAddress,
-                        keyBuffer?.count ?? 0,
-                        UnsafeMutableRawPointer(bitPattern: newMessageID)
+                let errorPointer = try Self.withKafkaCHeaders(for: message.headers) { cHeaders in
+                    try self._produceVariadic(
+                        topicHandle: topicHandle,
+                        partition: Int32(message.partition.rawValue),
+                        messageFlags: RD_KAFKA_MSG_F_COPY,
+                        key: keyBuffer,
+                        value: valueBuffer,
+                        opaque: UnsafeMutableRawPointer(bitPattern: newMessageID),
+                        cHeaders: cHeaders
                     )
-                    return rd_kafka_last_error()
-                } else {
-                    let errorPointer = try Self.withKafkaCHeaders(for: message.headers) { cHeaders in
-                        // Setting message headers only works with `rd_kafka_produceva` (variadic arguments).
-                        try self._produceVariadic(
-                            topicHandle: topicHandle,
-                            partition: Int32(message.partition.rawValue),
-                            messageFlags: RD_KAFKA_MSG_F_COPY,
-                            key: keyBuffer,
-                            value: valueBuffer,
-                            opaque: UnsafeMutableRawPointer(bitPattern: newMessageID),
-                            cHeaders: cHeaders
-                        )
-                    }
-                    return rd_kafka_error_code(errorPointer)
                 }
+                return rd_kafka_error_code(errorPointer)
             }
         }
 

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -647,6 +647,78 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         }
     }
 
+    // MARK: - Concurrent Produce Tests
+
+    @Test func concurrentSendsDoNotLoseMessages() async throws {
+        try await withTestTopic(partitions: 4) { testTopic in
+            let (producer, events) = try KafkaProducer.makeProducerWithEvents(
+                config: self.producerConfig,
+                logger: .kafkaTest
+            )
+
+            let serviceGroupConfiguration = ServiceGroupConfiguration(
+                services: [producer],
+                logger: .kafkaTest
+            )
+            let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    try await serviceGroup.run()
+                }
+
+                // Drain events to collect delivery reports
+                let acknowledgedCount = ManagedAtomic<Int>(0)
+                group.addTask {
+                    for await event in events {
+                        switch event {
+                        case .deliveryReports(let reports):
+                            for report in reports {
+                                if case .acknowledged = report.status {
+                                    acknowledgedCount.wrappingIncrement(ordering: .relaxed)
+                                }
+                            }
+                        default:
+                            break
+                        }
+                    }
+                }
+
+                // Send 100 messages concurrently from multiple tasks — exercises the
+                // rd_kafka_produceva path under contention. Before the fix, the old
+                // rd_kafka_produce + rd_kafka_last_error() path could return wrong
+                // error codes when tasks shared a cooperative thread pool thread.
+                let messageCount = 100
+                try await withThrowingTaskGroup(of: Void.self) { sendGroup in
+                    for i in 0..<messageCount {
+                        sendGroup.addTask {
+                            let message = KafkaProducerMessage(
+                                topic: testTopic,
+                                key: "key-\(i)",
+                                value: "value-\(i)"
+                            )
+                            try producer.send(message)
+                        }
+                    }
+                    try await sendGroup.waitForAll()
+                }
+
+                // Wait for delivery reports
+                for _ in 0..<100 {
+                    if acknowledgedCount.load(ordering: .relaxed) >= messageCount { break }
+                    try await Task.sleep(for: .milliseconds(100))
+                }
+
+                #expect(
+                    acknowledgedCount.load(ordering: .relaxed) >= messageCount,
+                    "Expected \(messageCount) acknowledged, got \(acknowledgedCount.load(ordering: .relaxed))"
+                )
+
+                await serviceGroup.triggerGracefulShutdown()
+            }
+        }
+    }
+
     // MARK: - storeOffset Tests
 
     @Test func produceAndConsumeWithStoreOffset() async throws {


### PR DESCRIPTION
## Summary

- Unify both produce paths (headerless and with-headers) to use `rd_kafka_produceva()`, eliminating the thread-local `rd_kafka_last_error()` race condition in Swift Concurrency

## Problem

The headerless `produce()` path called `rd_kafka_produce()` then `rd_kafka_last_error()` to get the error. Per the librdkafka docs: *"The last error is stored per-thread."* In Swift Concurrency, multiple Tasks share cooperative thread pool threads. A concurrent `send()` from another Task could overwrite the thread-local error before the first Task reads it, causing:

- Silent message loss (failed send reads another task's success code)
- Spurious errors (successful send reads another task's error code)

The with-headers path already used `rd_kafka_produceva()` which returns errors directly — no race.

## Fix

Remove the `if message.headers.isEmpty` branch and always use `_produceVariadic()` → `rd_kafka_produceva()`. The helper already handles empty headers correctly (the header loop simply doesn't execute).

## Test plan

- [x] Existing unit tests pass (`send`, `sendTwoTopics`, `sendEmptyMessage` — all headerless)
- [x] Existing `produceAndConsumeWithMessageHeaders` integration test (with-headers path)
- [x] New `concurrentSendsDoNotLoseMessages` integration test — 100 messages from concurrent tasks on 4 partitions, verifies all acknowledged