### PR TITLE
Fix threading and error handling in consumer iterator drop

### DIFF
--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -484,7 +484,15 @@ public final class KafkaConsumer: Sendable, Service {
         while !Task.isCancelled {
             let nextAction = self.stateMachine.withLockedValue { $0.nextEventPollLoopAction() }
             switch nextAction {
-            case .pollForEvents(let client):
+            case .initiateCloseAndPoll(let client), .pollForEvents(let client):
+                if case .initiateCloseAndPoll = nextAction {
+                    do {
+                        try client.consumerClose()
+                    } catch {
+                        self.logger.error("Closing KafkaConsumer failed", metadata: ["error": "\(error)"])
+                        self.stateMachine.withLockedValue { $0.closeFailed() }
+                    }
+                }
                 // Event poll to serve any events queued inside of `librdkafka` (statistics, logs, offset commits).
                 let events = client.consumerEventPoll()
                 for event in events {
@@ -534,6 +542,8 @@ public final class KafkaConsumer: Sendable, Service {
                     )
                 }
 
+                try await Task.sleep(for: self.config.pollInterval)
+            case .suspendPollLoop:
                 try await Task.sleep(for: self.config.pollInterval)
             case .terminatePollLoop(let client):
                 // Final drain: the close process may have completed (isConsumerClosed = true)
@@ -884,12 +894,20 @@ extension KafkaConsumer {
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             /// - Parameter rebalanceContext: The context for the C rebalance callback.
             case running(client: RDKafkaClient, rebalanceContext: RebalanceContext)
-            /// The ``KafkaConsumer/triggerGracefulShutdown()`` has been invoked.
-            /// We are now in the process of commiting our last state to the broker.
+            /// The ``KafkaConsumer`` is being closed.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             /// - Parameter rebalanceContext: The context for the C rebalance callback.
-            case finishing(client: RDKafkaClient, rebalanceContext: RebalanceContext)
+            case finishing(
+                client: RDKafkaClient,
+                rebalanceContext: RebalanceContext,
+                closeInitiated: Bool,
+                gracefulShutdownRequested: Bool
+            )
+            /// The ``KafkaConsumer`` has closed its queue and left the group,
+            /// but is waiting for ``KafkaConsumer/triggerGracefulShutdown()`` to be invoked
+            /// so it doesn't shut down the `ServiceGroup` early.
+            case finishedAwaitingGracefulShutdown(client: RDKafkaClient)
             /// The ``KafkaConsumer`` is closed.
             case finished
         }
@@ -914,12 +932,18 @@ extension KafkaConsumer {
             )
         }
 
-        /// Action to be taken when wanting to poll for a new message.
+        /// Action to be taken when polling for events.
         enum EventPollLoopAction {
-            /// Serve any queued callbacks on the event queue.
+            /// Poll for new events.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             case pollForEvents(client: RDKafkaClient)
+            /// Initiate consumer close, then poll for new events.
+            ///
+            /// - Parameter client: Client used for handling the connection to the Kafka cluster.
+            case initiateCloseAndPoll(client: RDKafkaClient)
+            /// Suspend the poll loop.
+            case suspendPollLoop
             /// Terminate the poll loop.
             ///
             /// - Parameter client: Client for final drain (may be nil if state was already `.finished`).
@@ -938,13 +962,29 @@ extension KafkaConsumer {
                 fatalError("Subscribe to consumer group / assign to topic partition pair before reading messages")
             case .running(let client, _):
                 return .pollForEvents(client: client)
-            case .finishing(let client, _):
+            case .finishing(let client, let rebalanceContext, let closeInitiated, let gracefulShutdownRequested):
                 if client.isConsumerClosed {
-                    self.state = .finished
-                    return .terminatePollLoop(client: client)
+                    if gracefulShutdownRequested {
+                        self.state = .finished
+                        return .terminatePollLoop(client: client)
+                    } else {
+                        self.state = .finishedAwaitingGracefulShutdown(client: client)
+                        return .suspendPollLoop
+                    }
                 } else {
+                    if !closeInitiated {
+                        self.state = .finishing(
+                            client: client,
+                            rebalanceContext: rebalanceContext,
+                            closeInitiated: true,
+                            gracefulShutdownRequested: gracefulShutdownRequested
+                        )
+                        return .initiateCloseAndPoll(client: client)
+                    }
                     return .pollForEvents(client: client)
                 }
+            case .finishedAwaitingGracefulShutdown:
+                return .suspendPollLoop
             case .finished:
                 return .terminatePollLoop(client: nil)
             }
@@ -974,7 +1014,7 @@ extension KafkaConsumer {
                 return .suspendPollLoop
             case .running(let client, _):
                 return .poll(client: client)
-            case .finishing, .finished:
+            case .finishing, .finishedAwaitingGracefulShutdown, .finished:
                 return .terminatePollLoop
             }
         }
@@ -1000,7 +1040,7 @@ extension KafkaConsumer {
                 return .setUpConnection(client: client)
             case .running:
                 fatalError("\(#function) should not be invoked more than once")
-            case .finishing:
+            case .finishing, .finishedAwaitingGracefulShutdown:
                 fatalError("\(#function) should only be invoked when KafkaConsumer is running")
             case .finished:
                 return .consumerClosed
@@ -1028,7 +1068,7 @@ extension KafkaConsumer {
                 return .throwClosedError
             case .running(let client, _):
                 return .client(client)
-            case .finishing, .finished:
+            case .finishing, .finishedAwaitingGracefulShutdown, .finished:
                 return .throwClosedError
             }
         }
@@ -1047,7 +1087,7 @@ extension KafkaConsumer {
                 return .client(client)
             case .running(let client, _):
                 return .client(client)
-            case .finishing, .finished:
+            case .finishing, .finishedAwaitingGracefulShutdown, .finished:
                 return .throwClosedError
             }
         }
@@ -1073,9 +1113,26 @@ extension KafkaConsumer {
                 self.state = .finished
                 return nil
             case .running(let client, let rebalanceContext):
-                self.state = .finishing(client: client, rebalanceContext: rebalanceContext)
+                self.state = .finishing(
+                    client: client,
+                    rebalanceContext: rebalanceContext,
+                    closeInitiated: true,
+                    gracefulShutdownRequested: true
+                )
                 return .triggerGracefulShutdown(client: client)
-            case .finishing, .finished:
+            case .finishing(let client, let rebalanceContext, let closeInitiated, _):
+                // Upgrade to graceful shutdown requested
+                self.state = .finishing(
+                    client: client,
+                    rebalanceContext: rebalanceContext,
+                    closeInitiated: closeInitiated,
+                    gracefulShutdownRequested: true
+                )
+                return nil
+            case .finishedAwaitingGracefulShutdown:
+                self.state = .finished
+                return nil
+            case .finished:
                 return nil
             }
         }
@@ -1087,9 +1144,28 @@ extension KafkaConsumer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .initializing:
                 self.state = .finished
-            case .running:
-                self.state = .finished
-            case .finishing, .finished:
+            case .running(let client, let rebalanceContext):
+                self.state = .finishing(
+                    client: client,
+                    rebalanceContext: rebalanceContext,
+                    closeInitiated: false,
+                    gracefulShutdownRequested: false
+                )
+            case .finishing, .finishedAwaitingGracefulShutdown, .finished:
+                break
+            }
+        }
+
+        /// Called if `consumerClose()` fails to avoid polling forever.
+        mutating func closeFailed() {
+            switch self.state {
+            case .finishing(let client, _, _, let gracefulShutdownRequested):
+                if gracefulShutdownRequested {
+                    self.state = .finished
+                } else {
+                    self.state = .finishedAwaitingGracefulShutdown(client: client)
+                }
+            default:
                 break
             }
         }
@@ -1103,7 +1179,8 @@ extension KafkaConsumer {
                 return nil
             case .initializing(let client, _),
                 .running(let client, _),
-                .finishing(let client, _):
+                .finishing(let client, _, _, _),
+                .finishedAwaitingGracefulShutdown(let client):
                 return client
             }
         }

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -1115,6 +1115,64 @@ import Foundation
         #expect(event1 == event2)
     }
 
+    // MARK: - Iterator Drop Shutdown Tests
+
+    @Test func iteratorDropDoesNotCrashServiceGroup() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            // Start consuming messages in a separate task, then drop the iterator
+            group.addTask {
+                for try await _ in consumer.messages {
+                    break  // immediately drop the iterator
+                }
+            }
+
+            // Wait for iterator drop to take effect
+            try await Task.sleep(for: .seconds(1))
+
+            // If we get here, run() did NOT exit early — ServiceGroup is still alive.
+            // Now shut down cleanly.
+            await serviceGroup.triggerGracefulShutdown()
+        }
+        // Test passes if no ServiceGroupError was thrown
+    }
+
+    @Test func iteratorDropThenGracefulShutdownSucceeds() async throws {
+        let config = makeConfig()
+        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
+
+            // Drop the iterator by creating and immediately discarding it
+            var iterator: KafkaConsumerMessages.AsyncIterator? = consumer.messages.makeAsyncIterator()
+            _ = iterator
+            iterator = nil
+
+            // Wait for state transition
+            try await Task.sleep(for: .seconds(1))
+
+            // Graceful shutdown should succeed without error
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
     // MARK: - KafkaError.RDKafkaCode Tests
 
     @Test func rdKafkaCodeStaticConstants() {


### PR DESCRIPTION
## Description
Fixes an issue where dropping the `KafkaConsumerMessages` iterator would prematurely terminate the `KafkaConsumer` service before a graceful shutdown was requested, which could cause a `ServiceGroup` to crash or exit unexpectedly. 

It also fixes multiple threading and error swallowing issues caused by tearing down the consumer inside a `deinit` method.

### Changes
- Moved `consumerClose()` from the `MachineHolder.deinit` ARC thread to the event loop's cooperative pool.
- Added `closeInitiated` to the `.finishing` state to ensure `consumerClose()` is called only once when the iterator is dropped.
- Added `.initiateCloseAndPoll` action to `EventPollLoopAction` to handle initiating the close and resuming event polling.
- Improved error handling by preventing an infinite polling loop if `consumerClose()` fails.
- Added 2 new tests verifying that breaking out of the iterator does not crash the `ServiceGroup` and completes graceful shutdown properly.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing
Added `iteratorDropDoesNotCrashServiceGroup` and `iteratorDropThenGracefulShutdownSucceeds` to `KafkaConsumerTests.swift`. 
All existing tests continue to pass.