### PR TITLE
refactor: refactor KafkaContiguousBytes protocol

### DIFF
--- a/Sources/Kafka/Data/Array+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/Array+KafkaContiguousBytes.swift
@@ -12,4 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension Array: KafkaContiguousBytes where Array.Element == UInt8 {}
+extension Array: KafkaContiguousBytes where Element == UInt8 {
+    public func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R {
+        try self.withUnsafeBufferPointer { buffer in
+            try body(buffer)
+        }
+    }
+}

--- a/Sources/Kafka/Data/ByteBuffer+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/ByteBuffer+KafkaContiguousBytes.swift
@@ -15,9 +15,9 @@
 import NIOCore
 
 extension ByteBuffer: KafkaContiguousBytes {
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
-        try self.withUnsafeReadableBytes {
-            try body($0)
+    public func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R {
+        try self.withUnsafeReadableBytes { rawBuffer in
+            try body(rawBuffer.bindMemory(to: UInt8.self))
         }
     }
 }

--- a/Sources/Kafka/Data/KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/KafkaContiguousBytes.swift
@@ -26,5 +26,5 @@ public protocol KafkaContiguousBytes {
     ///         the same buffer pointer will be passed in every time.
     /// - warning: The buffer argument to the body should not be stored or used
     ///            outside of the lifetime of the call to the closure.
-    func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+    func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R
 }

--- a/Sources/Kafka/Data/String+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/String+KafkaContiguousBytes.swift
@@ -15,14 +15,10 @@
 import NIOCore
 
 extension String: KafkaContiguousBytes {
-    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    public func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R {
         if let read = try self.utf8.withContiguousStorageIfAvailable({ unsafePointer in
-            // Fast Path
-            let unsafeRawBufferPointer = UnsafeRawBufferPointer(
-                start: unsafePointer.baseAddress,
-                count: self.utf8.count
-            )
-            return try body(unsafeRawBufferPointer)
+            // Fast path
+            return try body(unsafePointer)
         }) {
             return read
         } else {

--- a/Sources/KafkaFoundationCompat/Data+KafkaContiguousBytes.swift
+++ b/Sources/KafkaFoundationCompat/Data+KafkaContiguousBytes.swift
@@ -13,7 +13,12 @@
 //===----------------------------------------------------------------------===//
 
 import Kafka
-
 import struct Foundation.Data
 
-extension Data: KafkaContiguousBytes {}
+extension Data: KafkaContiguousBytes {
+    public func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R {
+        try self.withUnsafeBytes { rawBuffer in
+            try body(rawBuffer.bindMemory(to: UInt8.self))
+        }
+    }
+}


### PR DESCRIPTION
Change KafkaContiguousBytes to func withUnsafeBytes<R>(_ body: (UnsafeBufferPointer<UInt8>) throws -> R) rethrows -> R
### Motivation:
When use  KafkaProducerMessage(topic: topic, value: data) then project have error - Instance method 'send' requires that 'Data' conform to 'KafkaContiguousBytes', but I use Data, and Data have KafkaContiguousBytes
### Modifications:
Change KafkaContiguousBytes protocol and change all func for this protocol
### Result:
All extensions for KafkaContiguousBytes changed to new func