### PR TITLE
Documentation catalog and editorial updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ let producer = try KafkaProducer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [producer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
@@ -85,11 +85,11 @@ let (producer, events) = try KafkaProducer.makeProducerWithEvents(
 
 let serviceGroup = ServiceGroup(
     services: [producer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
@@ -125,11 +125,11 @@ let consumer = try KafkaConsumer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
@@ -154,11 +154,11 @@ let consumer = try KafkaConsumer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
@@ -185,11 +185,11 @@ let consumer = try KafkaConsumer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
@@ -290,7 +290,7 @@ for await event in events {
         } else if error.isRetriable {
             // Transient error — will likely resolve
         }
-        print("Error: \(error.rdKafkaCode)")
+        print("Error: \(error)")
     default:
         break
     }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Swift Kafka Client library provides a convenient way to interact with [Apach
 - Integration with [swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle), [swift-log](https://github.com/apple/swift-log), and [swift-metrics](https://github.com/apple/swift-metrics)
 - Full librdkafka configuration exposed as typed Swift properties
 
-## Adding Kafka as a Dependency
+## Adding Kafka as a dependency
 
 To use the `Kafka` library in a SwiftPM project,
 add the following line to the dependencies in your `Package.swift` file:
@@ -114,7 +114,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
 The consumer delivers messages as an `AsyncSequence`. Iterate them with a standard `for try await` loop that integrates naturally with Swift concurrency, structured tasks, and cancellation:
 
-#### Consumer Groups
+#### Consumer groups
 
 ```swift
 var config = KafkaConsumerConfig()
@@ -140,7 +140,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 }
 ```
 
-#### At-Least-Once Processing
+#### At-least-once processing
 
 For at-least-once delivery semantics, disable automatic offset storage and manually store offsets after processing:
 
@@ -171,7 +171,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 }
 ```
 
-#### Manual Commits
+#### Manual commits
 
 To control exactly when offsets are committed to the broker:
 
@@ -207,7 +207,7 @@ To commit all previously stored offsets at once:
 try await consumer.commit()
 ```
 
-#### Dynamic Subscription Management
+#### Dynamic subscription management
 
 Change topics at runtime:
 
@@ -222,7 +222,7 @@ let topics = try consumer.subscribedTopics()
 try consumer.unsubscribe()
 ```
 
-#### Pause and Resume
+#### Pause and resume
 
 Pause and resume partition consumption temporarily, useful for applying backpressure or performing maintenance without leaving the consumer group:
 
@@ -233,7 +233,7 @@ try consumer.pause(topicPartitions: [partition])
 try consumer.resume(topicPartitions: [partition])
 ```
 
-### Security Mechanisms
+### Security mechanisms
 
 Configure both the `KafkaProducer` and the `KafkaConsumer` to use different security mechanisms via the `securityProtocol` property.
 
@@ -253,7 +253,7 @@ config.bootstrapServers = ["localhost:9092"]
 config.securityProtocol = .ssl
 ```
 
-#### SASL + Plaintext
+#### SASL + plaintext
 
 ```swift
 var config = KafkaProducerConfig()
@@ -275,7 +275,7 @@ config.saslUsername = "user"
 config.saslPassword = "password"
 ```
 
-### Error Handling
+### Error handling
 
 The events sequence surfaces errors from librdkafka with typed error codes:
 
@@ -307,7 +307,7 @@ Its source files are excluded in `Package.swift`.
 - **macOS**: `brew install openssl@3`
 - **Linux**: `apt-get install libssl-dev libsasl2-dev`
 
-## Development Setup
+## Development setup
 
 ### Running tests locally
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Swift Kafka Client library provides a convenient way to interact with [Apach
 
 ## Features
 
-- Async/await producer with awaitable delivery acknowledgements (`sendAndAwait`)
+- Async/await producer with awaitable delivery acknowledgments (`sendAndAwait`)
 - High-throughput fire-and-forget producer with batched delivery reports
 - `AsyncSequence`-based consumer with automatic rebalancing
 - At-least-once delivery semantics via manual offset storage
@@ -36,13 +36,13 @@ Finally, add `import Kafka` to your source code.
 
 ## Usage
 
-`Kafka` should be used within a [`Swift Service Lifecycle`](https://github.com/swift-server/swift-service-lifecycle)
+Run `Kafka` within a [`Swift Service Lifecycle`](https://github.com/swift-server/swift-service-lifecycle)
 [`ServiceGroup`](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/main/documentation/servicelifecycle/servicegroup) for proper startup and shutdown handling.
 Both the `KafkaProducer` and the `KafkaConsumer` implement the [`Service`](https://swiftpackageindex.com/swift-server/swift-service-lifecycle/main/documentation/servicelifecycle/service) protocol.
 
 ### Producer API
 
-The `sendAndAwait(_:)` method produces a message and asynchronously awaits broker acknowledgement — giving you confirmation of exactly which partition and offset your message landed at, without blocking any threads:
+The `sendAndAwait(_:)` method produces a message and asynchronously awaits broker acknowledgment, confirming the partition and offset where your message landed without blocking any threads:
 
 ```swift
 var config = KafkaProducerConfig()
@@ -72,7 +72,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 }
 ```
 
-For high-throughput pipelines where you need to maximize send rate, use the fire-and-forget `send(_:)` method and process delivery reports in batches through the events sequence:
+For high-throughput pipelines that need to maximize send rate, use the fire-and-forget `send(_:)` method and process delivery reports in batches through the events sequence:
 
 ```swift
 var config = KafkaProducerConfig()
@@ -100,7 +100,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
             switch event {
             case .deliveryReports(let reports):
                 for report in reports {
-                    // Handle delivery acknowledgement
+                    // Handle delivery acknowledgment
                 }
             default:
                 break
@@ -112,7 +112,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
 ### Consumer API
 
-Messages are delivered as an `AsyncSequence` — consume them with a standard `for try await` loop that integrates naturally with Swift concurrency, structured tasks, and cancellation:
+The consumer delivers messages as an `AsyncSequence`. Iterate them with a standard `for try await` loop that integrates naturally with Swift concurrency, structured tasks, and cancellation:
 
 #### Consumer Groups
 
@@ -165,7 +165,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
         for try await message in consumer.messages {
             // Process message...
             try consumer.storeOffset(message)
-            // Offset will be committed automatically by the background auto-commit timer
+            // The background auto-commit timer commits the offset automatically.
         }
     }
 }
@@ -209,7 +209,7 @@ try await consumer.commit()
 
 #### Dynamic Subscription Management
 
-Topics can be changed at runtime:
+Change topics at runtime:
 
 ```swift
 // Subscribe to additional topics
@@ -224,7 +224,7 @@ try consumer.unsubscribe()
 
 #### Pause and Resume
 
-Partition consumption can be temporarily paused and resumed, useful for applying backpressure or performing maintenance without leaving the consumer group:
+Pause and resume partition consumption temporarily, useful for applying backpressure or performing maintenance without leaving the consumer group:
 
 ```swift
 let partition = KafkaTopicPartition(topic: "topic-name", partition: KafkaPartition(rawValue: 0))
@@ -235,7 +235,7 @@ try consumer.resume(topicPartitions: [partition])
 
 ### Security Mechanisms
 
-Both the `KafkaProducer` and the `KafkaConsumer` can be configured to use different security mechanisms via the `securityProtocol` property.
+Configure both the `KafkaProducer` and the `KafkaConsumer` to use different security mechanisms via the `securityProtocol` property.
 
 #### Plaintext
 
@@ -277,7 +277,7 @@ config.saslPassword = "password"
 
 ### Error Handling
 
-Errors from librdkafka are surfaced through the events sequence with typed error codes:
+The events sequence surfaces errors from librdkafka with typed error codes:
 
 ```swift
 let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(config: config, logger: logger)
@@ -286,9 +286,9 @@ for await event in events {
     switch event {
     case .error(let error):
         if error.isFatal {
-            // Client is irrecoverable — initiate shutdown
+            // The client is irrecoverable — initiate shutdown.
         } else if error.isRetriable {
-            // Transient error — will likely resolve
+            // Transient error — likely resolves on its own.
         }
         print("Error: \(error)")
     default:
@@ -300,7 +300,7 @@ for await event in events {
 ## librdkafka
 
 The Package depends on [the `librdkafka` library](https://github.com/confluentinc/librdkafka), which is included as a git submodule.
-It has source files that are excluded in `Package.swift`.
+Its source files are excluded in `Package.swift`.
 
 ### Dependencies
 
@@ -311,7 +311,7 @@ It has source files that are excluded in `Package.swift`.
 
 ### Running tests locally
 
-Integration tests require a running Kafka broker which can be started with Docker:
+Integration tests require a running Kafka broker. Start one with Docker:
 
 ```shell
 docker run -d -p 9092:9092 apache/kafka:3.9.1
@@ -322,18 +322,18 @@ swift test
 
 ### Running tests in Docker
 
-We provide a Docker environment for this package. This will automatically start a local Kafka server and run the tests:
+The package provides a Docker environment that automatically starts a local Kafka server and runs the tests:
 
 ```shell
 docker compose -f docker/docker-compose.yaml run client swift test
 ```
 
-Alternatively you can use a `Makefile` target:
+Alternatively, use a `Makefile` target:
 ```shell
 make docker-test
 ```
 
-You can specify Swift compiler version using `SWIFT_VERSION` environment variable:
+Specify the Swift compiler version using the `SWIFT_VERSION` environment variable:
 ```shell
 SWIFT_VERSION=6.2 make docker-test
 ```

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
@@ -17,7 +17,7 @@ import Metrics
 extension KafkaConfiguration {
     // MARK: - Metrics
 
-    /// Configuration for the consumer metrics emitted by `SwiftKafka`.
+    /// Configuration for the consumer metrics that the Kafka client emits.
     public struct ConsumerMetrics: Sendable {
         internal var enabled: Bool {
             self.updateInterval != nil
@@ -77,7 +77,7 @@ extension KafkaConfiguration {
         }
     }
 
-    /// Configuration for the producer metrics emitted by `SwiftKafka`.
+    /// Configuration for the producer metrics that the Kafka client emits.
     public struct ProducerMetrics: Sendable {
         internal var enabled: Bool {
             self.updateInterval != nil

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
@@ -23,7 +23,7 @@ extension KafkaConfiguration {
             self.updateInterval != nil
                 && (self.queuedOperation != nil || self.totalKafkaBrokerRequests != nil
                     || self.totalKafkaBrokerBytesSent != nil || self.totalKafkaBrokerResponses != nil
-                    || self.totalKafkaBrokerResponsesSize != nil || self.totalKafkaBrokerMessagesBytesRecieved != nil
+                    || self.totalKafkaBrokerResponsesSize != nil || self.totalKafkaBrokerMessagesBytesReceived != nil
                     || self.topicsInMetadataCache != nil)
         }
 
@@ -43,9 +43,9 @@ extension KafkaConfiguration {
         public var totalKafkaBrokerResponsesSize: Gauge?
 
         /// Total number of messages consumed, not including ignored messages (due to offset, and so on), from Kafka brokers.
-        public var totalKafkaBrokerMessagesRecieved: Gauge?
+        public var totalKafkaBrokerMessagesReceived: Gauge?
         /// Total number of message bytes (including framing) received from Kafka brokers.
-        public var totalKafkaBrokerMessagesBytesRecieved: Gauge?
+        public var totalKafkaBrokerMessagesBytesReceived: Gauge?
 
         /// Number of topics in the metadata cache.
         public var topicsInMetadataCache: Gauge?
@@ -67,10 +67,10 @@ extension KafkaConfiguration {
             Self.record(rdKafkaStatistics.totalKafkaBrokerResponses, to: self.totalKafkaBrokerResponses)
             Self.record(rdKafkaStatistics.totalKafkaBrokerResponsesSize, to: self.totalKafkaBrokerResponsesSize)
 
-            Self.record(rdKafkaStatistics.totalKafkaBrokerMessagesRecieved, to: self.totalKafkaBrokerMessagesRecieved)
+            Self.record(rdKafkaStatistics.totalKafkaBrokerMessagesReceived, to: self.totalKafkaBrokerMessagesReceived)
             Self.record(
-                rdKafkaStatistics.totalKafkaBrokerMessagesBytesRecieved,
-                to: self.totalKafkaBrokerMessagesBytesRecieved
+                rdKafkaStatistics.totalKafkaBrokerMessagesBytesReceived,
+                to: self.totalKafkaBrokerMessagesBytesReceived
             )
 
             Self.record(rdKafkaStatistics.topicsInMetadataCache, to: self.topicsInMetadataCache)

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Metrics.swift
@@ -30,7 +30,7 @@ extension KafkaConfiguration {
         /// Update interval for statistics.
         public var updateInterval: Duration?
 
-        /// Number of operations (callbacks, events, etc) waiting in the queue.
+        /// Number of operations (callbacks, events, and so on) waiting in the queue.
         public var queuedOperation: Gauge?
 
         /// Total number of requests sent to Kafka brokers.
@@ -42,7 +42,7 @@ extension KafkaConfiguration {
         /// Total number of bytes received from Kafka brokers.
         public var totalKafkaBrokerResponsesSize: Gauge?
 
-        /// Total number of messages consumed, not including ignored messages (due to offset, etc), from Kafka brokers.
+        /// Total number of messages consumed, not including ignored messages (due to offset, and so on), from Kafka brokers.
         public var totalKafkaBrokerMessagesRecieved: Gauge?
         /// Total number of message bytes (including framing) received from Kafka brokers.
         public var totalKafkaBrokerMessagesBytesRecieved: Gauge?

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -99,6 +99,11 @@ extension KafkaConfiguration {
             /// The password associated with the private key.
             public var password: String
 
+            /// Creates a new private key reference from the given location and password.
+            ///
+            /// - Parameters:
+            ///   - location: The private key's location, either a file path or an inline PEM string.
+            ///   - password: The password associated with the private key.
             public init(location: Location, password: String) {
                 self.key = location
                 self.password = password
@@ -112,6 +117,11 @@ extension KafkaConfiguration {
             /// The key store's password.
             public var password: String
 
+            /// Creates a new key store reference from the given file location and password.
+            ///
+            /// - Parameters:
+            ///   - location: Path to the PKCS#12 key store.
+            ///   - password: The key store's password.
             public init(location: String, password: String) {
                 self.location = location
                 self.password = password
@@ -200,6 +210,9 @@ extension KafkaConfiguration {
             certificateRevocationListPath: nil
         )
 
+        /// Creates a new TLS configuration with default values.
+        ///
+        /// By default, no client identity is configured and the broker is verified using probed trust roots.
         public init() {}
 
         // MARK: TLSConfiguration + Dictionary
@@ -285,7 +298,9 @@ extension KafkaConfiguration {
                     self.rawValue = rawValue
                 }
 
-                /// (Lowest granularity is milliseconds)
+                /// Creates a minimum interval between key refresh attempts from the given duration.
+                ///
+                /// - Note: The lowest granularity is milliseconds.
                 public static func value(_ value: Duration) -> KeyRefreshAttempts {
                     precondition(
                         value.canBeRepresentedAsMilliseconds,
@@ -304,6 +319,9 @@ extension KafkaConfiguration {
             /// Default: `.value(.milliseconds(60000))`
             public var minTimeBeforeRelogin: KeyRefreshAttempts = .value(.milliseconds(60000))
 
+            /// Creates a new Kerberos configuration that authenticates using the given keytab.
+            ///
+            /// - Parameter keytab: Path to the Kerberos keytab file.
             public init(keytab: String) {
                 self.keytab = keytab
             }

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -51,7 +51,7 @@ extension KafkaConfiguration {
 
             let _internal: _TrustRoots
 
-            /// A list of standard paths will be probed and the first one found will be used as the default root certificate location path.
+            /// Probes a list of standard paths and uses the first one found as the default root certificate location.
             public static let probe = TrustRoots(_internal: .probe)
 
             /// File or directory path to root certificate(s) for verifying the broker's key.

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -19,7 +19,7 @@ extension KafkaConfiguration {
     public struct TLSConfiguration: Sendable, Hashable {
         /// Certificate chain consisting of one leaf certificate and potentially multiple intermediate certificates.
         ///
-        /// The public key of the leaf certificate will be used for authentication.
+        /// Authentication uses the public key of the leaf certificate.
         public struct LeafAndIntermediates: Sendable, Hashable {
             internal enum _Key: Sendable, Hashable {
                 case file(location: String)
@@ -280,7 +280,7 @@ extension KafkaConfiguration {
             public var serviceName: String = "kafka"
             /// This client's Kerberos principal name.
             ///
-            /// (Not supported on Windows, will use the logon user's principal).
+            /// (Not supported on Windows, uses the logon user's principal).
             ///
             /// Default: `"kafkaclient"`
             public var principal: String = "kafkaclient"
@@ -384,7 +384,7 @@ extension KafkaConfiguration {
             ///         For example: `principal=admin extension_traceId=123`
             ///     - clientID: Public identifier for the application. Must be unique across all clients that the authorization server handles.
             ///     - clientSecret: Client secret only known to the application and the authorization server.
-            ///     This should be a sufficiently random string that is not guessable.
+            ///     Use a sufficiently random string that isn't guessable.
             ///     - tokenEndPointURL: OAuth/OIDC issuer token endpoint HTTP(S) URI used to retrieve token.
             ///     - scope: The client uses this to specify the scope of the access request to the broker.
             ///     - extensions: Allow additional information to be provided to the broker.

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -82,7 +82,7 @@ extension KafkaConfiguration {
 
                 let _internal: _Location
 
-                /// A key located in a file at the given `location`.
+                /// A key loaded from a file at the path you provide.
                 public static func file(location: String) -> Location {
                     Location(
                         _internal: .file(location: location)
@@ -102,7 +102,7 @@ extension KafkaConfiguration {
             /// The password associated with the private key.
             public var password: String
 
-            /// Creates a new private key reference from the given location and password.
+            /// Creates a new private key reference from the location and password you provide.
             ///
             /// - Parameters:
             ///   - location: The private key's location, either a file path or an inline PEM string.
@@ -120,7 +120,7 @@ extension KafkaConfiguration {
             /// The key store's password.
             public var password: String
 
-            /// Creates a new key store reference from the given file location and password.
+            /// Creates a new key store reference from the file location and password you provide.
             ///
             /// - Parameters:
             ///   - location: Path to the PKCS#12 key store.
@@ -143,7 +143,7 @@ extension KafkaConfiguration {
 
             let _internal: _ClientIdentity
 
-            /// Use TLS client verification with a given private/public key pair.
+            /// Use TLS client verification with the private/public key pair you provide.
             ///
             /// - Parameters:
             ///     - privateKey: The client's private key (PEM) used for authentication.
@@ -160,7 +160,7 @@ extension KafkaConfiguration {
                 )
             }
 
-            /// Use TLS client verification with a given key store.
+            /// Use TLS client verification with the key store you provide.
             ///
             /// - Parameters:
             ///     - keyStore: The client's keystore (PKCS#12) used for authentication.
@@ -310,7 +310,7 @@ extension KafkaConfiguration {
                     self.rawValue = rawValue
                 }
 
-                /// Creates a minimum interval between key refresh attempts from the given duration.
+                /// Creates a minimum interval between key refresh attempts from the duration you provide.
                 ///
                 /// - Note: The lowest granularity is milliseconds.
                 public static func value(_ value: Duration) -> KeyRefreshAttempts {
@@ -333,7 +333,7 @@ extension KafkaConfiguration {
             /// Default: `.value(.milliseconds(60000))`
             public var minTimeBeforeRelogin: KeyRefreshAttempts = .value(.milliseconds(60000))
 
-            /// Creates a new Kerberos configuration that authenticates using the given keytab.
+            /// Creates a new Kerberos configuration that authenticates using the keytab you provide.
             ///
             /// - Parameter keytab: Path to the Kerberos keytab file.
             public init(keytab: String) {

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -15,7 +15,7 @@
 extension KafkaConfiguration {
     // MARK: - TLSConfiguration
 
-    /// Use to configure a TLS connection.
+    /// A configuration for a TLS connection.
     public struct TLSConfiguration: Sendable, Hashable {
         /// Certificate chain consisting of one leaf certificate and potentially multiple intermediate certificates.
         /// The public key of the leaf certificate will be used for authentication.
@@ -69,7 +69,7 @@ extension KafkaConfiguration {
             }
         }
 
-        /// A TLS private key.
+        /// A TLS private key with its associated password.
         public struct PrivateKey: Sendable, Hashable {
             public struct Location: Sendable, Hashable {
                 internal enum _Location: Sendable, Hashable {
@@ -105,7 +105,7 @@ extension KafkaConfiguration {
             }
         }
 
-        /// A TLS key store (PKCS#12).
+        /// A TLS key store in PKCS#12 format.
         public struct KeyStore: Sendable, Hashable {
             /// Path to the key store.
             public var location: String
@@ -254,7 +254,7 @@ extension KafkaConfiguration {
 
     // MARK: - SASLMechanism
 
-    /// Available SASL mechanisms that can be used for authentication.
+    /// SASL mechanisms available for authentication.
     public struct SASLMechanism: Sendable, Hashable {
         /// Used to configure Kerberos.
         public struct KerberosConfiguration: Sendable, Hashable {
@@ -483,7 +483,7 @@ extension KafkaConfiguration {
 
     // MARK: - SecurityProtocol
 
-    /// Protocol used to communicate with brokers.
+    /// The protocol the client uses to communicate with brokers.
     public struct SecurityProtocol: Sendable, Hashable {
         internal enum _SecurityProtocol: Sendable, Hashable {
             case plaintext
@@ -494,7 +494,7 @@ extension KafkaConfiguration {
 
         private let _internal: _SecurityProtocol
 
-        /// Send messages as plaintext (no security protocol used).
+        /// Sends messages as plaintext without any security protocol.
         public static let plaintext = SecurityProtocol(
             _internal: .plaintext
         )

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -194,7 +194,7 @@ extension KafkaConfiguration {
         public var clientIdentity: ClientIdentity? = nil
 
         /// Configuration for the TLS verification of the broker.
-        /// Default:  `verify(trustRoots: .probe, certificateRevocationListPath: nil)``
+        /// Default: `.verify(trustRoots: .probe, certificateRevocationListPath: nil)`
         public var brokerVerification: BrokerVerification = .verify(
             trustRoots: .probe,
             certificateRevocationListPath: nil
@@ -358,7 +358,7 @@ extension KafkaConfiguration {
             ///     - tokenEndPointURL: OAuth/OIDC issuer token endpoint HTTP(S) URI used to retrieve token.
             ///     - scope: The client uses this to specify the scope of the access request to the broker.
             ///     - extensions: Allow additional information to be provided to the broker.
-            ///     Comma-separated list of key=value pairs. E.g., "supportFeatureX=true,organizationId=sales-emea".
+            ///     Comma-separated list of key=value pairs. For example, "supportFeatureX=true,organizationId=sales-emea".
             static func oidc(
                 configuration: String? = nil,
                 clientID: String,

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -43,6 +43,7 @@ extension KafkaConfiguration {
             }
         }
 
+        /// A set of trust roots used to verify the broker's TLS certificate.
         public struct TrustRoots: Sendable, Hashable {
             internal enum _TrustRoots: Sendable, Hashable {
                 case probe
@@ -72,6 +73,7 @@ extension KafkaConfiguration {
 
         /// A TLS private key with its associated password.
         public struct PrivateKey: Sendable, Hashable {
+            /// The source of a TLS private key, either a file path or an inline PEM string.
             public struct Location: Sendable, Hashable {
                 internal enum _Location: Sendable, Hashable {
                     case file(location: String)

--- a/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration+Security.swift
@@ -18,6 +18,7 @@ extension KafkaConfiguration {
     /// A configuration for a TLS connection.
     public struct TLSConfiguration: Sendable, Hashable {
         /// Certificate chain consisting of one leaf certificate and potentially multiple intermediate certificates.
+        ///
         /// The public key of the leaf certificate will be used for authentication.
         public struct LeafAndIntermediates: Sendable, Hashable {
             internal enum _Key: Sendable, Hashable {
@@ -200,10 +201,12 @@ extension KafkaConfiguration {
         }
 
         /// Configuration for the TLS verification of the client.
+        ///
         /// Default: `nil`
         public var clientIdentity: ClientIdentity? = nil
 
         /// Configuration for the TLS verification of the broker.
+        ///
         /// Default: `.verify(trustRoots: .probe, certificateRevocationListPath: nil)`
         public var brokerVerification: BrokerVerification = .verify(
             trustRoots: .probe,
@@ -272,20 +275,27 @@ extension KafkaConfiguration {
         /// Used to configure Kerberos.
         public struct KerberosConfiguration: Sendable, Hashable {
             /// Kerberos principal name that Kafka runs as, not including `/hostname@REALM`.
+            ///
             /// Default: `"kafka"`
             public var serviceName: String = "kafka"
-            /// This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+            /// This client's Kerberos principal name.
+            ///
+            /// (Not supported on Windows, will use the logon user's principal).
+            ///
             /// Default: `"kafkaclient"`
             public var principal: String = "kafkaclient"
             /// Shell command to refresh or acquire the client's Kerberos ticket.
+            ///
             /// This command is executed on client creation and every ``KafkaConfiguration/SASLMechanism/KerberosConfiguration/minTimeBeforeRelogin``.
             /// %{config.prop.name} is replaced by corresponding config object value.
+            ///
             /// Default: `kinit -R -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal} || kinit -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal}"`.
             public var kinitCommand: String = """
                 kinit -R -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal} || \
                 kinit -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal}"
                 """
             /// Path to Kerberos keytab file.
+            ///
             /// This configuration property is only used as a variable in ``KafkaConfiguration/SASLMechanism/KerberosConfiguration/kinitCommand``
             /// as  ... -t "%{sasl.kerberos.keytab}".
             public var keytab: String
@@ -314,8 +324,10 @@ extension KafkaConfiguration {
             }
 
             /// Minimum time in between key refresh attempts.
+            ///
             /// Disable automatic key refresh by setting this property to 0.
             /// (Lowest granularity is milliseconds)
+            ///
             /// Default: `.value(.milliseconds(60000))`
             public var minTimeBeforeRelogin: KeyRefreshAttempts = .value(.milliseconds(60000))
 

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -42,7 +42,7 @@ public enum KafkaConfiguration {
         /// Default: `1_000_000`
         public var maximumBytes: Int = 1_000_000
 
-        /// Maximum size for a message to be copied to buffer. Messages larger than this will be passed by reference (zero-copy) at the expense of larger iovecs.
+        /// Maximum size for a message to be copied to buffer. Messages larger than this are passed by reference (zero-copy) at the expense of larger iovecs.
         /// Default: `65535`
         public var maximumBytesToCopy: Int = 65535
 
@@ -73,11 +73,11 @@ public enum KafkaConfiguration {
         }
 
         /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions, or partition leader changes.
-        /// If there are no locally referenced topics (no topic objects created, no messages produced, no subscription, or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.
+        /// If there are no locally referenced topics (no topic objects created, no messages produced, no subscription, or no assignment) then only the broker list is refreshed every interval but no more often than every 10s.
         /// Default: `.interval(.milliseconds(300_000))`
         public var refreshInterval: RefreshInterval = .interval(.milliseconds(300_000))
 
-        /// When a topic loses its leader a new metadata request will be enqueued with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+        /// When a topic loses its leader, the client enqueues a new metadata request with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
         /// Default: `.milliseconds(250)`
         public var refreshFastInterval: Duration = .milliseconds(250) {
             didSet {
@@ -92,7 +92,7 @@ public enum KafkaConfiguration {
         /// Default: `true`
         public var isSparseRefreshingEnabled: Bool = true
 
-        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be nonexistent and the client will mark the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as nonexistent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, for example, on `send()`.
+        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic seems nonexistent and the client marks the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as nonexistent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, for example, on `send()`.
         /// Default: `.milliseconds(30000)`
         public var maximumPropagation: Duration = .milliseconds(30000) {
             didSet {
@@ -108,7 +108,7 @@ public enum KafkaConfiguration {
 
     /// Socket options.
     public struct SocketOptions: Sendable, Hashable {
-        /// Default timeout for network requests. Producer: ProduceRequests will use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
+        /// Default timeout for network requests. Producer: ProduceRequests use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
         /// and remaining ``KafkaTopicConfiguration/messageTimeout``for the first message in the batch.
         /// Default: `.milliseconds(60000)`
         public var timeout: Duration = .milliseconds(60000) {
@@ -176,7 +176,7 @@ public enum KafkaConfiguration {
         public var maximumFailures: MaximumFailures = .failures(1)
 
         /// Maximum time allowed for broker connection setup (TCP connection setup as well SSL and SASL handshake).
-        /// If the connection to the broker is not fully functional after this the connection will be closed and retried.
+        /// If the connection to the broker is not fully functional after this, the client closes and retries the connection.
         /// Default: `.milliseconds(30000)`
         public var connectionSetupTimeout: Duration = .milliseconds(30000)
 

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Collection of types used in the configuration structs this library provides.
+/// A namespace of types used in the library's configuration structs.
 public enum KafkaConfiguration {
     /// The address of a Kafka broker.
     public struct BrokerAddress: Sendable, Hashable, CustomStringConvertible {
@@ -35,7 +35,7 @@ public enum KafkaConfiguration {
         }
     }
 
-    /// Message options.
+    /// Options that govern Kafka message size and copy behavior.
     public struct MessageOptions: Sendable, Hashable {
         /// Maximum Kafka protocol request message size. Due to differing framing overhead between protocol versions, the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests.
         /// The broker will enforce the topic's `max.message.bytes` limit [(see Apache Kafka documentation)](https://kafka.apache.org/documentation/#brokerconfigs_message.max.bytes).
@@ -49,7 +49,7 @@ public enum KafkaConfiguration {
         public init() {}
     }
 
-    /// Topic metadata options.
+    /// Options that control how the client refreshes topic and broker metadata.
     public struct TopicMetadataOptions: Sendable, Hashable {
         /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions, or partition leader changes.
         public struct RefreshInterval: Sendable, Hashable {
@@ -106,7 +106,7 @@ public enum KafkaConfiguration {
         public init() {}
     }
 
-    /// Socket options.
+    /// Options that configure socket-level networking behavior.
     public struct SocketOptions: Sendable, Hashable {
         /// Default timeout for network requests. Producer: ProduceRequests use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
         /// and remaining ``KafkaTopicConfiguration/messageTimeout``for the first message in the batch.
@@ -183,7 +183,7 @@ public enum KafkaConfiguration {
         public init() {}
     }
 
-    /// Broker options.
+    /// Options that configure broker connection behavior.
     public struct BrokerOptions: Sendable, Hashable {
         /// How long to cache the broker address resolving results.
         /// (Lowest granularity is milliseconds)
@@ -204,7 +204,7 @@ public enum KafkaConfiguration {
         public init() {}
     }
 
-    /// Reconnect options.
+    /// Options that control reconnection backoff after a broker connection drops.
     public struct ReconnectOptions: Sendable, Hashable {
         /// The initial time to wait before reconnecting to a broker after the connection has been closed.
         public struct Backoff: Sendable, Hashable {

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -45,8 +45,8 @@ public enum KafkaConfiguration {
     public struct MessageOptions: Sendable, Hashable {
         /// Maximum Kafka protocol request message size.
         ///
-        /// Due to differing framing overhead between protocol versions, the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests.
-        /// The broker will enforce the topic's `max.message.bytes` limit [(see Apache Kafka documentation)](https://kafka.apache.org/documentation/#brokerconfigs_message.max.bytes).
+        /// Due to differing framing overhead between protocol versions, the producer can't reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests.
+        /// The broker enforces the topic's `max.message.bytes` limit [(see Apache Kafka documentation)](https://kafka.apache.org/documentation/#brokerconfigs_message.max.bytes).
         ///
         /// Default: `1_000_000`
         public var maximumBytes: Int = 1_000_000
@@ -96,7 +96,7 @@ public enum KafkaConfiguration {
 
         /// When a topic loses its leader, the client enqueues a new metadata request with this initial interval, exponentially increasing until the topic metadata has been refreshed.
         ///
-        /// This is used to recover quickly from transitioning leader brokers.
+        /// This setting helps recover quickly from transitioning leader brokers.
         ///
         /// Default: `.milliseconds(250)`
         public var refreshFastInterval: Duration = .milliseconds(250) {

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -43,12 +43,18 @@ public enum KafkaConfiguration {
 
     /// Options that govern Kafka message size and copy behavior.
     public struct MessageOptions: Sendable, Hashable {
-        /// Maximum Kafka protocol request message size. Due to differing framing overhead between protocol versions, the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests.
+        /// Maximum Kafka protocol request message size.
+        ///
+        /// Due to differing framing overhead between protocol versions, the producer is unable to reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests.
         /// The broker will enforce the topic's `max.message.bytes` limit [(see Apache Kafka documentation)](https://kafka.apache.org/documentation/#brokerconfigs_message.max.bytes).
+        ///
         /// Default: `1_000_000`
         public var maximumBytes: Int = 1_000_000
 
-        /// Maximum size for a message to be copied to buffer. Messages larger than this are passed by reference (zero-copy) at the expense of larger iovecs.
+        /// Maximum size for a message to be copied to buffer.
+        ///
+        /// Messages larger than this are passed by reference (zero-copy) at the expense of larger iovecs.
+        ///
         /// Default: `65535`
         public var maximumBytesToCopy: Int = 65535
 
@@ -82,11 +88,16 @@ public enum KafkaConfiguration {
         }
 
         /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions, or partition leader changes.
+        ///
         /// If there are no locally referenced topics (no topic objects created, no messages produced, no subscription, or no assignment) then only the broker list is refreshed every interval but no more often than every 10s.
+        ///
         /// Default: `.interval(.milliseconds(300_000))`
         public var refreshInterval: RefreshInterval = .interval(.milliseconds(300_000))
 
-        /// When a topic loses its leader, the client enqueues a new metadata request with this initial interval, exponentially increasing until the topic metadata has been refreshed. This is used to recover quickly from transitioning leader brokers.
+        /// When a topic loses its leader, the client enqueues a new metadata request with this initial interval, exponentially increasing until the topic metadata has been refreshed.
+        ///
+        /// This is used to recover quickly from transitioning leader brokers.
+        ///
         /// Default: `.milliseconds(250)`
         public var refreshFastInterval: Duration = .milliseconds(250) {
             didSet {
@@ -98,10 +109,14 @@ public enum KafkaConfiguration {
         }
 
         /// Sparse metadata requests (consumes less network bandwidth).
+        ///
         /// Default: `true`
         public var isSparseRefreshingEnabled: Bool = true
 
-        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic seems nonexistent and the client marks the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as nonexistent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, for example, on `send()`.
+        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers.
+        ///
+        /// If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic seems nonexistent and the client marks the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as nonexistent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, for example, on `send()`.
+        ///
         /// Default: `.milliseconds(30000)`
         public var maximumPropagation: Duration = .milliseconds(30000) {
             didSet {
@@ -118,8 +133,11 @@ public enum KafkaConfiguration {
 
     /// Options that configure socket-level networking behavior.
     public struct SocketOptions: Sendable, Hashable {
-        /// Default timeout for network requests. Producer: ProduceRequests use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
-        /// and remaining ``KafkaTopicConfiguration/messageTimeout``for the first message in the batch.
+        /// Default timeout for network requests.
+        ///
+        /// Producer: ProduceRequests use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
+        /// and remaining ``KafkaTopicConfiguration/messageTimeout`` for the first message in the batch.
+        ///
         /// Default: `.milliseconds(60000)`
         public var timeout: Duration = .milliseconds(60000) {
             didSet {
@@ -148,18 +166,22 @@ public enum KafkaConfiguration {
         }
 
         /// Broker socket send buffer size.
+        ///
         /// Default: `.systemDefault`
         public var sendBufferBytes: BufferSize = .systemDefault
 
         /// Broker socket receive buffer size.
+        ///
         /// Default: `.systemDefault`
         public var receiveBufferBytes: BufferSize = .systemDefault
 
         /// Enable TCP keep-alives (SO_KEEPALIVE) on broker sockets.
+        ///
         /// Default: `false`
         public var isKeepaliveEnabled: Bool = false
 
         /// Disable the Nagle algorithm (TCP_NODELAY) on broker sockets.
+        ///
         /// Default: `false`
         public var isNagleDisabled: Bool = false
 
@@ -184,11 +206,14 @@ public enum KafkaConfiguration {
         ///
         /// - Warning: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker becoming desynchronized in case of request timeouts.
         /// - Note: The connection is automatically re-established.
+        ///
         /// Default: `.failures(1)`
         public var maximumFailures: MaximumFailures = .failures(1)
 
         /// Maximum time allowed for broker connection setup (TCP connection setup as well SSL and SASL handshake).
+        ///
         /// If the connection to the broker is not fully functional after this, the client closes and retries the connection.
+        ///
         /// Default: `.milliseconds(30000)`
         public var connectionSetupTimeout: Duration = .milliseconds(30000)
 
@@ -199,7 +224,9 @@ public enum KafkaConfiguration {
     /// Options that configure broker connection behavior.
     public struct BrokerOptions: Sendable, Hashable {
         /// How long to cache the broker address resolving results.
+        ///
         /// (Lowest granularity is milliseconds)
+        ///
         /// Default: `.milliseconds(1000)`
         public var addressTimeToLive: Duration = .milliseconds(1000) {
             didSet {
@@ -211,6 +238,7 @@ public enum KafkaConfiguration {
         }
 
         /// Allowed broker ``KafkaConfiguration/IPAddressFamily``.
+        ///
         /// Default: `.any`
         public var addressFamily: IPAddressFamily = .any
 
@@ -244,12 +272,15 @@ public enum KafkaConfiguration {
         }
 
         /// The initial time to wait before reconnecting to a broker after the connection has been closed.
+        ///
         /// The time is increased exponentially until ``KafkaConfiguration/ReconnectOptions/maximumBackoff`` is reached.
         /// -25% to +50% jitter is applied to each reconnect backoff.
+        ///
         /// Default: `.backoff(.milliseconds(100))`
         public var backoff: Backoff = .backoff(.milliseconds(100))
 
         /// The maximum time to wait before reconnecting to a broker after the connection has been closed.
+        ///
         /// Default: `.milliseconds(10000)`
         public var maximumBackoff: Duration = .milliseconds(10000) {
             didSet {

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -51,7 +51,7 @@ public enum KafkaConfiguration {
 
     /// Topic metadata options.
     public struct TopicMetadataOptions: Sendable, Hashable {
-        /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions or partition leader changes.
+        /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions, or partition leader changes.
         public struct RefreshInterval: Sendable, Hashable {
             internal let rawValue: Int
 
@@ -72,8 +72,8 @@ public enum KafkaConfiguration {
             public static let disabled: RefreshInterval = .init(rawValue: -1)
         }
 
-        /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions or partition leader changes.
-        /// If there are no locally referenced topics (no topic objects created, no messages produced, no subscription or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.
+        /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions, or partition leader changes.
+        /// If there are no locally referenced topics (no topic objects created, no messages produced, no subscription, or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.
         /// Default: `.interval(.milliseconds(300_000))`
         public var refreshInterval: RefreshInterval = .interval(.milliseconds(300_000))
 
@@ -92,7 +92,7 @@ public enum KafkaConfiguration {
         /// Default: `true`
         public var isSparseRefreshingEnabled: Bool = true
 
-        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be non-existent and the client will mark the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as non-existent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, e.g., on `send()`.
+        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers. If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic will seem to be nonexistent and the client will mark the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as nonexistent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, for example, on `send()`.
         /// Default: `.milliseconds(30000)`
         public var maximumPropagation: Duration = .milliseconds(30000) {
             didSet {
@@ -152,7 +152,7 @@ public enum KafkaConfiguration {
         /// Default: `false`
         public var isNagleDisabled: Bool = false
 
-        /// Disconnect from the broker when this number of send failures (e.g., timed-out requests) is reached.
+        /// Disconnect from the broker when this number of send failures (for example, timed-out requests) is reached.
         public struct MaximumFailures: Sendable, Hashable {
             internal let rawValue: Int
 
@@ -168,7 +168,7 @@ public enum KafkaConfiguration {
             public static let disabled: MaximumFailures = .init(rawValue: 0)
         }
 
-        /// Disconnect from the broker when this number of send failures (e.g., timed-out requests) is reached.
+        /// Disconnect from the broker when this number of send failures (for example, timed-out requests) is reached.
         ///
         /// - Warning: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker becoming desynchronized in case of request timeouts.
         /// - Note: The connection is automatically re-established.
@@ -228,7 +228,7 @@ public enum KafkaConfiguration {
         }
 
         /// The initial time to wait before reconnecting to a broker after the connection has been closed.
-        /// The time is increased exponentially until ``KafkaConfiguration/ReconnectOptions/maximumBackoff``is reached.
+        /// The time is increased exponentially until ``KafkaConfiguration/ReconnectOptions/maximumBackoff`` is reached.
         /// -25% to +50% jitter is applied to each reconnect backoff.
         /// Default: `.backoff(.milliseconds(100))`
         public var backoff: Backoff = .backoff(.milliseconds(100))

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -22,10 +22,16 @@ public enum KafkaConfiguration {
         /// The port to connect to.
         public var port: Int
 
+        /// A textual representation of the broker address in `host:port` form.
         public var description: String {
             "\(self.host):\(self.port)"
         }
 
+        /// Creates a new broker address from a host and port.
+        ///
+        /// - Parameters:
+        ///   - host: The host component of the broker address.
+        ///   - port: The port to connect to.
         public init(
             host: String,
             port: Int
@@ -46,6 +52,7 @@ public enum KafkaConfiguration {
         /// Default: `65535`
         public var maximumBytesToCopy: Int = 65535
 
+        /// Creates a new set of message options with default values.
         public init() {}
     }
 
@@ -59,7 +66,9 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// (Lowest granularity is milliseconds)
+            /// Creates a refresh interval for the given duration.
+            ///
+            /// - Note: The lowest granularity is milliseconds.
             public static func interval(_ value: Duration) -> RefreshInterval {
                 precondition(
                     value.canBeRepresentedAsMilliseconds,
@@ -103,6 +112,7 @@ public enum KafkaConfiguration {
             }
         }
 
+        /// Creates a new set of topic metadata options with default values.
         public init() {}
     }
 
@@ -128,6 +138,7 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
+            /// Creates a buffer size of the given number of bytes.
             public static func value(_ value: Int) -> BufferSize {
                 .init(rawValue: value)
             }
@@ -160,6 +171,7 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
+            /// Creates a maximum-failures threshold from the given number of send failures.
             public static func failures(_ value: Int) -> MaximumFailures {
                 .init(rawValue: value)
             }
@@ -180,6 +192,7 @@ public enum KafkaConfiguration {
         /// Default: `.milliseconds(30000)`
         public var connectionSetupTimeout: Duration = .milliseconds(30000)
 
+        /// Creates a new set of socket options with default values.
         public init() {}
     }
 
@@ -201,6 +214,7 @@ public enum KafkaConfiguration {
         /// Default: `.any`
         public var addressFamily: IPAddressFamily = .any
 
+        /// Creates a new set of broker options with default values.
         public init() {}
     }
 
@@ -214,7 +228,9 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// (Lowest granularity is milliseconds)
+            /// Creates a reconnect backoff for the given duration.
+            ///
+            /// - Note: The lowest granularity is milliseconds.
             public static func backoff(_ value: Duration) -> Backoff {
                 precondition(
                     value.canBeRepresentedAsMilliseconds,
@@ -244,6 +260,7 @@ public enum KafkaConfiguration {
             }
         }
 
+        /// Creates a new set of reconnect options with default values.
         public init() {}
     }
 
@@ -251,29 +268,48 @@ public enum KafkaConfiguration {
 
     /// Available debug contexts to enable.
     public struct DebugOption: Sendable, Hashable, CustomStringConvertible {
+        /// A textual representation of the debug context, suitable for librdkafka's `debug` setting.
         public let description: String
 
+        /// Enables debug logging for generic, non-categorized client events.
         public static let generic = DebugOption(description: "generic")
+        /// Enables debug logging for broker connection and communication events.
         public static let broker = DebugOption(description: "broker")
+        /// Enables debug logging for topic-level operations and state changes.
         public static let topic = DebugOption(description: "topic")
+        /// Enables debug logging for cluster metadata requests and updates.
         public static let metadata = DebugOption(description: "metadata")
+        /// Enables debug logging for protocol feature negotiation with brokers.
         public static let feature = DebugOption(description: "feature")
+        /// Enables debug logging for internal message queue operations.
         public static let queue = DebugOption(description: "queue")
+        /// Enables debug logging for individual message production and delivery.
         public static let msg = DebugOption(description: "msg")
+        /// Enables debug logging for the Kafka wire protocol exchanges.
         public static let `protocol` = DebugOption(description: "protocol")
+        /// Enables debug logging for consumer group coordination and rebalances.
         public static let cgrp = DebugOption(description: "cgrp")
+        /// Enables debug logging for security, authentication, and TLS handshake events.
         public static let security = DebugOption(description: "security")
+        /// Enables debug logging for consumer fetch requests and responses.
         public static let fetch = DebugOption(description: "fetch")
+        /// Enables debug logging for client interceptor invocations.
         public static let interceptor = DebugOption(description: "interceptor")
+        /// Enables debug logging for plugin loading and lifecycle events.
         public static let plugin = DebugOption(description: "plugin")
+        /// Enables debug logging for high-level consumer operations.
         public static let consumer = DebugOption(description: "consumer")
+        /// Enables debug logging for administrative API requests.
         public static let admin = DebugOption(description: "admin")
+        /// Enables debug logging for exactly-once semantics, including the idempotent and transactional producer.
         public static let eos = DebugOption(description: "eos")
+        /// Enables debug logging for every available context.
         public static let all = DebugOption(description: "all")
     }
 
     /// Available IP address families.
     public struct IPAddressFamily: Sendable, Hashable, CustomStringConvertible {
+        /// A textual representation of the IP address family.
         public let description: String
 
         /// Use any IP address family.

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -244,6 +244,8 @@ public enum KafkaConfiguration {
 
         /// The IP address family the broker is allowed to use.
         ///
+        /// See ``KafkaConfiguration/IPAddressFamily`` for the available values.
+        ///
         /// Default: `.any`
         public var addressFamily: IPAddressFamily = .any
 

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -45,7 +45,7 @@ public enum KafkaConfiguration {
     public struct MessageOptions: Sendable, Hashable {
         /// Maximum Kafka protocol request message size.
         ///
-        /// Due to differing framing overhead between protocol versions, the producer can't reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol ProduceRequests.
+        /// Due to differing framing overhead between protocol versions, the producer can't reliably enforce a strict max message limit at produce time and may exceed the maximum size by one message in protocol `ProduceRequest`s.
         /// The broker enforces the topic's `max.message.bytes` limit [(see Apache Kafka documentation)](https://kafka.apache.org/documentation/#brokerconfigs_message.max.bytes).
         ///
         /// Default: `1_000_000`
@@ -64,7 +64,9 @@ public enum KafkaConfiguration {
 
     /// Options that control how the client refreshes topic and broker metadata.
     public struct TopicMetadataOptions: Sendable, Hashable {
-        /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions, or partition leader changes.
+        /// The interval at which the client refreshes topic and broker metadata.
+        ///
+        /// Periodic refreshes proactively discover new brokers, topics, partitions, and partition leader changes.
         public struct RefreshInterval: Sendable, Hashable {
             internal let rawValue: Int
 
@@ -72,7 +74,7 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// Creates a refresh interval for the given duration.
+            /// Creates a refresh interval for the duration you provide.
             ///
             /// - Note: The lowest granularity is milliseconds.
             public static func interval(_ value: Duration) -> RefreshInterval {
@@ -87,8 +89,9 @@ public enum KafkaConfiguration {
             public static let disabled: RefreshInterval = .init(rawValue: -1)
         }
 
-        /// Period of time at which topic and broker metadata is refreshed to proactively discover any new brokers, topics, partitions, or partition leader changes.
+        /// The interval at which topic and broker metadata is refreshed.
         ///
+        /// Periodic refreshes proactively discover new brokers, topics, partitions, and partition leader changes.
         /// If there are no locally referenced topics (no topic objects created, no messages produced, no subscription, or no assignment) then only the broker list is refreshed every interval but no more often than every 10s.
         ///
         /// Default: `.interval(.milliseconds(300_000))`
@@ -113,9 +116,11 @@ public enum KafkaConfiguration {
         /// Default: `true`
         public var isSparseRefreshingEnabled: Bool = true
 
-        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate throughout the cluster to all brokers.
+        /// Apache Kafka topic creation is asynchronous and it takes some time for a new topic to propagate to all brokers.
         ///
-        /// If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic seems nonexistent and the client marks the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC. This setting delays marking a topic as nonexistent until the configured propagation max time has passed. The maximum propagation time is calculated from the time the topic is first referenced in the client, for example, on `send()`.
+        /// If a client requests topic metadata after manual topic creation but before the topic has been fully propagated to the broker the client is requesting metadata from, the topic seems nonexistent and the client marks the topic as such, failing queued produced messages with ERR__UNKNOWN_TOPIC.
+        /// This setting delays marking a topic as nonexistent until the configured propagation max time has passed.
+        /// The maximum propagation time is calculated from the time the topic is first referenced in the client, for example, on `send()`.
         ///
         /// Default: `.milliseconds(30000)`
         public var maximumPropagation: Duration = .milliseconds(30000) {
@@ -135,7 +140,7 @@ public enum KafkaConfiguration {
     public struct SocketOptions: Sendable, Hashable {
         /// Default timeout for network requests.
         ///
-        /// Producer: ProduceRequests use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
+        /// Producer: `ProduceRequest`s use the lesser value of ``KafkaConfiguration/SocketOptions/timeout``
         /// and remaining ``KafkaTopicConfiguration/messageTimeout`` for the first message in the batch.
         ///
         /// Default: `.milliseconds(60000)`
@@ -156,7 +161,7 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// Creates a buffer size of the given number of bytes.
+            /// Creates a buffer size from the number of bytes you provide.
             public static func value(_ value: Int) -> BufferSize {
                 .init(rawValue: value)
             }
@@ -193,7 +198,7 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// Creates a maximum-failures threshold from the given number of send failures.
+            /// Creates a maximum-failures threshold from the number of send failures you provide.
             public static func failures(_ value: Int) -> MaximumFailures {
                 .init(rawValue: value)
             }
@@ -237,7 +242,7 @@ public enum KafkaConfiguration {
             }
         }
 
-        /// Allowed broker ``KafkaConfiguration/IPAddressFamily``.
+        /// The IP address family the broker is allowed to use.
         ///
         /// Default: `.any`
         public var addressFamily: IPAddressFamily = .any
@@ -256,7 +261,7 @@ public enum KafkaConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// Creates a reconnect backoff for the given duration.
+            /// Creates a reconnect backoff for the duration you provide.
             ///
             /// - Note: The lowest granularity is milliseconds.
             public static func backoff(_ value: Duration) -> Backoff {

--- a/Sources/Kafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConfiguration.swift
@@ -152,7 +152,7 @@ public enum KafkaConfiguration {
         /// Default: `false`
         public var isNagleDisabled: Bool = false
 
-        /// Disconnect from the broker when this number of send failures (for example, timed-out requests) is reached.
+        /// Disconnects from the broker after this number of send failures (for example, timed-out requests).
         public struct MaximumFailures: Sendable, Hashable {
             internal let rawValue: Int
 
@@ -168,7 +168,7 @@ public enum KafkaConfiguration {
             public static let disabled: MaximumFailures = .init(rawValue: 0)
         }
 
-        /// Disconnect from the broker when this number of send failures (for example, timed-out requests) is reached.
+        /// Disconnects from the broker after this number of send failures (for example, timed-out requests).
         ///
         /// - Warning: It is highly recommended to leave this setting at its default value of 1 to avoid the client and broker becoming desynchronized in case of request timeouts.
         /// - Note: The connection is automatically re-established.

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -14,6 +14,7 @@
 
 import struct Foundation.UUID
 
+/// Configuration values that control a `KafkaConsumer` instance.
 public struct KafkaConsumerConfiguration {
     // MARK: - Kafka-specific Config properties
 

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -131,7 +131,7 @@ public struct KafkaConsumerConfiguration {
     /// The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
     ///
     /// When set to `false`, the application must explicitly call ``KafkaConsumer/storeOffset(_:)``
-    /// after processing each message. This is the **recommended pattern** for at-least-once delivery
+    /// after processing each message. This is the recommended pattern for at-least-once delivery
     /// semantics — it prevents offsets from being committed for unprocessed messages.
     ///
     /// Default: `true`

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -42,9 +42,9 @@ public struct KafkaConsumerConfiguration {
         ///
         /// - Parameters:
         ///     - partition: The partition of the topic to consume from.
-        ///     - groupID: The ID of the consumer group to commit to. Defaults to no group ID. Specifying a group ID is useful if partitions assignment is manually managed but committed offsets should still be tracked in a consumer group.
+        ///     - groupID: The ID of the consumer group to commit to. Defaults to no group ID. Specifying a group ID is useful when manually managing partition assignment but still tracking committed offsets in a consumer group.
         ///     - topic: The name of the Kafka topic.
-        ///     - offset: The offset to start consuming from. Defaults to the end of the Kafka partition queue (meaning wait for the next produced message).
+        ///     - offset: The offset to start consuming from. Defaults to the end of the Kafka partition queue (waits for the next produced message).
         public static func partition(
             _ partition: KafkaPartition,
             groupID: String? = nil,
@@ -112,9 +112,9 @@ public struct KafkaConsumerConfiguration {
 
     /// Maximum allowed time between calls to consume messages.
     ///
-    /// If this interval is exceeded, the consumer is considered failed and the group rebalances to reassign the partitions to another consumer group member.
+    /// If this interval is exceeded, the group considers the consumer failed and rebalances to reassign the partitions to another consumer group member.
     ///
-    /// - Warning: Offset commits may be not possible at this point.
+    /// - Warning: Offset commits may not be possible at this point.
     ///
     /// The interval is checked two times per second. See KIP-62 for more information.
     ///
@@ -227,7 +227,7 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// The maximum amount of time the server will block before answering the fetch request when there isn’t sufficient data to immediately satisfy the requirement given by `fetch.min.bytes`.
+    /// The maximum amount of time the server blocks before answering the fetch request when there isn't sufficient data to immediately satisfy the requirement given by `fetch.min.bytes`.
     ///
     /// Default: `.milliseconds(500)`
     public var maximumFetchWaitTime: Duration = .milliseconds(500) {

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -120,11 +120,14 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// Automatically and periodically commit offsets in the background. Note: Setting this to `false` does not prevent the consumer from fetching previously committed start offsets.
+    /// A Boolean value that indicates whether the consumer commits offsets automatically and periodically in the background.
+    ///
+    /// - Note: Setting this to `false` does not prevent the consumer from fetching previously committed start offsets.
+    ///
     /// Default: `true`
     public var isAutoCommitEnabled: Bool = true
 
-    /// Automatically store offset of last message provided to application.
+    /// A Boolean value that indicates whether the consumer automatically stores the offset of the last message provided to the application.
     /// The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
     ///
     /// When set to `false`, the application must explicitly call ``KafkaConsumer/storeOffset(_:)``
@@ -158,7 +161,7 @@ public struct KafkaConsumerConfiguration {
     /// Default: `.largest`
     public var autoOffsetReset: AutoOffsetReset = .largest
 
-    /// Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics.
+    /// A Boolean value that indicates whether the consumer allows automatic topic creation on the broker when subscribing to or assigning nonexistent topics.
     /// The broker must also be configured with ``KafkaConsumerConfiguration/isAutoCreateTopicsEnabled`` = `true` for this configuration to take effect.
     /// Default: `false`
     public var isAutoCreateTopicsEnabled: Bool = false

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -73,7 +73,7 @@ public struct KafkaConsumerConfiguration {
     public struct SessionOptions: Sendable, Hashable {
         /// Client group session and failure detection timeout.
         /// The consumer sends periodic heartbeats (``KafkaConsumerConfiguration/heartbeatInterval``) to indicate its liveness to the broker.
-        /// If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance.
+        /// If no heartbeats are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance.
         /// (Lowest granularity is milliseconds)
         /// Default: `.milliseconds(45000)`
         public var timeout: Duration = .milliseconds(45000) {
@@ -120,7 +120,7 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.
+    /// Automatically and periodically commit offsets in the background. Note: Setting this to `false` does not prevent the consumer from fetching previously committed start offsets.
     /// Default: `true`
     public var isAutoCommitEnabled: Bool = true
 
@@ -198,8 +198,8 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// The maximum amount of time the server will block before answering the fetch request
-    /// there isn’t sufficient data to immediately satisfy the requirement given by fetch.min.bytes.
+    /// The maximum amount of time the server will block before answering the fetch request when
+    /// there isn’t sufficient data to immediately satisfy the requirement given by `fetch.min.bytes`.
     /// Default: `.milliseconds(500)`
     public var maximumFetchWaitTime: Duration = .milliseconds(500) {
         didSet {

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -14,7 +14,7 @@
 
 import struct Foundation.UUID
 
-/// Configuration values that control a `KafkaConsumer` instance.
+/// Configuration values that control a Kafka consumer instance.
 public struct KafkaConsumerConfiguration {
     // MARK: - Kafka-specific Config properties
 
@@ -39,7 +39,7 @@ public struct KafkaConsumerConfiguration {
         }
 
         /// A consumption strategy based on partition assignment.
-        /// The consumer reads from a specific partition of a topic at a given offset.
+        /// The consumer reads from a specific partition of a topic at the offset you provide.
         ///
         /// - Parameters:
         ///     - partition: The partition of the topic to consume from.
@@ -272,7 +272,7 @@ public struct KafkaConsumerConfiguration {
     /// Default: `.plaintext`
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
-    /// Creates a new consumer configuration; deprecated in favor of `KafkaConsumerConfig`.
+    /// Creates a new consumer configuration; deprecated in favor of the newer config type.
     @available(*, deprecated, message: "Use KafkaConsumerConfig instead")
     public init(
         consumptionStrategy: ConsumptionStrategy,

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -273,6 +273,8 @@ public struct KafkaConsumerConfiguration {
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
     /// Creates a new consumer configuration; deprecated in favor of the newer config type.
+    ///
+    /// Use ``KafkaConsumerConfig`` for new code.
     @available(*, deprecated, message: "Use KafkaConsumerConfig instead")
     public init(
         consumptionStrategy: ConsumptionStrategy,

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -18,7 +18,9 @@ public struct KafkaConsumerConfiguration {
     // MARK: - Kafka-specific Config properties
 
     /// The time between two consecutive polls.
+    ///
     /// Effectively controls the rate at which incoming events and messages are consumed.
+    ///
     /// Default: `.milliseconds(100)`
     public var pollInterval: Duration = .milliseconds(100)
 
@@ -72,9 +74,11 @@ public struct KafkaConsumerConfiguration {
     /// Client group session options.
     public struct SessionOptions: Sendable, Hashable {
         /// Client group session and failure detection timeout.
+        ///
         /// The consumer sends periodic heartbeats (``KafkaConsumerConfiguration/heartbeatInterval``) to indicate its liveness to the broker.
         /// If no heartbeats are received by the broker for a group member within the session timeout, the broker removes the consumer from the group and triggers a rebalance.
         /// (Lowest granularity is milliseconds)
+        ///
         /// Default: `.milliseconds(45000)`
         public var timeout: Duration = .milliseconds(45000) {
             didSet {
@@ -93,7 +97,9 @@ public struct KafkaConsumerConfiguration {
     public var session: SessionOptions = .init()
 
     /// Group session keepalive heartbeat interval.
+    ///
     /// (Lowest granularity is milliseconds)
+    ///
     /// Default: `.milliseconds(3000)`
     public var heartbeatInterval: Duration = .milliseconds(3000) {
         didSet {
@@ -104,13 +110,16 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// Maximum allowed time between calls to consume messages. If this interval is exceeded, the consumer is considered failed and the group rebalances to reassign the partitions to another consumer group member.
+    /// Maximum allowed time between calls to consume messages.
+    ///
+    /// If this interval is exceeded, the consumer is considered failed and the group rebalances to reassign the partitions to another consumer group member.
     ///
     /// - Warning: Offset commits may be not possible at this point.
     ///
     /// The interval is checked two times per second. See KIP-62 for more information.
     ///
     /// (Lowest granularity is milliseconds)
+    ///
     /// Default: `.milliseconds(300_000)`
     public var maximumPollInterval: Duration = .milliseconds(300_000) {
         didSet {
@@ -129,6 +138,7 @@ public struct KafkaConsumerConfiguration {
     public var isAutoCommitEnabled: Bool = true
 
     /// A Boolean value that indicates whether the consumer automatically stores the offset of the last message provided to the application.
+    ///
     /// The offset store is an in-memory store of the next offset to (auto-)commit for each partition.
     ///
     /// When set to `false`, the application must explicitly call ``KafkaConsumer/storeOffset(_:)``
@@ -159,40 +169,54 @@ public struct KafkaConsumerConfiguration {
         public static let error = AutoOffsetReset(description: "error")
     }
 
-    /// Action to take when there is no initial offset in the offset store or the desired offset is out of range. See ``KafkaConsumerConfiguration/AutoOffsetReset-swift.struct`` for more information.
+    /// Action to take when there is no initial offset in the offset store or the desired offset is out of range.
+    ///
+    /// See ``KafkaConsumerConfiguration/AutoOffsetReset-swift.struct`` for more information.
+    ///
     /// Default: `.largest`
     public var autoOffsetReset: AutoOffsetReset = .largest
 
     /// A Boolean value that indicates whether the consumer allows automatic topic creation on the broker when subscribing to or assigning nonexistent topics.
+    ///
     /// The broker must also be configured with ``KafkaConsumerConfiguration/isAutoCreateTopicsEnabled`` = `true` for this configuration to take effect.
+    ///
     /// Default: `false`
     public var isAutoCreateTopicsEnabled: Bool = false
 
     // MARK: - Common Client Config Properties
 
     /// Client identifier.
+    ///
     /// Default: `"rdkafka"`
     public var identifier: String = "rdkafka"
 
     /// Initial list of brokers.
+    ///
     /// Default: `[]`
     public var bootstrapBrokerAddresses: [KafkaConfiguration.BrokerAddress] = []
 
-    /// Message options.
+    /// Options that govern Kafka message size and copy behavior.
     public var message: KafkaConfiguration.MessageOptions = .init()
 
-    /// Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hiccups.
+    /// The maximum Kafka protocol response message size.
+    ///
+    /// This serves as a safety precaution to avoid memory exhaustion in case of protocol errors.
+    ///
     /// Default: `100_000_000`
     public var maximumReceiveMessageBytes: Int = 100_000_000
 
     /// Maximum number of in-flight requests per broker connection.
+    ///
     /// This is a generic property applied to all broker communication, however, it is primarily relevant to produce requests.
     /// In particular, note that other mechanisms limit the number of outstanding consumer fetch requests per broker to one.
+    ///
     /// Default: `1_000_000`
     public var maximumInFlightRequestsPerConnection: Int = 1_000_000
 
     /// Metadata cache max age.
+    ///
     /// (Lowest granularity is milliseconds)
+    ///
     /// Default: `.milliseconds(900_000)`
     public var maximumMetadataAge: Duration = .milliseconds(900_000) {
         didSet {
@@ -203,8 +227,8 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// The maximum amount of time the server will block before answering the fetch request when
-    /// there isn’t sufficient data to immediately satisfy the requirement given by `fetch.min.bytes`.
+    /// The maximum amount of time the server will block before answering the fetch request when there isn’t sufficient data to immediately satisfy the requirement given by `fetch.min.bytes`.
+    ///
     /// Default: `.milliseconds(500)`
     public var maximumFetchWaitTime: Duration = .milliseconds(500) {
         didSet {
@@ -221,10 +245,12 @@ public struct KafkaConsumerConfiguration {
     public var topicMetadata: KafkaConfiguration.TopicMetadataOptions = .init()
 
     /// Topic denylist.
+    ///
     /// Default: `[]`
     public var topicDenylist: [String] = []
 
     /// Debug options.
+    ///
     /// Default: `[]`
     public var debugOptions: [KafkaConfiguration.DebugOption] = []
 
@@ -237,10 +263,11 @@ public struct KafkaConsumerConfiguration {
     /// Reconnect options.
     public var reconnect: KafkaConfiguration.ReconnectOptions = .init()
 
-    /// Options for librdkafka metrics updates
+    /// Options for librdkafka metrics updates.
     public var metrics: KafkaConfiguration.ConsumerMetrics = .init()
 
     /// Security protocol to use (plaintext, ssl, sasl_plaintext, sasl_ssl).
+    ///
     /// Default: `.plaintext`
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -73,7 +73,7 @@ public struct KafkaConsumerConfiguration {
     public struct SessionOptions: Sendable, Hashable {
         /// Client group session and failure detection timeout.
         /// The consumer sends periodic heartbeats (``KafkaConsumerConfiguration/heartbeatInterval``) to indicate its liveness to the broker.
-        /// If no heartbeats are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance.
+        /// If no heartbeats are received by the broker for a group member within the session timeout, the broker removes the consumer from the group and triggers a rebalance.
         /// (Lowest granularity is milliseconds)
         /// Default: `.milliseconds(45000)`
         public var timeout: Duration = .milliseconds(45000) {
@@ -103,7 +103,7 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// Maximum allowed time between calls to consume messages. If this interval is exceeded the consumer is considered failed and the group will rebalance to reassign the partitions to another consumer group member.
+    /// Maximum allowed time between calls to consume messages. If this interval is exceeded, the consumer is considered failed and the group rebalances to reassign the partitions to another consumer group member.
     ///
     /// - Warning: Offset commits may be not possible at this point.
     ///

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -22,7 +22,7 @@ public struct KafkaConsumerConfiguration {
     /// Default: `.milliseconds(100)`
     public var pollInterval: Duration = .milliseconds(100)
 
-    /// A struct representing the different Kafka message consumption strategies.
+    /// The Kafka message consumption strategy.
     public struct ConsumptionStrategy: Sendable, Hashable {
         enum _ConsumptionStrategy: Sendable, Hashable {
             case partition(groupID: String?, topic: String, partition: KafkaPartition, offset: KafkaOffset)

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -85,6 +85,7 @@ public struct KafkaConsumerConfiguration {
             }
         }
 
+        /// Creates a new set of consumer group session options with default values.
         public init() {}
     }
 
@@ -139,6 +140,7 @@ public struct KafkaConsumerConfiguration {
 
     /// Available actions to take when there is no initial offset in offset store / offset is out of range.
     public struct AutoOffsetReset: Sendable, Hashable, CustomStringConvertible {
+        /// A textual representation of the auto-offset-reset action.
         public let description: String
 
         /// Automatically reset the offset to the smallest offset.
@@ -242,6 +244,7 @@ public struct KafkaConsumerConfiguration {
     /// Default: `.plaintext`
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
+    /// Creates a new consumer configuration; deprecated in favor of `KafkaConsumerConfig`.
     @available(*, deprecated, message: "Use KafkaConsumerConfig instead")
     public init(
         consumptionStrategy: ConsumptionStrategy,

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -39,6 +39,8 @@ public struct KafkaProducerConfiguration {
 
     // MARK: - Producer-specific Config Properties
 
+    /// A Boolean value that indicates whether the producer guarantees idempotent message delivery.
+    ///
     /// When set to `true`, the producer ensures that messages are successfully produced exactly once and in the original produce order.
     /// The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled:
     /// ``KafkaProducerConfiguration/maximumInFlightRequestsPerConnection`` = `5` (must be less than or equal to 5),
@@ -101,7 +103,7 @@ public struct KafkaProducerConfiguration {
     /// Default: `2_147_483_647`
     public var maximumMessageSendRetries: Int = 2_147_483_647
 
-    /// Allow automatic topic creation on the broker when producing to non-existent topics.
+    /// A Boolean value that indicates whether the producer allows automatic topic creation on the broker when producing to nonexistent topics.
     /// The broker must also be configured with ``isAutoCreateTopicsEnabled`` = `true` for this configuration to take effect.
     /// Default: `true`
     public var isAutoCreateTopicsEnabled: Bool = true

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -20,15 +20,19 @@ public struct KafkaProducerConfiguration {
     /// If the ``isAutoCreateTopicsEnabled`` option is set to `true`,
     /// the broker automatically generates topics when producing data to nonexistent topics.
     /// The configuration specified in this ``KafkaTopicConfiguration`` is applied to the newly created topic.
+    ///
     /// Default: See default values of ``KafkaTopicConfiguration``
     public var topicConfiguration: KafkaTopicConfiguration = .init()
 
     /// The time between two consecutive polls.
+    ///
     /// Effectively controls the rate at which incoming events are consumed.
+    ///
     /// Default: `.milliseconds(100)`
     public var pollInterval: Duration = .milliseconds(100)
 
     /// Maximum timeout for flushing outstanding produce requests when the ``KafkaProducer`` is shutting down.
+    ///
     /// Default: `10000`
     public var flushTimeoutMilliseconds: Int = 10000 {
         didSet {
@@ -50,12 +54,15 @@ public struct KafkaProducerConfiguration {
     /// ``KafkaTopicConfiguration/requiredAcknowledgements`` = ``KafkaTopicConfiguration/RequiredAcknowledgments/all``,
     /// queuing strategy = FIFO.
     /// Producer instantiation will fail if the user-supplied configuration is incompatible.
+    ///
     /// Default: `false`
     public var isIdempotenceEnabled: Bool = false
 
     /// Options that control producer queue size, buffering, and retry behavior.
     public struct QueueConfiguration: Sendable, Hashable {
-        /// Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
+        /// Maximum number of messages allowed on the producer queue.
+        ///
+        /// This queue is shared by all topics and partitions.
         public struct MessageLimit: Sendable, Hashable {
             internal let rawValue: Int
 
@@ -72,12 +79,18 @@ public struct KafkaProducerConfiguration {
             public static let unlimited: MessageLimit = .init(rawValue: 0)
         }
 
-        /// Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
+        /// Maximum number of messages allowed on the producer queue.
+        ///
+        /// This queue is shared by all topics and partitions.
+        ///
         /// Default: `.maximumLimit(100_000)`
         public var messageLimit: MessageLimit = .maximumLimit(100_000)
 
-        /// Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions.
+        /// Maximum total message size sum allowed on the producer queue.
+        ///
+        /// This queue is shared by all topics and partitions.
         /// This property has higher priority than ``KafkaProducerConfiguration/QueueConfiguration/MessageLimit-swift.struct``.
+        ///
         /// Default: `1_048_576 * 1024`
         public var maximumMessageBytes: Int = 1_048_576 * 1024
 
@@ -85,6 +98,7 @@ public struct KafkaProducerConfiguration {
         ///
         /// A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
         /// (Lowest granularity is milliseconds)
+        ///
         /// Default: `.milliseconds(5)`
         public var maximumMessageQueueTime: Duration = .milliseconds(5) {
             didSet {
@@ -105,21 +119,26 @@ public struct KafkaProducerConfiguration {
     /// The number of times to retry sending a failed message.
     ///
     /// - Note: Retrying may cause reordering unless ``KafkaProducerConfiguration/isIdempotenceEnabled`` is set to `true`.
+    ///
     /// Default: `2_147_483_647`
     public var maximumMessageSendRetries: Int = 2_147_483_647
 
     /// A Boolean value that indicates whether the producer allows automatic topic creation on the broker when producing to nonexistent topics.
+    ///
     /// The broker must also be configured with ``isAutoCreateTopicsEnabled`` = `true` for this configuration to take effect.
+    ///
     /// Default: `true`
     public var isAutoCreateTopicsEnabled: Bool = true
 
     // MARK: - Common Client Config Properties
 
     /// Client identifier.
+    ///
     /// Default: `"rdkafka"`
     public var identifier: String = "rdkafka"
 
     /// Initial list of brokers.
+    ///
     /// Default: `[]`
     public var bootstrapBrokerAddresses: [KafkaConfiguration.BrokerAddress] = []
 
@@ -129,17 +148,22 @@ public struct KafkaProducerConfiguration {
     /// The maximum Kafka protocol response message size.
     ///
     /// This serves as a safety precaution to avoid memory exhaustion in case of protocol errors.
+    ///
     /// Default: `100_000_000`
     public var maximumReceiveMessageBytes: Int = 100_000_000
 
     /// Maximum number of in-flight requests per broker connection.
+    ///
     /// This is a generic property applied to all broker communication, however, it is primarily relevant to produce requests.
     /// In particular, note that other mechanisms limit the number of outstanding consumer fetch requests per broker to one.
+    ///
     /// Default: `1_000_000`
     public var maximumInFlightRequestsPerConnection: Int = 1_000_000
 
     /// Metadata cache max age.
+    ///
     /// (Lowest granularity is milliseconds)
+    ///
     /// Default: `.milliseconds(900_000)`
     public var maximumMetadataAge: Duration = .milliseconds(900_000) {
         didSet {
@@ -154,10 +178,12 @@ public struct KafkaProducerConfiguration {
     public var topicMetadata: KafkaConfiguration.TopicMetadataOptions = .init()
 
     /// Topic denylist.
+    ///
     /// Default: `[]`
     public var topicDenylist: [String] = []
 
     /// Debug options.
+    ///
     /// Default: `[]`
     public var debugOptions: [KafkaConfiguration.DebugOption] = []
 
@@ -170,10 +196,11 @@ public struct KafkaProducerConfiguration {
     /// Reconnect options.
     public var reconnect: KafkaConfiguration.ReconnectOptions = .init()
 
-    /// Options for librdkafka metrics updates
+    /// Options for librdkafka metrics updates.
     public var metrics: KafkaConfiguration.ProducerMetrics = .init()
 
     /// Security protocol to use (plaintext, ssl, sasl_plaintext, sasl_ssl).
+    ///
     /// Default: `.plaintext`
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -206,6 +206,8 @@ public struct KafkaProducerConfiguration {
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
     /// Creates a new producer configuration; deprecated in favor of the newer config type.
+    ///
+    /// Use ``KafkaProducerConfig`` for new code.
     @available(*, deprecated, message: "Use KafkaProducerConfig instead")
     public init(
         bootstrapBrokerAddresses: [KafkaConfiguration.BrokerAddress]

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -15,6 +15,8 @@
 public struct KafkaProducerConfiguration {
     // MARK: - Kafka-specific Config properties
 
+    /// Topic configuration applied to topics that the broker auto-creates.
+    ///
     /// If the ``isAutoCreateTopicsEnabled`` option is set to `true`,
     /// the broker automatically generates topics when producing data to nonexistent topics.
     /// The configuration specified in this ``KafkaTopicConfiguration`` is applied to the newly created topic.
@@ -51,7 +53,7 @@ public struct KafkaProducerConfiguration {
     /// Default: `false`
     public var isIdempotenceEnabled: Bool = false
 
-    /// Producer queue options.
+    /// Options that control producer queue size, buffering, and retry behavior.
     public struct QueueConfiguration: Sendable, Hashable {
         /// Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions.
         public struct MessageLimit: Sendable, Hashable {
@@ -78,7 +80,8 @@ public struct KafkaProducerConfiguration {
         /// Default: `1_048_576 * 1024`
         public var maximumMessageBytes: Int = 1_048_576 * 1024
 
-        /// How long to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers.
+        /// The duration to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) for transmission to brokers.
+        ///
         /// A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
         /// (Lowest granularity is milliseconds)
         /// Default: `.milliseconds(5)`
@@ -94,10 +97,10 @@ public struct KafkaProducerConfiguration {
         public init() {}
     }
 
-    /// Producer queue options.
+    /// Options that control producer queue size, buffering, and retry behavior.
     public var queue: QueueConfiguration = .init()
 
-    /// How many times to retry sending a failing Message.
+    /// The number of times to retry sending a failed message.
     ///
     /// - Note: Retrying may cause reordering unless ``KafkaProducerConfiguration/isIdempotenceEnabled`` is set to `true`.
     /// Default: `2_147_483_647`
@@ -118,10 +121,12 @@ public struct KafkaProducerConfiguration {
     /// Default: `[]`
     public var bootstrapBrokerAddresses: [KafkaConfiguration.BrokerAddress] = []
 
-    /// Message options.
+    /// Options that govern Kafka message size and copy behavior.
     public var message: KafkaConfiguration.MessageOptions = .init()
 
-    /// Maximum Kafka protocol response message size. This serves as a safety precaution to avoid memory exhaustion in case of protocol hiccups.
+    /// The maximum Kafka protocol response message size.
+    ///
+    /// This serves as a safety precaution to avoid memory exhaustion in case of protocol errors.
     /// Default: `100_000_000`
     public var maximumReceiveMessageBytes: Int = 100_000_000
 

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -16,8 +16,8 @@ public struct KafkaProducerConfiguration {
     // MARK: - Kafka-specific Config properties
 
     /// If the ``isAutoCreateTopicsEnabled`` option is set to `true`,
-    /// the broker will automatically generate topics when producing data to non-existent topics.
-    /// The configuration specified in this ``KafkaTopicConfiguration`` will be applied to the newly created topic.
+    /// the broker automatically generates topics when producing data to nonexistent topics.
+    /// The configuration specified in this ``KafkaTopicConfiguration`` is applied to the newly created topic.
     /// Default: See default values of ``KafkaTopicConfiguration``
     public var topicConfiguration: KafkaTopicConfiguration = .init()
 
@@ -39,7 +39,7 @@ public struct KafkaProducerConfiguration {
 
     // MARK: - Producer-specific Config Properties
 
-    /// When set to true, the producer will ensure that messages are successfully produced exactly once and in the original produce order.
+    /// When set to `true`, the producer ensures that messages are successfully produced exactly once and in the original produce order.
     /// The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled:
     /// ``KafkaProducerConfiguration/maximumInFlightRequestsPerConnection`` = `5` (must be less than or equal to 5),
     /// ``KafkaProducerConfiguration/maximumMessageSendRetries`` = `UInt32.max` (must be greater than 0),

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Configuration values that control a `KafkaProducer` instance.
 public struct KafkaProducerConfiguration {
     // MARK: - Kafka-specific Config properties
 

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Configuration values that control a `KafkaProducer` instance.
+/// Configuration values that control a Kafka producer instance.
 public struct KafkaProducerConfiguration {
     // MARK: - Kafka-specific Config properties
 
@@ -32,7 +32,7 @@ public struct KafkaProducerConfiguration {
     /// Default: `.milliseconds(100)`
     public var pollInterval: Duration = .milliseconds(100)
 
-    /// Maximum timeout for flushing outstanding produce requests when the ``KafkaProducer`` is shutting down.
+    /// Maximum timeout for flushing outstanding produce requests during producer shutdown.
     ///
     /// Default: `10000`
     public var flushTimeoutMilliseconds: Int = 10000 {
@@ -71,7 +71,7 @@ public struct KafkaProducerConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// Creates a producer-queue message limit from the given maximum number of messages.
+            /// Creates a producer-queue message limit from the maximum number of messages you provide.
             public static func maximumLimit(_ value: Int) -> MessageLimit {
                 .init(rawValue: value)
             }
@@ -205,7 +205,7 @@ public struct KafkaProducerConfiguration {
     /// Default: `.plaintext`
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
-    /// Creates a new producer configuration; deprecated in favor of `KafkaProducerConfig`.
+    /// Creates a new producer configuration; deprecated in favor of the newer config type.
     @available(*, deprecated, message: "Use KafkaProducerConfig instead")
     public init(
         bootstrapBrokerAddresses: [KafkaConfiguration.BrokerAddress]

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -53,7 +53,7 @@ public struct KafkaProducerConfiguration {
     /// ``KafkaProducerConfiguration/maximumMessageSendRetries`` = `UInt32.max` (must be greater than 0),
     /// ``KafkaTopicConfiguration/requiredAcknowledgements`` = ``KafkaTopicConfiguration/RequiredAcknowledgments/all``,
     /// queuing strategy = FIFO.
-    /// Producer instantiation will fail if the user-supplied configuration is incompatible.
+    /// Producer instantiation fails if the user-supplied configuration is incompatible.
     ///
     /// Default: `false`
     public var isIdempotenceEnabled: Bool = false

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -76,7 +76,7 @@ public struct KafkaProducerConfiguration {
         /// Default: `1_048_576 * 1024`
         public var maximumMessageBytes: Int = 1_048_576 * 1024
 
-        /// How long wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers.
+        /// How long to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers.
         /// A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
         /// (Lowest granularity is milliseconds)
         /// Default: `.milliseconds(5)`
@@ -97,7 +97,7 @@ public struct KafkaProducerConfiguration {
 
     /// How many times to retry sending a failing Message.
     ///
-    /// - Note: retrying may cause reordering unless ``KafkaProducerConfiguration/isIdempotenceEnabled`` is set to `true`.
+    /// - Note: Retrying may cause reordering unless ``KafkaProducerConfiguration/isIdempotenceEnabled`` is set to `true`.
     /// Default: `2_147_483_647`
     public var maximumMessageSendRetries: Int = 2_147_483_647
 

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -63,6 +63,7 @@ public struct KafkaProducerConfiguration {
                 self.rawValue = rawValue
             }
 
+            /// Creates a producer-queue message limit from the given maximum number of messages.
             public static func maximumLimit(_ value: Int) -> MessageLimit {
                 .init(rawValue: value)
             }
@@ -94,6 +95,7 @@ public struct KafkaProducerConfiguration {
             }
         }
 
+        /// Creates a new producer queue configuration with default values.
         public init() {}
     }
 
@@ -175,6 +177,7 @@ public struct KafkaProducerConfiguration {
     /// Default: `.plaintext`
     public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
+    /// Creates a new producer configuration; deprecated in favor of `KafkaProducerConfig`.
     @available(*, deprecated, message: "Use KafkaProducerConfig instead")
     public init(
         bootstrapBrokerAddresses: [KafkaConfiguration.BrokerAddress]

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -35,12 +35,17 @@ public struct KafkaTopicConfiguration {
     }
 
     /// This field indicates the number of acknowledgments the leader broker must receive from ISR brokers before responding to the request.
+    ///
     /// If there are less than `min.insync.replicas` (broker configuration) in the ISR set the produce request will fail.
+    ///
     /// Default: `.all`
     public var requiredAcknowledgements: RequiredAcknowledgments = .all
 
-    /// The ack timeout of the producer request. This value is only enforced by the broker and relies on ``requiredAcknowledgements`` being != 0.
+    /// The ack timeout of the producer request.
+    ///
+    /// This value is only enforced by the broker and relies on ``requiredAcknowledgements`` being != 0.
     /// (Lowest granularity is milliseconds)
+    ///
     /// Default: `.milliseconds(30000)`
     public var requestTimeout: Duration = .milliseconds(30000) {
         didSet {
@@ -80,10 +85,13 @@ public struct KafkaTopicConfiguration {
     /// This is the maximum time librdkafka may use to deliver a message (including retries).
     /// Delivery error occurs when either the retry count or the message timeout is exceeded.
     /// (Lowest granularity is milliseconds)
+    ///
     /// Default: `.timeout(.milliseconds(300_000))`
     public var messageTimeout: MessageTimeout = .timeout(.milliseconds(300_000))
 
-    /// Partitioner. Computes the partition where a message is stored.
+    /// Partitioner.
+    ///
+    /// Computes the partition where a message is stored.
     public struct Partitioner: Sendable, Hashable, CustomStringConvertible {
         /// A textual representation of the partitioner algorithm.
         public let description: String
@@ -96,7 +104,9 @@ public struct KafkaTopicConfiguration {
         public static let consistentRandom = Partitioner(description: "consistent_random")
         /// Java Producer compatible Murmur2 hash of key. Maps NULL keys to a single partition.
         public static let murmur2 = Partitioner(description: "murmur2")
-        /// Java Producer compatible Murmur2 hash of key. Randomly partitions NULL keys. This is functionally equivalent to the default partitioner in the Java Producer.
+        /// Java Producer compatible Murmur2 hash of key.
+        ///
+        /// Randomly partitions NULL keys. This is functionally equivalent to the default partitioner in the Java Producer.
         public static let murmur2Random = Partitioner(description: "murmur2_random")
         /// FNV-1a hash of key. Maps NULL keys to a single partition.
         public static let fnv1a = Partitioner(description: "fnv1a")
@@ -104,7 +114,10 @@ public struct KafkaTopicConfiguration {
         public static let fnv1aRandom = Partitioner(description: "fnv1a_random")
     }
 
-    /// Partitioner. See ``KafkaTopicConfiguration/Partitioner-swift.struct`` for more information.
+    /// Partitioner.
+    ///
+    /// See ``KafkaTopicConfiguration/Partitioner-swift.struct`` for more information.
+    ///
     /// Default: `.consistentRandom`
     public var partitioner: Partitioner = .consistentRandom
 
@@ -226,6 +239,7 @@ public struct KafkaTopicConfiguration {
         }
 
         /// Compression codec to use for compressing message sets.
+        ///
         /// Default: `.inherit`
         public var codec: Codec = .inherit
     }

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -78,23 +78,23 @@ public struct KafkaTopicConfiguration {
     /// Default: `.timeout(.milliseconds(300_000))`
     public var messageTimeout: MessageTimeout = .timeout(.milliseconds(300_000))
 
-    /// Partitioner. Computes the partition that a message is stored in.
+    /// Partitioner. Computes the partition where a message is stored.
     public struct Partitioner: Sendable, Hashable, CustomStringConvertible {
         public let description: String
 
         /// Random distribution.
         public static let random = Partitioner(description: "random")
-        /// CRC32 hash of key (Empty and NULL keys are mapped to a single partition).
+        /// CRC32 hash of key. Maps empty and NULL keys to a single partition.
         public static let consistent = Partitioner(description: "consistent")
-        /// CRC32 hash of key (Empty and NULL keys are randomly partitioned).
+        /// CRC32 hash of key. Randomly partitions empty and NULL keys.
         public static let consistentRandom = Partitioner(description: "consistent_random")
-        /// Java Producer compatible Murmur2 hash of key (NULL keys are mapped to a single partition).
+        /// Java Producer compatible Murmur2 hash of key. Maps NULL keys to a single partition.
         public static let murmur2 = Partitioner(description: "murmur2")
-        /// Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer).
+        /// Java Producer compatible Murmur2 hash of key. Randomly partitions NULL keys. This is functionally equivalent to the default partitioner in the Java Producer.
         public static let murmur2Random = Partitioner(description: "murmur2_random")
-        /// FNV-1a hash of key (NULL keys are mapped to a single partition).
+        /// FNV-1a hash of key. Maps NULL keys to a single partition.
         public static let fnv1a = Partitioner(description: "fnv1a")
-        /// FNV-1a hash of key (NULL keys are randomly partitioned).
+        /// FNV-1a hash of key. Randomly partitions NULL keys.
         public static let fnv1aRandom = Partitioner(description: "fnv1a_random")
     }
 

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -22,6 +22,7 @@ public struct KafkaTopicConfiguration {
             self.rawValue = rawValue
         }
 
+        /// Creates a required-acknowledgments value that requires at least the given number of in-sync replica acknowledgments.
         public static func atLeast(_ value: Int) -> RequiredAcknowledgments {
             .init(rawValue: value)
         }
@@ -58,7 +59,9 @@ public struct KafkaTopicConfiguration {
             self.rawValue = rawValue
         }
 
-        /// (Lowest granularity is milliseconds)
+        /// Creates a message-delivery timeout from the given duration.
+        ///
+        /// - Note: The lowest granularity is milliseconds.
         public static func timeout(_ value: Duration) -> MessageTimeout {
             precondition(
                 value.canBeRepresentedAsMilliseconds,
@@ -67,6 +70,7 @@ public struct KafkaTopicConfiguration {
             return .init(rawValue: value.inMilliseconds)
         }
 
+        /// A message timeout that never expires; messages remain queued for delivery indefinitely.
         public static let infinite: MessageTimeout = .init(rawValue: 0)
     }
 
@@ -81,6 +85,7 @@ public struct KafkaTopicConfiguration {
 
     /// Partitioner. Computes the partition where a message is stored.
     public struct Partitioner: Sendable, Hashable, CustomStringConvertible {
+        /// A textual representation of the partitioner algorithm.
         public let description: String
 
         /// Random distribution.
@@ -115,6 +120,9 @@ public struct KafkaTopicConfiguration {
                 self.rawValue = rawValue
             }
 
+            /// Creates a compression level with the given numeric value.
+            ///
+            /// Valid ranges depend on the selected codec.
             public static func level(_ value: Int) -> Level {
                 .init(rawValue: value)
             }
@@ -170,10 +178,12 @@ public struct KafkaTopicConfiguration {
 
             private let _internal: _Codec
 
+            /// A textual representation of the compression codec name.
             public var description: String {
                 self._internal.description
             }
 
+            /// The compression level associated with the codec, or `.codecDependent` when the codec has no configurable level.
             public var level: Level {
                 self._internal.level
             }
@@ -223,6 +233,7 @@ public struct KafkaTopicConfiguration {
     /// Compression-related configuration options.
     public var compression: Compression = .init()
 
+    /// Creates a new topic configuration with default values.
     public init() {}
 }
 

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -26,7 +26,7 @@ public struct KafkaTopicConfiguration {
             .init(rawValue: value)
         }
 
-        /// Broker will block until the message is committed by all in-sync replicas (ISRs).
+        /// Broker blocks until the message is committed by all in-sync replicas (ISRs).
         public static let all: RequiredAcknowledgments = .init(rawValue: -1)
 
         /// Broker does not send any response/ack to the client.
@@ -105,7 +105,7 @@ public struct KafkaTopicConfiguration {
     /// Compression-related configuration options.
     public struct Compression: Sendable, Hashable {
         /// Compression level parameter for algorithm selected by configuration property ``codec-swift.property``.
-        /// Higher values will result in better compression at the cost of more CPU usage.
+        /// Higher values produce better compression at the cost of more CPU usage.
         public struct Level: Sendable, Hashable {
             internal let rawValue: Int
 

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 /// Configuration applied to new topics that the producer creates.
+///
+/// The ``KafkaProducer`` applies this configuration when auto-creating topics.
 public struct KafkaTopicConfiguration {
     /// The number of acknowledgments the leader broker must receive from in-sync replica (ISR) brokers before responding to the request.
     public struct RequiredAcknowledgments: Sendable, Hashable {

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Used to configure new topics created by the ``KafkaProducer``.
+/// Configuration applied to new topics that the ``KafkaProducer`` creates.
 public struct KafkaTopicConfiguration {
-    /// This number of acknowledgments the leader broker must receive from ISR brokers before responding to the request.
+    /// The number of acknowledgments the leader broker must receive from in-sync replica (ISR) brokers before responding to the request.
     public struct RequiredAcknowledgments: Sendable, Hashable {
         internal let rawValue: Int
 
@@ -29,7 +29,7 @@ public struct KafkaTopicConfiguration {
         /// Broker blocks until the message is committed by all in-sync replicas (ISRs).
         public static let all: RequiredAcknowledgments = .init(rawValue: -1)
 
-        /// Broker does not send any response/ack to the client.
+        /// The broker does not send any response or acknowledgment to the client.
         public static let noAcknowledgments: RequiredAcknowledgments = .init(rawValue: 0)
     }
 
@@ -50,7 +50,7 @@ public struct KafkaTopicConfiguration {
         }
     }
 
-    /// Local message timeout.
+    /// A local timeout for delivering a produced message.
     public struct MessageTimeout: Sendable, Hashable {
         internal let rawValue: UInt
 
@@ -70,7 +70,8 @@ public struct KafkaTopicConfiguration {
         public static let infinite: MessageTimeout = .init(rawValue: 0)
     }
 
-    /// Local message timeout.
+    /// The local timeout for delivering a produced message.
+    ///
     /// This value is only enforced locally and limits the time a produced message waits for successful delivery.
     /// This is the maximum time librdkafka may use to deliver a message (including retries).
     /// Delivery error occurs when either the retry count or the message timeout is exceeded.
@@ -104,7 +105,8 @@ public struct KafkaTopicConfiguration {
 
     /// Compression-related configuration options.
     public struct Compression: Sendable, Hashable {
-        /// Compression level parameter for algorithm selected by configuration property ``codec-swift.property``.
+        /// The compression level for the algorithm selected by the ``codec-swift.property`` configuration property.
+        ///
         /// Higher values produce better compression at the cost of more CPU usage.
         public struct Level: Sendable, Hashable {
             internal let rawValue: Int
@@ -121,7 +123,7 @@ public struct KafkaTopicConfiguration {
             public static let codecDependent: Level = .init(rawValue: -1)
         }
 
-        /// Process to compress and decompress data.
+        /// A compression codec that compresses and decompresses message data.
         public struct Codec: Sendable, Hashable, CustomStringConvertible {
             private enum _Codec: Sendable, Hashable, CustomStringConvertible {
                 case none

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Configuration applied to new topics that the ``KafkaProducer`` creates.
+/// Configuration applied to new topics that the producer creates.
 public struct KafkaTopicConfiguration {
     /// The number of acknowledgments the leader broker must receive from in-sync replica (ISR) brokers before responding to the request.
     public struct RequiredAcknowledgments: Sendable, Hashable {
@@ -22,7 +22,7 @@ public struct KafkaTopicConfiguration {
             self.rawValue = rawValue
         }
 
-        /// Creates a required-acknowledgments value that requires at least the given number of in-sync replica acknowledgments.
+        /// Creates a required-acknowledgments value that requires at least the number of in-sync replica acknowledgments you specify.
         public static func atLeast(_ value: Int) -> RequiredAcknowledgments {
             .init(rawValue: value)
         }
@@ -64,7 +64,7 @@ public struct KafkaTopicConfiguration {
             self.rawValue = rawValue
         }
 
-        /// Creates a message-delivery timeout from the given duration.
+        /// Creates a message-delivery timeout from the duration you provide.
         ///
         /// - Note: The lowest granularity is milliseconds.
         public static func timeout(_ value: Duration) -> MessageTimeout {
@@ -89,9 +89,9 @@ public struct KafkaTopicConfiguration {
     /// Default: `.timeout(.milliseconds(300_000))`
     public var messageTimeout: MessageTimeout = .timeout(.milliseconds(300_000))
 
-    /// Partitioner.
+    /// The algorithm a producer uses to assign each message to a partition of its topic.
     ///
-    /// Computes the partition where a message is stored.
+    /// Most algorithms hash the message key so identical keys map to the same partition; messages with no key are typically distributed at random.
     public struct Partitioner: Sendable, Hashable, CustomStringConvertible {
         /// A textual representation of the partitioner algorithm.
         public let description: String
@@ -114,16 +114,18 @@ public struct KafkaTopicConfiguration {
         public static let fnv1aRandom = Partitioner(description: "fnv1a_random")
     }
 
-    /// Partitioner.
+    /// The partitioning algorithm applied to messages produced to this topic.
     ///
-    /// See ``KafkaTopicConfiguration/Partitioner-swift.struct`` for more information.
+    /// See ``KafkaTopicConfiguration/Partitioner-swift.struct`` for the available algorithms.
     ///
     /// Default: `.consistentRandom`
     public var partitioner: Partitioner = .consistentRandom
 
     /// Compression-related configuration options.
     public struct Compression: Sendable, Hashable {
-        /// The compression level for the algorithm selected by the ``codec-swift.property`` configuration property.
+        /// A compression level for the configured codec.
+        ///
+        /// The valid range depends on the codec selected by ``codec-swift.property``.
         ///
         /// Higher values produce better compression at the cost of more CPU usage.
         public struct Level: Sendable, Hashable {
@@ -133,7 +135,7 @@ public struct KafkaTopicConfiguration {
                 self.rawValue = rawValue
             }
 
-            /// Creates a compression level with the given numeric value.
+            /// Creates a compression level with the numeric value you provide.
             ///
             /// Valid ranges depend on the selected codec.
             public static func level(_ value: Int) -> Level {

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -34,14 +34,14 @@ public struct KafkaTopicConfiguration {
         public static let noAcknowledgments: RequiredAcknowledgments = .init(rawValue: 0)
     }
 
-    /// This field indicates the number of acknowledgments the leader broker must receive from ISR brokers before responding to the request.
+    /// The number of acknowledgments the leader broker must receive from ISR brokers before responding to the request.
     ///
-    /// If there are less than `min.insync.replicas` (broker configuration) in the ISR set the produce request will fail.
+    /// If there are less than `min.insync.replicas` (broker configuration) in the ISR set, the produce request fails.
     ///
     /// Default: `.all`
     public var requiredAcknowledgements: RequiredAcknowledgments = .all
 
-    /// The ack timeout of the producer request.
+    /// The acknowledgment timeout of the producer request.
     ///
     /// This value is only enforced by the broker and relies on ``requiredAcknowledgements`` being != 0.
     /// (Lowest granularity is milliseconds)

--- a/Sources/Kafka/Data/ByteBuffer+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/ByteBuffer+KafkaContiguousBytes.swift
@@ -15,6 +15,7 @@
 import NIOCore
 
 extension ByteBuffer: KafkaContiguousBytes {
+    /// Calls the given closure with a pointer to the buffer's readable bytes.
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         try self.withUnsafeReadableBytes {
             try body($0)

--- a/Sources/Kafka/Data/ByteBuffer+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/ByteBuffer+KafkaContiguousBytes.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 extension ByteBuffer: KafkaContiguousBytes {
-    /// Calls the given closure with a pointer to the buffer's readable bytes.
+    /// Calls the closure you provide with a pointer to the buffer's readable bytes.
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         try self.withUnsafeReadableBytes {
             try body($0)

--- a/Sources/Kafka/Data/KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/KafkaContiguousBytes.swift
@@ -21,7 +21,7 @@
 /// By conforming your own types to this protocol, you can pass instances of those types
 /// directly to ``KafkaProducerMessage`` as key and value.
 public protocol KafkaContiguousBytes {
-    /// Calls the given closure with the contents of the underlying storage.
+    /// Calls the closure you provide with the contents of the underlying storage.
     ///
     /// - Note: Calling `withUnsafeBytes` multiple times doesn't guarantee that
     ///         the same buffer pointer is passed in every time.

--- a/Sources/Kafka/Data/KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/KafkaContiguousBytes.swift
@@ -23,9 +23,9 @@
 public protocol KafkaContiguousBytes {
     /// Calls the given closure with the contents of the underlying storage.
     ///
-    /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
-    ///         the same buffer pointer will be passed in every time.
-    /// - Warning: The buffer argument to the body should not be stored or used
+    /// - Note: Calling `withUnsafeBytes` multiple times doesn't guarantee that
+    ///         the same buffer pointer is passed in every time.
+    /// - Warning: Don't store the buffer argument to the body or use it
     ///            outside of the lifetime of the call to the closure.
     func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
 }

--- a/Sources/Kafka/Data/KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/KafkaContiguousBytes.swift
@@ -22,9 +22,9 @@
 public protocol KafkaContiguousBytes {
     /// Calls the given closure with the contents of the underlying storage.
     ///
-    /// - note: Calling `withUnsafeBytes` multiple times does not guarantee that
+    /// - Note: Calling `withUnsafeBytes` multiple times does not guarantee that
     ///         the same buffer pointer will be passed in every time.
-    /// - warning: The buffer argument to the body should not be stored or used
+    /// - Warning: The buffer argument to the body should not be stored or used
     ///            outside of the lifetime of the call to the closure.
     func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
 }

--- a/Sources/Kafka/Data/KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/KafkaContiguousBytes.swift
@@ -12,12 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Conformance to this protocol gives users a way to provide their own "bag of bytes" types
-/// to be used for the serialization of Kafka messages.
-/// It provides a general interface for bytes since the Swift Standard Library currently does not
-/// provide such a protocol.
+/// A general interface for contiguous byte storage used to serialize Kafka messages.
 ///
-/// By conforming your own types to this protocol, you will be able to pass instances of said types
+/// Conformance to this protocol gives you a way to provide your own byte-container types for the
+/// serialization of Kafka messages. It provides a general interface for bytes since the Swift
+/// Standard Library currently does not provide such a protocol.
+///
+/// By conforming your own types to this protocol, you can pass instances of those types
 /// directly to ``KafkaProducerMessage`` as key and value.
 public protocol KafkaContiguousBytes {
     /// Calls the given closure with the contents of the underlying storage.

--- a/Sources/Kafka/Data/Never+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/Never+KafkaContiguousBytes.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 extension Never: KafkaContiguousBytes {
+    /// Unreachable conformance; `Never` is uninhabited and this method always traps if invoked.
     public func withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         fatalError("This statement should never be reached")
     }

--- a/Sources/Kafka/Data/String+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/String+KafkaContiguousBytes.swift
@@ -15,6 +15,7 @@
 import NIOCore
 
 extension String: KafkaContiguousBytes {
+    /// Calls the given closure with a pointer to the string's UTF-8 bytes.
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         if let read = try self.utf8.withContiguousStorageIfAvailable({ unsafePointer in
             // Fast Path

--- a/Sources/Kafka/Data/String+KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/String+KafkaContiguousBytes.swift
@@ -15,7 +15,7 @@
 import NIOCore
 
 extension String: KafkaContiguousBytes {
-    /// Calls the given closure with a pointer to the string's UTF-8 bytes.
+    /// Calls the closure you provide with a pointer to the string's UTF-8 bytes.
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         if let read = try self.utf8.withContiguousStorageIfAvailable({ unsafePointer in
             // Fast Path

--- a/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
+++ b/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
@@ -188,10 +188,12 @@ extension RDKafkaClient {
         }
     }
 
+    /// Creates an `RDKafkaClient` configured for topic management using the given consumer configuration.
     public static func makeClientForTopics(config: KafkaConsumerConfig, logger: Logger) throws -> RDKafkaClient {
         try Self.makeClient(type: .consumer, configDictionary: config.config, events: [], logger: logger)
     }
 
+    /// Creates an `RDKafkaClient` configured for topic management using the given consumer configuration.
     @available(*, deprecated, message: "Use makeClientForTopics(config:logger:) with KafkaConsumerConfig instead")
     public static func makeClientForTopics(config: KafkaConsumerConfiguration, logger: Logger) throws -> RDKafkaClient {
         try Self.makeClient(type: .consumer, configDictionary: config.dictionary, events: [], logger: logger)

--- a/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
+++ b/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
@@ -26,7 +26,7 @@ private func queueEventCallback(_ rk: OpaquePointer?, _ context: UnsafeMutableRa
 
 @_spi(Internal)
 extension RDKafkaClient {
-    /// Create a topic with a unique name (`UUID`).
+    /// Creates a topic with a unique UUID-based name.
     /// - Parameter partitions: Partitions in topic (default: -1 - default for broker)
     /// - Returns: Name of newly created topic.
     /// - Throws: A ``KafkaError`` if the topic creation failed.
@@ -188,12 +188,12 @@ extension RDKafkaClient {
         }
     }
 
-    /// Creates an `RDKafkaClient` configured for topic management using the given consumer configuration.
+    /// Creates a topic-management client using the consumer configuration you provide.
     public static func makeClientForTopics(config: KafkaConsumerConfig, logger: Logger) throws -> RDKafkaClient {
         try Self.makeClient(type: .consumer, configDictionary: config.config, events: [], logger: logger)
     }
 
-    /// Creates an `RDKafkaClient` configured for topic management using the given consumer configuration.
+    /// Creates a topic-management client using the consumer configuration you provide.
     @available(*, deprecated, message: "Use makeClientForTopics(config:logger:) with KafkaConsumerConfig instead")
     public static func makeClientForTopics(config: KafkaConsumerConfiguration, logger: Logger) throws -> RDKafkaClient {
         try Self.makeClient(type: .consumer, configDictionary: config.dictionary, events: [], logger: logger)

--- a/Sources/Kafka/ForTesting/TestMessages.swift
+++ b/Sources/Kafka/ForTesting/TestMessages.swift
@@ -27,7 +27,7 @@ public enum _TestMessagesError: Error {
     case deliveryReportsIncorrect
 }
 
-/// Builds an array of test producer messages with unique keys for the given topic.
+/// Builds an array of test producer messages with unique keys for the topic you provide.
 @_spi(Internal)
 public func _createTestMessages(
     topic: String,
@@ -44,7 +44,7 @@ public func _createTestMessages(
     }
 }
 
-/// Sends the given messages and verifies that each one is acknowledged via the producer's events sequence.
+/// Sends the messages you provide and verifies that each one is acknowledged via the producer's events sequence.
 @_spi(Internal)
 public func _sendAndAcknowledgeMessages(
     producer: KafkaProducer,

--- a/Sources/Kafka/ForTesting/TestMessages.swift
+++ b/Sources/Kafka/ForTesting/TestMessages.swift
@@ -16,13 +16,18 @@ import NIOCore
 import struct Foundation.Date
 import struct Foundation.UUID
 
+/// An error thrown by the SPI test helpers when delivery report verification fails.
 @_spi(Internal)
 public enum _TestMessagesError: Error {
+    /// The set of received delivery report IDs doesn't match the IDs of the messages that were sent.
     case deliveryReportsIdsIncorrect
+    /// The number of acknowledged messages doesn't match the number of messages that were sent.
     case deliveryReportsNotAllMessagesAcknoledged
+    /// One or more delivery reports reference content that doesn't match the original messages.
     case deliveryReportsIncorrect
 }
 
+/// Builds an array of test producer messages with unique keys for the given topic.
 @_spi(Internal)
 public func _createTestMessages(
     topic: String,
@@ -39,6 +44,7 @@ public func _createTestMessages(
     }
 }
 
+/// Sends the given messages and verifies that each one is acknowledged via the producer's events sequence.
 @_spi(Internal)
 public func _sendAndAcknowledgeMessages(
     producer: KafkaProducer,

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -1,12 +1,12 @@
 # Consuming messages
 
-Receive records from Kafka topics through an AsyncSequence, control offset commits, and pause or resume partition consumption.
+Receive records from Kafka topics as an asynchronous sequence, control offset commits, and pause or resume partitions.
 
 ## Overview
 
-A ``KafkaConsumer`` joins a consumer group and surfaces records as a ``KafkaConsumerMessages`` `AsyncSequence`. You iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
+A ``KafkaConsumer`` joins a consumer group and exposes records through a ``KafkaConsumerMessages`` asynchronous sequence. You iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
 
-By default, the consumer stores and commits offsets automatically as you iterate. For at-least-once delivery, you can disable automatic offset storage and store offsets yourself after a record finishes processing. For full control, you can also turn off the periodic auto-commit and commit explicitly.
+By default, the consumer stores and commits offsets automatically as you iterate. For at-least-once delivery, you can disable automatic offset storage and store offsets yourself after your code finishes processing a record. For full control, you can also turn off the periodic auto-commit and commit explicitly.
 
 ### Configure a consumer group
 
@@ -48,7 +48,7 @@ Each ``KafkaConsumerMessage`` carries the topic, partition, offset, key, value, 
 
 ### Achieve at-least-once delivery
 
-For at-least-once semantics, disable automatic offset storage and call ``KafkaConsumer/storeOffset(_:)`` only after the record finishes processing. The consumer's background auto-commit timer then commits the stored offsets:
+For at-least-once semantics, disable automatic offset storage and call ``KafkaConsumer/storeOffset(_:)`` only after your code finishes processing the record. The consumer's background auto-commit timer then commits the stored offsets:
 
 ```swift
 var config = KafkaConsumerConfig()
@@ -96,7 +96,7 @@ try await consumer.commit()
 
 ### Manage subscriptions dynamically
 
-Topic subscriptions can change at runtime:
+Topic subscriptions can change at runtime — call ``KafkaConsumer/subscribe(topics:)`` again to update them:
 
 ```swift
 // Subscribe to additional topics.
@@ -111,7 +111,7 @@ try consumer.unsubscribe()
 
 ### Pause and resume partitions
 
-You can pause specific partitions to apply backpressure or perform maintenance without leaving the consumer group:
+Pause specific partitions to apply backpressure or perform maintenance without leaving the consumer group:
 
 ```swift
 let partition = KafkaTopicPartition(topic: "topic-name", partition: KafkaPartition(rawValue: 0))

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -29,11 +29,11 @@ let consumer = try KafkaConsumer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -4,7 +4,7 @@ Receive records from Kafka topics as an asynchronous sequence, control offset co
 
 ## Overview
 
-A ``KafkaConsumer`` joins a consumer group and exposes records through a ``KafkaConsumerMessages`` asynchronous sequence. You iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
+A ``KafkaConsumer`` joins a consumer group and exposes records through a ``KafkaConsumerMessages`` asynchronous sequence. Iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
 
 By default, the consumer stores and commits offsets automatically as you iterate. For at-least-once delivery, you can disable automatic offset storage and store offsets yourself after your code finishes processing a record. For full control, you can also turn off the periodic auto-commit and commit explicitly.
 
@@ -15,7 +15,10 @@ A ``KafkaConsumerConfig`` holds the broker addresses and the consumption strateg
 ```swift
 var config = KafkaConsumerConfig()
 config.bootstrapServers = ["localhost:9092"]
-config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+config.consumptionStrategy = .group(
+    id: "example-group",
+    topics: ["topic-name"]
+)
 ```
 
 For security options, see <doc:SecuringConnections>.
@@ -53,7 +56,10 @@ For at-least-once semantics, disable automatic offset storage and call ``KafkaCo
 ```swift
 var config = KafkaConsumerConfig()
 config.bootstrapServers = ["localhost:9092"]
-config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+config.consumptionStrategy = .group(
+    id: "example-group",
+    topics: ["topic-name"]
+)
 config.enableAutoOffsetStore = false
 
 let consumer = try KafkaConsumer(config: config, logger: logger)
@@ -75,7 +81,10 @@ To control exactly when offsets reach the broker, disable auto-commit and call `
 ```swift
 var config = KafkaConsumerConfig()
 config.bootstrapServers = ["localhost:9092"]
-config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+config.consumptionStrategy = .group(
+    id: "example-group",
+    topics: ["topic-name"]
+)
 config.enableAutoCommit = false
 
 let consumer = try KafkaConsumer(config: config, logger: logger)
@@ -114,7 +123,10 @@ try consumer.unsubscribe()
 Pause specific partitions to apply backpressure or perform maintenance without leaving the consumer group:
 
 ```swift
-let partition = KafkaTopicPartition(topic: "topic-name", partition: KafkaPartition(rawValue: 0))
+let partition = KafkaTopicPartition(
+    topic: "topic-name",
+    partition: KafkaPartition(rawValue: 0)
+)
 try consumer.pause(topicPartitions: [partition])
 // ... later
 try consumer.resume(topicPartitions: [partition])

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -6,7 +6,7 @@ Receive records from Kafka topics as an asynchronous sequence, control offset co
 
 A ``KafkaConsumer`` joins a consumer group and exposes records through a ``KafkaConsumerMessages`` asynchronous sequence. Iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
 
-By default, the consumer stores and commits offsets automatically as you iterate. For at-least-once delivery, you can disable automatic offset storage and store offsets yourself after your code finishes processing a record. For full control, you can also turn off the periodic auto-commit and commit explicitly.
+By default, the consumer stores and commits offsets automatically as iteration proceeds. For at-least-once delivery, disable automatic offset storage and store offsets after processing each record. For full control, also turn off the periodic auto-commit and commit explicitly.
 
 ### Configure a consumer group
 
@@ -51,7 +51,7 @@ Each ``KafkaConsumerMessage`` carries the topic, partition, offset, key, value, 
 
 ### Achieve at-least-once delivery
 
-For at-least-once semantics, disable automatic offset storage and call ``KafkaConsumer/storeOffset(_:)`` only after your code finishes processing the record. The consumer's background auto-commit timer then commits the stored offsets:
+For at-least-once semantics, disable automatic offset storage and call ``KafkaConsumer/storeOffset(_:)`` only after processing each record. The consumer's background auto-commit timer then commits the stored offsets:
 
 ```swift
 var config = KafkaConsumerConfig()
@@ -105,7 +105,7 @@ try await consumer.commit()
 
 ### Manage subscriptions dynamically
 
-Topic subscriptions can change at runtime — call ``KafkaConsumer/subscribe(topics:)`` again to update them:
+Topic subscriptions change at runtime — call ``KafkaConsumer/subscribe(topics:)`` again to update them:
 
 ```swift
 // Subscribe to additional topics.

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -1,0 +1,154 @@
+# Consuming messages
+
+Receive records from Kafka topics through an AsyncSequence, control offset commits, and pause or resume partition consumption.
+
+## Overview
+
+A ``KafkaConsumer`` joins a consumer group and surfaces records as a ``KafkaConsumerMessages`` `AsyncSequence`. You iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
+
+By default, the consumer stores and commits offsets automatically as you iterate. For at-least-once delivery, you can disable automatic offset storage and store offsets yourself after a record finishes processing. For full control, you can also turn off the periodic auto-commit and commit explicitly.
+
+### Configure a consumer group
+
+A ``KafkaConsumerConfig`` holds the broker addresses and the consumption strategy. To join a consumer group, set ``KafkaConsumerConfig/consumptionStrategy`` to `.group(id:topics:)`:
+
+```swift
+var config = KafkaConsumerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+```
+
+For security options, see <doc:SecuringConnections>.
+
+### Iterate the message sequence
+
+Run the consumer inside a `ServiceGroup` and read records from ``KafkaConsumer/messages``:
+
+```swift
+let consumer = try KafkaConsumer(config: config, logger: logger)
+
+let serviceGroup = ServiceGroup(
+    services: [consumer],
+    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    logger: logger
+)
+
+try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { try await serviceGroup.run() }
+
+    group.addTask {
+        for try await message in consumer.messages {
+            print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
+        }
+    }
+}
+```
+
+Each ``KafkaConsumerMessage`` carries the topic, partition, offset, key, value, headers, and timestamp.
+
+### Achieve at-least-once delivery
+
+For at-least-once semantics, disable automatic offset storage and call ``KafkaConsumer/storeOffset(_:)`` only after the record finishes processing. The consumer's background auto-commit timer then commits the stored offsets:
+
+```swift
+var config = KafkaConsumerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+config.enableAutoOffsetStore = false
+
+let consumer = try KafkaConsumer(config: config, logger: logger)
+
+// ... run inside a ServiceGroup as in the previous example.
+
+for try await message in consumer.messages {
+    // Process the record.
+    try consumer.storeOffset(message)
+}
+```
+
+If processing fails before `storeOffset(_:)` runs, the consumer redelivers the record on its next start.
+
+### Commit offsets manually
+
+To control exactly when offsets reach the broker, disable auto-commit and call ``KafkaConsumer/commit(_:)`` per record:
+
+```swift
+var config = KafkaConsumerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+config.enableAutoCommit = false
+
+let consumer = try KafkaConsumer(config: config, logger: logger)
+
+// ... run inside a ServiceGroup as above.
+
+for try await message in consumer.messages {
+    // Process the record.
+    try await consumer.commit(message)
+}
+```
+
+To commit every previously stored offset in one call, use ``KafkaConsumer/commit()``:
+
+```swift
+try await consumer.commit()
+```
+
+### Manage subscriptions dynamically
+
+Topic subscriptions can change at runtime:
+
+```swift
+// Subscribe to additional topics.
+try consumer.subscribe(topics: ["topic-a", "topic-b"])
+
+// Query the current subscription.
+let topics = try consumer.subscribedTopics()
+
+// Unsubscribe from all topics.
+try consumer.unsubscribe()
+```
+
+### Pause and resume partitions
+
+You can pause specific partitions to apply backpressure or perform maintenance without leaving the consumer group:
+
+```swift
+let partition = KafkaTopicPartition(topic: "topic-name", partition: KafkaPartition(rawValue: 0))
+try consumer.pause(topicPartitions: [partition])
+// ... later
+try consumer.resume(topicPartitions: [partition])
+```
+
+While a partition is paused, the consumer stops fetching records for it but continues to participate in the group, including heartbeats and rebalances.
+
+## Topics
+
+### Reading records
+
+- ``KafkaConsumer/messages``
+- ``KafkaConsumerMessages``
+- ``KafkaConsumerMessage``
+
+### Managing subscriptions
+
+- ``KafkaConsumer/subscribe(topics:)``
+- ``KafkaConsumer/unsubscribe()``
+- ``KafkaConsumer/subscribedTopics()``
+
+### Controlling offsets
+
+- ``KafkaConsumer/storeOffset(_:)``
+- ``KafkaConsumer/commit(_:)``
+- ``KafkaConsumer/commit()``
+
+### Pausing partitions
+
+- ``KafkaConsumer/pause(topicPartitions:)``
+- ``KafkaConsumer/resume(topicPartitions:)``
+
+### Observing rebalances and events
+
+- ``KafkaConsumerRebalance``
+- ``KafkaConsumerEvent``
+- ``KafkaConsumerEvents``

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -4,7 +4,7 @@ Add the Kafka client to your package, then run a producer or consumer inside a s
 
 ## Overview
 
-Kafka exposes a producer and a consumer that conform to the `Service` protocol from `swift-service-lifecycle`. You run them inside a `ServiceGroup`, which manages graceful startup and shutdown, and you exchange records with the broker through `async`/`await` and `AsyncSequence`.
+Kafka exposes a producer and a consumer that conform to the `Service` protocol from `swift-service-lifecycle`. Run them inside a `ServiceGroup`, which manages graceful startup and shutdown, and exchange records with the broker through `async`/`await` and `AsyncSequence`.
 
 This article walks you through adding the dependency, sending a single message, and reading messages from a topic.
 
@@ -13,7 +13,10 @@ This article walks you through adding the dependency, sending a single message, 
 Add the package to the dependencies in your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/swift-server/swift-kafka-client", branch: "main")
+.package(
+    url: "https://github.com/swift-server/swift-kafka-client", 
+    branch: "main"
+)
 ```
 
 Then add `Kafka` to your target's dependencies:
@@ -66,7 +69,10 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        let message = KafkaProducerMessage(
+            topic: "topic-name",
+            value: "Hello, World!"
+        )
         let report = try await producer.sendAndAwait(message)
         switch report.status {
         case .acknowledged(let ack):
@@ -85,7 +91,10 @@ To consume messages, create a ``KafkaConsumer`` with a group consumption strateg
 ```swift
 var config = KafkaConsumerConfig()
 config.bootstrapServers = ["localhost:9092"]
-config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+config.consumptionStrategy = .group(
+    id: "example-group",
+    topics: ["topic-name"]
+)
 
 let consumer = try KafkaConsumer(config: config, logger: logger)
 

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -4,7 +4,7 @@ Add the Kafka client to your package, then run a producer or consumer inside a s
 
 ## Overview
 
-The Kafka module exposes a producer and a consumer that conform to the `Service` protocol from swift-service-lifecycle. You run them inside a `ServiceGroup`, which manages graceful startup and shutdown, and you exchange records with the broker through `async`/`await` and `AsyncSequence`.
+Kafka exposes a producer and a consumer that conform to the `Service` protocol from `swift-service-lifecycle`. You run them inside a `ServiceGroup`, which manages graceful startup and shutdown, and you exchange records with the broker through `async`/`await` and `AsyncSequence`.
 
 This article walks you through adding the dependency, sending a single message, and reading messages from a topic.
 
@@ -33,14 +33,14 @@ Finally, import the module in your source code:
 import Kafka
 ```
 
-### Install the native dependencies
+### Install system dependencies
 
 The package wraps the native `librdkafka` C library, which depends on OpenSSL.
 
 - On macOS, run `brew install openssl@3`.
 - On Linux, run `apt-get install libssl-dev libsasl2-dev`.
 
-### Send your first message
+### Send a first message
 
 To produce a message and wait for the broker to acknowledge it, configure a ``KafkaProducer``, run it inside a `ServiceGroup`, and call ``KafkaProducer/sendAndAwait(_:)``:
 
@@ -106,7 +106,7 @@ try await withThrowingTaskGroup(of: Void.self) { group in
 }
 ```
 
-### Run a local broker for development
+### Run a local broker
 
 You can stand up a Kafka broker on `localhost:9092` with Docker:
 
@@ -114,6 +114,6 @@ You can stand up a Kafka broker on `localhost:9092` with Docker:
 docker run -d -p 9092:9092 apache/kafka:3.9.1
 ```
 
-### Continue learning
+### Next steps
 
 For more detail on each side of the pipeline, see <doc:ProducingMessages> and <doc:ConsumingMessages>. To configure TLS or SASL authentication, see <doc:SecuringConnections>.

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -58,11 +58,11 @@ let producer = try KafkaProducer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [producer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
@@ -91,11 +91,11 @@ let consumer = try KafkaConsumer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -6,7 +6,7 @@ Add the Kafka client to your package, then run a producer or consumer inside a s
 
 Kafka exposes a producer and a consumer that conform to the `Service` protocol from `swift-service-lifecycle`. Run them inside a `ServiceGroup`, which manages graceful startup and shutdown, and exchange records with the broker through `async`/`await` and `AsyncSequence`.
 
-This article walks you through adding the dependency, sending a single message, and reading messages from a topic.
+This article walks through adding the dependency, sending a single message, and reading messages from a topic.
 
 ### Add Kafka as a dependency
 
@@ -117,7 +117,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
 ### Run a local broker
 
-You can stand up a Kafka broker on `localhost:9092` with Docker:
+Stand up a Kafka broker on `localhost:9092` with Docker:
 
 ```shell
 docker run -d -p 9092:9092 apache/kafka:3.9.1

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -1,0 +1,119 @@
+# Getting started
+
+Add the Kafka client to your package, then run a producer or consumer inside a service group.
+
+## Overview
+
+The Kafka module exposes a producer and a consumer that conform to the `Service` protocol from swift-service-lifecycle. You run them inside a `ServiceGroup`, which manages graceful startup and shutdown, and you exchange records with the broker through `async`/`await` and `AsyncSequence`.
+
+This article walks you through adding the dependency, sending a single message, and reading messages from a topic.
+
+### Add Kafka as a dependency
+
+Add the package to the dependencies in your `Package.swift`:
+
+```swift
+.package(url: "https://github.com/swift-server/swift-kafka-client", branch: "main")
+```
+
+Then add `Kafka` to your target's dependencies:
+
+```swift
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "Kafka", package: "swift-kafka-client"),
+    ]
+)
+```
+
+Finally, import the module in your source code:
+
+```swift
+import Kafka
+```
+
+### Install the native dependencies
+
+The package wraps the native `librdkafka` C library, which depends on OpenSSL.
+
+- On macOS, run `brew install openssl@3`.
+- On Linux, run `apt-get install libssl-dev libsasl2-dev`.
+
+### Send your first message
+
+To produce a message and wait for the broker to acknowledge it, configure a ``KafkaProducer``, run it inside a `ServiceGroup`, and call ``KafkaProducer/sendAndAwait(_:)``:
+
+```swift
+import Kafka
+import Logging
+import ServiceLifecycle
+
+let logger = Logger(label: "kafka-example")
+
+var config = KafkaProducerConfig()
+config.bootstrapServers = ["localhost:9092"]
+
+let producer = try KafkaProducer(config: config, logger: logger)
+
+let serviceGroup = ServiceGroup(
+    services: [producer],
+    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    logger: logger
+)
+
+try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { try await serviceGroup.run() }
+
+    group.addTask {
+        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        let report = try await producer.sendAndAwait(message)
+        switch report.status {
+        case .acknowledged(let ack):
+            print("Delivered to partition \(ack.partition) at offset \(ack.offset)")
+        case .failure(let error):
+            print("Delivery failed: \(error)")
+        }
+    }
+}
+```
+
+### Read messages from a topic
+
+To consume messages, create a ``KafkaConsumer`` with a group consumption strategy, run it inside a `ServiceGroup`, and iterate ``KafkaConsumer/messages``:
+
+```swift
+var config = KafkaConsumerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
+
+let consumer = try KafkaConsumer(config: config, logger: logger)
+
+let serviceGroup = ServiceGroup(
+    services: [consumer],
+    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    logger: logger
+)
+
+try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { try await serviceGroup.run() }
+
+    group.addTask {
+        for try await message in consumer.messages {
+            print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
+        }
+    }
+}
+```
+
+### Run a local broker for development
+
+You can stand up a Kafka broker on `localhost:9092` with Docker:
+
+```shell
+docker run -d -p 9092:9092 apache/kafka:3.9.1
+```
+
+### Continue learning
+
+For more detail on each side of the pipeline, see <doc:ProducingMessages> and <doc:ConsumingMessages>. To configure TLS or SASL authentication, see <doc:SecuringConnections>.

--- a/Sources/Kafka/Kafka.docc/Kafka.md
+++ b/Sources/Kafka/Kafka.docc/Kafka.md
@@ -4,7 +4,7 @@ A Swift client for Apache Kafka built on structured concurrency and Service Life
 
 ## Overview
 
-Kafka wraps the native [`librdkafka`](https://github.com/confluentinc/librdkafka) C library and exposes it through idiomatic Swift APIs. You configure a producer or consumer, run it as part of a `ServiceGroup`, and exchange records with the broker over `async`/`await` and `AsyncSequence`.
+Kafka wraps the [`librdkafka`](https://github.com/confluentinc/librdkafka) C library and exposes it through idiomatic Swift APIs. You configure a producer or consumer, run it as part of a `ServiceGroup`, and exchange records with the broker over `async`/`await` and `AsyncSequence`.
 
 Kafka integrates with [swift-log](https://github.com/apple/swift-log) for structured logging, [swift-metrics](https://github.com/apple/swift-metrics) for observability, and [swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle) for graceful startup and shutdown. It supports plaintext, TLS, and SASL authentication. Additional features include dynamic subscription management, manual offset control for at-least-once delivery, and the ability to pause and resume partition consumption.
 

--- a/Sources/Kafka/Kafka.docc/Kafka.md
+++ b/Sources/Kafka/Kafka.docc/Kafka.md
@@ -1,0 +1,64 @@
+# ``Kafka``
+
+A Swift client for Apache Kafka built on structured concurrency and Service Lifecycle.
+
+## Overview
+
+The Kafka module wraps the native [`librdkafka`](https://github.com/confluentinc/librdkafka) C library and exposes it through idiomatic Swift APIs. You configure a producer or consumer, run it as part of a `ServiceGroup`, and exchange records with the broker over `async`/`await` and `AsyncSequence`.
+
+The module integrates with [swift-log](https://github.com/apple/swift-log) for structured logging, [swift-metrics](https://github.com/apple/swift-metrics) for observability, and [swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle) for graceful startup and shutdown. It supports plaintext, TLS, and SASL authentication, dynamic subscription management, manual offset control for at-least-once delivery, and pause and resume of partition consumption.
+
+## Topics
+
+### Essentials
+
+- <doc:GettingStarted>
+- <doc:ProducingMessages>
+- <doc:ConsumingMessages>
+- <doc:SecuringConnections>
+
+### Producing messages
+
+- ``KafkaProducer``
+- ``KafkaProducerMessage``
+- ``KafkaDeliveryReport``
+- ``KafkaAcknowledgedMessage``
+- ``KafkaProducerMessageID``
+- ``KafkaProducerEvents``
+- ``KafkaProducerEvent``
+
+### Consuming messages
+
+- ``KafkaConsumer``
+- ``KafkaConsumerMessages``
+- ``KafkaConsumerMessage``
+- ``KafkaConsumerEvents``
+- ``KafkaConsumerEvent``
+- ``KafkaConsumerRebalance``
+- ``KafkaTimestampType``
+
+### Configuring clients
+
+- ``KafkaProducerConfig``
+- ``KafkaConsumerConfig``
+- ``KafkaProducerConfiguration``
+- ``KafkaConsumerConfiguration``
+- ``KafkaTopicConfiguration``
+- ``KafkaConfig``
+- ``KafkaConfiguration``
+
+### Identifying topics, partitions, and offsets
+
+- ``KafkaTopicPartition``
+- ``KafkaTopicPartitionOffset``
+- ``KafkaPartition``
+- ``KafkaOffset``
+- ``KafkaHeader``
+
+### Handling errors
+
+- ``KafkaError``
+
+### Working with message data
+
+- ``KafkaContiguousBytes``

--- a/Sources/Kafka/Kafka.docc/Kafka.md
+++ b/Sources/Kafka/Kafka.docc/Kafka.md
@@ -4,9 +4,9 @@ A Swift client for Apache Kafka built on structured concurrency and Service Life
 
 ## Overview
 
-The Kafka module wraps the native [`librdkafka`](https://github.com/confluentinc/librdkafka) C library and exposes it through idiomatic Swift APIs. You configure a producer or consumer, run it as part of a `ServiceGroup`, and exchange records with the broker over `async`/`await` and `AsyncSequence`.
+Kafka wraps the native [`librdkafka`](https://github.com/confluentinc/librdkafka) C library and exposes it through idiomatic Swift APIs. You configure a producer or consumer, run it as part of a `ServiceGroup`, and exchange records with the broker over `async`/`await` and `AsyncSequence`.
 
-The module integrates with [swift-log](https://github.com/apple/swift-log) for structured logging, [swift-metrics](https://github.com/apple/swift-metrics) for observability, and [swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle) for graceful startup and shutdown. It supports plaintext, TLS, and SASL authentication, dynamic subscription management, manual offset control for at-least-once delivery, and pause and resume of partition consumption.
+Kafka integrates with [swift-log](https://github.com/apple/swift-log) for structured logging, [swift-metrics](https://github.com/apple/swift-metrics) for observability, and [swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle) for graceful startup and shutdown. It supports plaintext, TLS, and SASL authentication. Additional features include dynamic subscription management, manual offset control for at-least-once delivery, and the ability to pause and resume partition consumption.
 
 ## Topics
 

--- a/Sources/Kafka/Kafka.docc/ProducingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ProducingMessages.md
@@ -30,11 +30,11 @@ let producer = try KafkaProducer(config: config, logger: logger)
 
 let serviceGroup = ServiceGroup(
     services: [producer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
@@ -62,11 +62,11 @@ let (producer, events) = try KafkaProducer.makeProducerWithEvents(
 
 let serviceGroup = ServiceGroup(
     services: [producer],
-    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    gracefulShutdownSignals: [.sigterm],
     logger: logger
 )
 
-try await withThrowingTaskGroup(of: Void.self) { group in
+await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {

--- a/Sources/Kafka/Kafka.docc/ProducingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ProducingMessages.md
@@ -6,7 +6,7 @@ Send records to Kafka topics with awaitable acknowledgments or with high-through
 
 A ``KafkaProducer`` offers two send styles. The awaitable ``KafkaProducer/sendAndAwait(_:)`` returns once the broker confirms delivery, and the fire-and-forget ``KafkaProducer/send(_:)`` enqueues records for transmission and reports outcomes through an `AsyncSequence` of events.
 
-Choose `sendAndAwait(_:)` when you need confirmation per message — for example, in a request handler that returns the resulting partition and offset to its caller. Choose `send(_:)` paired with an events sequence when you need maximum throughput and can process delivery reports in batches.
+Choose `sendAndAwait(_:)` for per-message confirmation — for example, in a request handler that returns the resulting partition and offset to its caller. Choose `send(_:)` paired with an events sequence for maximum throughput when batched delivery report processing is acceptable.
 
 Either way, the producer conforms to the `Service` protocol and runs inside a `ServiceGroup`, so the surrounding application controls its lifecycle.
 
@@ -95,7 +95,7 @@ The synchronous ``KafkaProducer/send(_:)`` returns a ``KafkaProducerMessageID``.
 
 ### Handle producer events
 
-Beyond delivery reports, the events sequence emits errors and other broker events. See ``KafkaProducerEvent`` for the full set of cases. To classify errors, read ``KafkaError/isFatal`` and ``KafkaError/isRetriable``: a fatal error means the producer can't recover, and your application needs to shut it down. A retriable error typically resolves on its own as the broker recovers.
+Beyond delivery reports, the events sequence emits errors and other broker events. See ``KafkaProducerEvent`` for the full set of cases. To classify errors, read ``KafkaError/isFatal`` and ``KafkaError/isRetriable``: a fatal error means the producer can't recover, and the application needs to shut it down. A retriable error typically resolves on its own as the broker recovers.
 
 ## Topics
 

--- a/Sources/Kafka/Kafka.docc/ProducingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ProducingMessages.md
@@ -8,7 +8,7 @@ A ``KafkaProducer`` offers two send styles. The awaitable ``KafkaProducer/sendAn
 
 Choose `sendAndAwait(_:)` when you need confirmation per message — for example, in a request handler that returns the resulting partition and offset to its caller. Choose `send(_:)` paired with an events sequence when you need maximum throughput and can process delivery reports in batches.
 
-In either case, the producer conforms to the `Service` protocol and runs inside a `ServiceGroup` so that the surrounding application controls its lifecycle.
+Either way, the producer conforms to the `Service` protocol and runs inside a `ServiceGroup`, so the surrounding application controls its lifecycle.
 
 ### Configure the producer
 
@@ -87,15 +87,15 @@ try await withThrowingTaskGroup(of: Void.self) { group in
 }
 ```
 
-The events sequence delivers reports in batches as `librdkafka` flushes them, which keeps overhead low compared with awaiting each message individually.
+The events sequence delivers reports in batches as `librdkafka` flushes them, which keeps overhead lower than awaiting each message individually.
 
 ### Identify a record before delivery
 
-The synchronous ``KafkaProducer/send(_:)`` returns a ``KafkaProducerMessageID`` you can use to match a later ``KafkaDeliveryReport`` back to the originating record. The same identifier appears on the report.
+The synchronous ``KafkaProducer/send(_:)`` returns a ``KafkaProducerMessageID``. Use this identifier to match a later ``KafkaDeliveryReport`` to the originating record; the same identifier appears on the report.
 
 ### Handle producer events
 
-Beyond delivery reports, the events sequence emits errors and other broker events. See ``KafkaProducerEvent`` for the full set of cases. To classify errors, read ``KafkaError/isFatal`` and ``KafkaError/isRetriable``: a fatal error means the producer is unrecoverable and the application needs to shut it down, while a retriable error typically resolves on its own as the broker recovers.
+Beyond delivery reports, the events sequence emits errors and other broker events. See ``KafkaProducerEvent`` for the full set of cases. To classify errors, read ``KafkaError/isFatal`` and ``KafkaError/isRetriable``: a fatal error means the producer can't recover, and your application needs to shut it down. A retriable error typically resolves on its own as the broker recovers.
 
 ## Topics
 

--- a/Sources/Kafka/Kafka.docc/ProducingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ProducingMessages.md
@@ -1,0 +1,113 @@
+# Producing messages
+
+Send records to Kafka topics with awaitable acknowledgments or with high-throughput batched delivery reports.
+
+## Overview
+
+A ``KafkaProducer`` offers two send styles. The awaitable ``KafkaProducer/sendAndAwait(_:)`` returns once the broker confirms delivery, and the fire-and-forget ``KafkaProducer/send(_:)`` enqueues records for transmission and reports outcomes through an `AsyncSequence` of events.
+
+Choose `sendAndAwait(_:)` when you need confirmation per message — for example, in a request handler that returns the resulting partition and offset to its caller. Choose `send(_:)` paired with an events sequence when you need maximum throughput and can process delivery reports in batches.
+
+In either case, the producer conforms to the `Service` protocol and runs inside a `ServiceGroup` so that the surrounding application controls its lifecycle.
+
+### Configure the producer
+
+A ``KafkaProducerConfig`` holds the broker addresses and other producer settings. The minimum requirement is `bootstrapServers`:
+
+```swift
+var config = KafkaProducerConfig()
+config.bootstrapServers = ["localhost:9092"]
+```
+
+For configurable security options, see <doc:SecuringConnections>.
+
+### Send and await acknowledgment
+
+Construct a ``KafkaProducer``, run it inside a `ServiceGroup`, and call ``KafkaProducer/sendAndAwait(_:)`` from a sibling task. The returned ``KafkaDeliveryReport`` carries a ``KafkaDeliveryReport/status`` value of `.acknowledged(KafkaAcknowledgedMessage)` on success, or `.failure(KafkaError)` if the broker rejects the record.
+
+```swift
+let producer = try KafkaProducer(config: config, logger: logger)
+
+let serviceGroup = ServiceGroup(
+    services: [producer],
+    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    logger: logger
+)
+
+try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { try await serviceGroup.run() }
+
+    group.addTask {
+        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        let report = try await producer.sendAndAwait(message)
+        switch report.status {
+        case .acknowledged(let ack):
+            print("Delivered to partition \(ack.partition) at offset \(ack.offset)")
+        case .failure(let error):
+            print("Delivery failed: \(error)")
+        }
+    }
+}
+```
+
+### Send records with batched delivery reports
+
+For high-throughput pipelines, create the producer alongside its events sequence with ``KafkaProducer/makeProducerWithEvents(config:logger:)``. Call ``KafkaProducer/send(_:)`` to enqueue records, and consume ``KafkaProducerEvent`` values from the events sequence to learn outcomes:
+
+```swift
+let (producer, events) = try KafkaProducer.makeProducerWithEvents(
+    config: config,
+    logger: logger
+)
+
+let serviceGroup = ServiceGroup(
+    services: [producer],
+    configuration: ServiceGroupConfiguration(gracefulShutdownSignals: [.sigterm]),
+    logger: logger
+)
+
+try await withThrowingTaskGroup(of: Void.self) { group in
+    group.addTask { try await serviceGroup.run() }
+
+    group.addTask {
+        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        try producer.send(message)
+
+        for await event in events {
+            switch event {
+            case .deliveryReports(let reports):
+                for report in reports {
+                    // Handle delivery acknowledgment.
+                }
+            default:
+                break
+            }
+        }
+    }
+}
+```
+
+The events sequence delivers reports in batches as `librdkafka` flushes them, which keeps overhead low compared with awaiting each message individually.
+
+### Identify a record before delivery
+
+The synchronous ``KafkaProducer/send(_:)`` returns a ``KafkaProducerMessageID`` you can use to match a later ``KafkaDeliveryReport`` back to the originating record. The same identifier appears on the report.
+
+### Handle producer events
+
+Beyond delivery reports, the events sequence emits errors and other broker events. See ``KafkaProducerEvent`` for the full set of cases. To classify errors, read ``KafkaError/isFatal`` and ``KafkaError/isRetriable``: a fatal error means the producer is unrecoverable and the application needs to shut it down, while a retriable error typically resolves on its own as the broker recovers.
+
+## Topics
+
+### Sending records
+
+- ``KafkaProducer/send(_:)``
+- ``KafkaProducer/sendAndAwait(_:)``
+- ``KafkaProducer/makeProducerWithEvents(config:logger:)``
+
+### Inspecting outcomes
+
+- ``KafkaDeliveryReport``
+- ``KafkaAcknowledgedMessage``
+- ``KafkaProducerMessageID``
+- ``KafkaProducerEvent``

--- a/Sources/Kafka/Kafka.docc/SecuringConnections.md
+++ b/Sources/Kafka/Kafka.docc/SecuringConnections.md
@@ -6,11 +6,11 @@ Configure TLS or SASL authentication for producers and consumers connecting to a
 
 Both ``KafkaProducer`` and ``KafkaConsumer`` accept the same security settings on their configuration types. You select the wire protocol with `securityProtocol`, and you provide SASL credentials when the chosen protocol requires them.
 
-The examples below configure a ``KafkaProducerConfig``. The same property names apply to ``KafkaConsumerConfig``.
+The following examples configure a ``KafkaProducerConfig``. The same property names apply to ``KafkaConsumerConfig``.
 
 ### Use plaintext for local development
 
-Plaintext sends data unencrypted and is appropriate only for local development against a broker on a trusted network:
+Plaintext sends data without encryption, and is appropriate only for local development against a broker on a trusted network:
 
 ```swift
 var config = KafkaProducerConfig()

--- a/Sources/Kafka/Kafka.docc/SecuringConnections.md
+++ b/Sources/Kafka/Kafka.docc/SecuringConnections.md
@@ -4,7 +4,7 @@ Configure TLS or SASL authentication for producers and consumers connecting to a
 
 ## Overview
 
-Both ``KafkaProducer`` and ``KafkaConsumer`` accept the same security settings on their configuration types. You select the wire protocol with `securityProtocol`, and you provide SASL credentials when the chosen protocol requires them.
+Both ``KafkaProducer`` and ``KafkaConsumer`` accept the same security settings on their configuration types. Select the wire protocol with `securityProtocol`, and provide SASL credentials when the chosen protocol requires them.
 
 The following examples configure a ``KafkaProducerConfig``. The same property names apply to ``KafkaConsumerConfig``.
 

--- a/Sources/Kafka/Kafka.docc/SecuringConnections.md
+++ b/Sources/Kafka/Kafka.docc/SecuringConnections.md
@@ -1,0 +1,57 @@
+# Securing connections
+
+Configure TLS or SASL authentication for producers and consumers connecting to a broker.
+
+## Overview
+
+Both ``KafkaProducer`` and ``KafkaConsumer`` accept the same security settings on their configuration types. You select the wire protocol with `securityProtocol`, and you provide SASL credentials when the chosen protocol requires them.
+
+The examples below configure a ``KafkaProducerConfig``. The same property names apply to ``KafkaConsumerConfig``.
+
+### Use plaintext for local development
+
+Plaintext sends data unencrypted and is appropriate only for local development against a broker on a trusted network:
+
+```swift
+var config = KafkaProducerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.securityProtocol = .plaintext
+```
+
+### Encrypt with TLS
+
+To encrypt the connection without authenticating, use TLS:
+
+```swift
+var config = KafkaProducerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.securityProtocol = .ssl
+```
+
+### Authenticate with SASL over plaintext
+
+For environments that authenticate clients with SASL but don't require encryption, set the protocol to `.sasl_plaintext` and provide a mechanism with credentials:
+
+```swift
+var config = KafkaProducerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.securityProtocol = .sasl_plaintext
+config.saslMechanisms = "PLAIN"
+config.saslUsername = "user"
+config.saslPassword = "password"
+```
+
+### Authenticate with SASL over TLS
+
+For production, combine SASL authentication with TLS encryption:
+
+```swift
+var config = KafkaProducerConfig()
+config.bootstrapServers = ["localhost:9092"]
+config.securityProtocol = .sasl_ssl
+config.saslMechanisms = "SCRAM-SHA-256"
+config.saslUsername = "user"
+config.saslPassword = "password"
+```
+
+`SCRAM-SHA-256` and `SCRAM-SHA-512` keep the password from traveling in the clear during the handshake; `PLAIN` does not, so reserve `PLAIN` for transports already protected by TLS.

--- a/Sources/Kafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/Kafka/KafkaAcknowledgedMessage.swift
@@ -17,9 +17,9 @@ import NIOCore
 
 /// A message acknowledged by the Kafka cluster.
 public struct KafkaAcknowledgedMessage {
-    /// The topic that the message was sent to.
+    /// The topic the producer sent the message to.
     public var topic: String
-    /// The partition that the message was sent to.
+    /// The partition the producer sent the message to.
     public var partition: KafkaPartition
     /// The key of the message.
     public var key: ByteBuffer?

--- a/Sources/Kafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/Kafka/KafkaAcknowledgedMessage.swift
@@ -31,7 +31,7 @@ public struct KafkaAcknowledgedMessage {
     public var headers: [KafkaHeader]
 
     /// Initialize ``KafkaAcknowledgedMessage`` from `rd_kafka_message_t` pointer.
-    /// - Throws: A ``KafkaAcknowledgedMessageError`` for failed acknowledgements or malformed messages.
+    /// - Throws: A ``KafkaAcknowledgedMessageError`` for failed acknowledgments or malformed messages.
     internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
         let rdKafkaMessage = messagePointer.pointee
 

--- a/Sources/Kafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/Kafka/KafkaAcknowledgedMessage.swift
@@ -31,7 +31,7 @@ public struct KafkaAcknowledgedMessage {
     public var headers: [KafkaHeader]
 
     /// Initialize ``KafkaAcknowledgedMessage`` from `rd_kafka_message_t` pointer.
-    /// - Throws: A ``KafkaAcknowledgedMessageError`` for failed acknowledgments or malformed messages.
+    /// - Throws: A ``KafkaError`` for failed acknowledgments or malformed messages.
     internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
         let rdKafkaMessage = messagePointer.pointee
 

--- a/Sources/Kafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/Kafka/KafkaAcknowledgedMessage.swift
@@ -30,7 +30,7 @@ public struct KafkaAcknowledgedMessage {
     /// The headers of the message.
     public var headers: [KafkaHeader]
 
-    /// Initialize ``KafkaAcknowledgedMessage`` from `rd_kafka_message_t` pointer.
+    /// Creates a ``KafkaAcknowledgedMessage`` from an `rd_kafka_message_t` pointer.
     /// - Throws: A ``KafkaError`` for failed acknowledgments or malformed messages.
     internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
         let rdKafkaMessage = messagePointer.pointee

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -761,7 +761,7 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     /// Commits all stored offsets to the broker.
-    /// Awaits until the commit succeeds or an error is encountered.
+    /// Awaits until the commit succeeds or encounters an error.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
     /// - Throws: A ``KafkaError`` if the commit failed or the consumer is closed.
@@ -809,8 +809,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// Retrieves the current positions (next offset to be fetched) for the given topic+partition pairs.
     ///
     /// The position reflects the consumer's in-memory position, which is the last consumed
-    /// message's offset + 1. This is useful for computing consumer lag when compared with
-    /// the committed offsets.
+    /// message's offset + 1. Use the position to compute consumer lag against the committed offsets.
     ///
     /// - Parameter topicPartitions: An array of ``KafkaTopicPartition`` to query.
     /// - Returns: An array of ``KafkaTopicPartitionOffset``. The ``KafkaTopicPartitionOffset/offset``
@@ -878,10 +877,9 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// This function is used to gracefully shut down a Kafka consumer client.
+    /// Gracefully shuts down a Kafka consumer client.
     ///
-    /// - Note: Invoking this function is not always needed as the ``KafkaConsumer``
-    /// will already shut down when consumption of the ``KafkaConsumerMessages`` has ended.
+    /// - Note: Invoking this method isn't always needed; the ``KafkaConsumer`` already shuts down when consumption of ``KafkaConsumerMessages`` ends.
     public func triggerGracefulShutdown() {
         let action = self.stateMachine.withLockedValue { $0.finish() }
         switch action {

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -39,6 +39,7 @@ extension KafkaConsumerEventsDelegate: NIOAsyncSequenceProducerDelegate {
 
 /// An asynchronous sequence of ``KafkaConsumerEvent`` values emitted by Kafka.
 public struct KafkaConsumerEvents: Sendable, AsyncSequence {
+    /// The type of event the sequence yields.
     public typealias Element = KafkaConsumerEvent
     typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaConsumerEventsDelegate>
@@ -48,11 +49,13 @@ public struct KafkaConsumerEvents: Sendable, AsyncSequence {
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
+        /// Returns the next consumer event, or `nil` if the sequence has finished.
         public mutating func next() async -> Element? {
             await self.wrappedIterator.next()
         }
     }
 
+    /// Returns an asynchronous iterator over the consumer event sequence.
     public func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(wrappedIterator: self.wrappedSequence.makeAsyncIterator())
     }
@@ -67,6 +70,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
     let stateMachine: LockedMachine
     let pollInterval: Duration
 
+    /// The type of message the sequence yields.
     public typealias Element = KafkaConsumerMessage
 
     /// An asynchronous iterator over ``KafkaConsumerMessage`` values received from the Kafka cluster.
@@ -95,6 +99,9 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
             )
         }
 
+        /// Returns the next consumer message, or `nil` when the consumer has shut down or the task is canceled.
+        ///
+        /// - Throws: A ``KafkaError`` if polling for the next message fails.
         public func next() async throws -> Element? {
             while !Task.isCancelled {
                 let action = self.stateMachineHolder.stateMachine.withLockedValue { $0.nextConsumerPollLoopAction() }
@@ -130,6 +137,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
         }
     }
 
+    /// Returns an asynchronous iterator over the consumer message sequence.
     public func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(
             stateMachine: self.stateMachine,
@@ -312,6 +320,9 @@ public final class KafkaConsumer: Sendable, Service {
         return (consumer, eventsSequence)
     }
 
+    /// Creates a new consumer from a `KafkaConsumerConfiguration`.
+    ///
+    /// This initializer is deprecated. Use ``init(config:logger:)`` instead.
     @available(*, deprecated, message: "Use init(config:logger:) instead")
     public convenience init(
         configuration: KafkaConsumerConfiguration,
@@ -323,6 +334,9 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
+    /// Creates a new consumer and an event sequence from a `KafkaConsumerConfiguration`.
+    ///
+    /// This method is deprecated. Use ``makeConsumerWithEvents(config:logger:)`` instead.
     @available(*, deprecated, message: "Use makeConsumerWithEvents(config:logger:) instead")
     public static func makeConsumerWithEvents(
         configuration: KafkaConsumerConfiguration,
@@ -712,6 +726,9 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
+    /// Commits the offset of the given message synchronously.
+    ///
+    /// This method is deprecated. Use ``commit(_:)`` instead.
     @available(*, deprecated, renamed: "commit")
     public func commitSync(_ message: KafkaConsumerMessage) async throws {
         try await self.commit(message)

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -828,7 +828,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Check if the current partition assignment has been lost involuntarily.
+    /// A Boolean value that indicates whether the current partition assignment is involuntarily lost.
     ///
     /// This is primarily useful when reacting to a rebalance event.
     /// When partitions are lost (for example, because `max.poll.interval.ms` was exceeded),

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -352,9 +352,9 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Subscribes to the given list of topics.
     ///
-    /// This replaces any previous subscription. The partition assignment happens
-    /// automatically using the consumer's consumer group. Topic names prefixed
-    /// with `^` are treated as regular expressions. Passing an empty array is
+    /// This replaces any previous subscription. The consumer assigns partitions
+    /// automatically using the consumer group. The consumer treats topic names prefixed
+    /// with `^` as regular expressions. Passing an empty array is
     /// equivalent to calling ``unsubscribe()``.
     ///
     /// - Parameter topics: An array of topic names to subscribe to.
@@ -385,7 +385,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// Clears all topic subscriptions. The consumer leaves the consumer group
     /// and stops receiving messages. This triggers a rebalance event.
-    /// Can re-subscribe later with ``subscribe(topics:)``.
+    /// Resubscribe later with ``subscribe(topics:)``.
     ///
     /// - Throws: A ``KafkaError`` if the consumer is closed or unsubscribing failed.
     public func unsubscribe() throws {
@@ -471,10 +471,10 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     /// Assigns the ``KafkaConsumer`` to a specific `partition` of a `topic`.
-    /// - Parameter topic: Name of the topic that this ``KafkaConsumer`` will read from.
-    /// - Parameter partition: Partition that this ``KafkaConsumer`` will read from.
+    /// - Parameter topic: Name of the topic to read from.
+    /// - Parameter partition: Partition to read from.
     /// - Parameter offset: The offset to start consuming from.
-    /// Defaults to the end of the Kafka partition queue (meaning wait for next produced message).
+    /// Defaults to the end of the Kafka partition queue (waits for the next produced message).
     /// - Throws: A ``KafkaError`` if the consumer could not be assigned to the topic + partition pair.
     private func assign(
         topic: String,
@@ -669,19 +669,19 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Stores the offset of a consumed message in the local offset store.
     ///
-    /// This is used for at-least-once delivery semantics. The typical pattern is:
+    /// Use this for at-least-once delivery semantics. The typical pattern is:
     /// 1. Set `enableAutoOffsetStore` to `false` in the consumer configuration.
     /// 2. Keep `enableAutoCommit` as `true` (the default).
     /// 3. After successfully processing a message, call `storeOffset(_:)`.
     /// 4. The auto-commit timer periodically commits stored offsets to the broker.
     ///
-    /// This ensures that only offsets for successfully processed messages are committed.
-    /// If the application crashes before calling `storeOffset`, the consumer re-delivers
+    /// This ensures the consumer commits only offsets for successfully processed messages.
+    /// If the application crashes before calling `storeOffset`, the consumer redelivers
     /// the message on the next consumer start (at-least-once).
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoOffsetStore`` is not set to `false`.
     ///
-    /// - Parameter message: The message whose offset should be stored.
+    /// - Parameter message: The message whose offset to store.
     /// - Throws: A ``KafkaError`` if storing the offset failed or the consumer is closed.
     public func storeOffset(_ message: KafkaConsumerMessage) throws {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
@@ -704,14 +704,14 @@ public final class KafkaConsumer: Sendable, Service {
     /// Marks all messages up to the passed message in the topic as read.
     ///
     /// Schedules a commit and returns immediately.
-    /// Any errors encountered after scheduling the commit will be discarded.
+    /// The consumer discards any errors encountered after scheduling the commit.
     ///
-    /// This method is only used for manual offset management.
+    /// Use this method only for manual offset management.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
     ///
     /// - Parameters:
-    ///     - message: Last received message that shall be marked as read.
+    ///     - message: Last received message to mark as read.
     /// - Throws: A ``KafkaError`` if committing failed.
     public func scheduleCommit(_ message: KafkaConsumerMessage) throws {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
@@ -737,14 +737,14 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Marks all messages up to the passed message in the topic as read.
     ///
-    /// Awaits until the commit succeeds or an error is encountered.
+    /// Awaits until the commit succeeds or an error occurs.
     ///
-    /// This method is only used for manual offset management.
+    /// Use this method only for manual offset management.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
     ///
     /// - Parameters:
-    ///     - message: Last received message that shall be marked as read.
+    ///     - message: Last received message to mark as read.
     /// - Throws: A ``KafkaError`` if committing failed.
     public func commit(_ message: KafkaConsumerMessage) async throws {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
@@ -802,8 +802,8 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Retrieves the last-committed offsets for the given topic+partition pairs from the broker.
     ///
-    /// This is useful for monitoring consumer lag and verifying that offsets have been
-    /// successfully committed.
+    /// Use this to monitor consumer lag and to verify that the broker received the
+    /// committed offsets.
     ///
     /// - Parameters:
     ///   - topicPartitions: An array of ``KafkaTopicPartition`` to query.
@@ -850,10 +850,10 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// A Boolean value that indicates whether the current partition assignment is involuntarily lost.
     ///
-    /// This is primarily useful when reacting to a rebalance event.
-    /// When partitions are lost (for example, because `max.poll.interval.ms` was exceeded),
-    /// committing offsets for those partitions will fail because they may already
-    /// be owned by another consumer in the group.
+    /// This value is primarily useful when reacting to a rebalance event.
+    /// When the consumer loses partitions (for example, because `max.poll.interval.ms` was exceeded),
+    /// committing offsets for those partitions fails because another consumer in the group
+    /// may already own them.
     ///
     /// - Returns: `true` if the current assignment is considered lost, `false` otherwise.
     /// - Throws: A ``KafkaError`` if the consumer is closed.
@@ -871,7 +871,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Seeks to specific offsets for the given partitions.
     ///
-    /// This is useful for replaying messages or skipping ahead. The partitions
+    /// Use this to replay messages or to skip ahead. The partitions
     /// must already be assigned to this consumer (via subscription or manual assignment).
     ///
     /// This call purges all pre-fetched messages for the given partitions.

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -665,7 +665,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// If the application crashes before calling `storeOffset`, the message will be
     /// re-delivered on the next consumer start (at-least-once).
     ///
-    /// - Warning: This method fails if `enableAutoOffsetStore` is not set to `false`.
+    /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoOffsetStore`` is not set to `false`.
     ///
     /// - Parameter message: The message whose offset should be stored.
     /// - Throws: A ``KafkaError`` if storing the offset failed or the consumer is closed.
@@ -693,7 +693,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// This method is only used for manual offset management.
     ///
-    /// - Warning: This method fails if the ``KafkaConsumerConfiguration/isAutoCommitEnabled`` configuration property is set to `true` (default).
+    /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
     ///
     /// - Parameters:
     ///     - message: Last received message that shall be marked as read.
@@ -722,7 +722,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// This method is only used for manual offset management.
     ///
-    /// - Warning: This method fails if the ``KafkaConsumerConfiguration/isAutoCommitEnabled`` configuration property is set to `true` (default).
+    /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
     ///
     /// - Parameters:
     ///     - message: Last received message that shall be marked as read.

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -480,7 +480,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Starts the ``KafkaConsumer``.
     ///
-    /// - Important: This method **must** be called and runs until either the calling task is canceled or gracefully shut down.
+    /// - Important: Call this method to drive the consumer. It runs until either the calling task is canceled or gracefully shut down.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()
@@ -655,13 +655,13 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Stores the offset of a consumed message in the local offset store.
     ///
-    /// This is used for **at-least-once** delivery semantics. The typical pattern is:
+    /// This is used for at-least-once delivery semantics. The typical pattern is:
     /// 1. Set `enableAutoOffsetStore` to `false` in the consumer configuration.
     /// 2. Keep `enableAutoCommit` as `true` (the default).
     /// 3. After successfully processing a message, call `storeOffset(_:)`.
     /// 4. The auto-commit timer periodically commits stored offsets to the broker.
     ///
-    /// This ensures that only offsets for **successfully processed** messages are committed.
+    /// This ensures that only offsets for successfully processed messages are committed.
     /// If the application crashes before calling `storeOffset`, the consumer re-delivers
     /// the message on the next consumer start (at-least-once).
     ///

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -37,14 +37,14 @@ extension KafkaConsumerEventsDelegate: NIOAsyncSequenceProducerDelegate {
 
 // MARK: - KafkaConsumerEvents
 
-/// `AsyncSequence` implementation for handling ``KafkaConsumerEvent``s emitted by Kafka.
+/// An asynchronous sequence of ``KafkaConsumerEvent`` values emitted by Kafka.
 public struct KafkaConsumerEvents: Sendable, AsyncSequence {
     public typealias Element = KafkaConsumerEvent
     typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaConsumerEventsDelegate>
     let wrappedSequence: WrappedSequence
 
-    /// `AsyncIteratorProtocol` implementation for handling ``KafkaConsumerEvent``s emitted by Kafka.
+    /// An asynchronous iterator over ``KafkaConsumerEvent`` values emitted by Kafka.
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
@@ -60,7 +60,7 @@ public struct KafkaConsumerEvents: Sendable, AsyncSequence {
 
 // MARK: - KafkaConsumerMessages
 
-/// `AsyncSequence` implementation for handling messages received from the Kafka cluster (``KafkaConsumerMessage``).
+/// An asynchronous sequence of ``KafkaConsumerMessage`` values received from the Kafka cluster.
 public struct KafkaConsumerMessages: Sendable, AsyncSequence {
     typealias LockedMachine = NIOLockedValueBox<KafkaConsumer.StateMachine>
 
@@ -69,7 +69,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
 
     public typealias Element = KafkaConsumerMessage
 
-    /// `AsyncIteratorProtocol` implementation for handling messages received from the Kafka cluster (``KafkaConsumerMessage``).
+    /// An asynchronous iterator over ``KafkaConsumerMessage`` values received from the Kafka cluster.
     public struct AsyncIterator: AsyncIteratorProtocol {
         private let stateMachineHolder: MachineHolder
         let pollInterval: Duration
@@ -140,7 +140,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
 
 // MARK: - KafkaConsumer
 
-/// Can be used to consume messages from a Kafka cluster.
+/// Consumes messages from a Kafka cluster.
 public final class KafkaConsumer: Sendable, Service {
     typealias ConsumerEventsProducer = NIOAsyncSequenceProducer<
         KafkaConsumerEvent,
@@ -165,7 +165,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// - Important: Must be declared AFTER `stateMachine` — see ordering note above.
     private let rebalanceContext: RebalanceContext
 
-    /// An asynchronous sequence containing messages from the Kafka cluster.
+    /// An asynchronous sequence of messages from the Kafka cluster.
     public let messages: KafkaConsumerMessages
 
     // Private initializer, use factory method or convenience init to create KafkaConsumer

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -44,7 +44,7 @@ public struct KafkaConsumerEvents: Sendable, AsyncSequence {
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaConsumerEventsDelegate>
     let wrappedSequence: WrappedSequence
 
-    /// `AsynceIteratorProtocol` implementation for handling ``KafkaConsumerEvent``s emitted by Kafka.
+    /// `AsyncIteratorProtocol` implementation for handling ``KafkaConsumerEvent``s emitted by Kafka.
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
@@ -69,7 +69,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
 
     public typealias Element = KafkaConsumerMessage
 
-    /// `AsynceIteratorProtocol` implementation for handling messages received from the Kafka cluster (``KafkaConsumerMessage``).
+    /// `AsyncIteratorProtocol` implementation for handling messages received from the Kafka cluster (``KafkaConsumerMessage``).
     public struct AsyncIterator: AsyncIteratorProtocol {
         private let stateMachineHolder: MachineHolder
         let pollInterval: Duration
@@ -158,7 +158,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///   `rd_kafka_destroy` stops all librdkafka threads before the `RebalanceContext`
     ///   (which holds the C callback's unretained pointer target) is deallocated.
     private let stateMachine: NIOLockedValueBox<StateMachine>
-    /// Source for yielding consumer events (rebalance, etc.). `nil` when created without events.
+    /// Source for yielding consumer events (rebalance, and so on). `nil` when created without events.
     private let eventsSource: ConsumerEventsProducer.Source?
     /// Context for the C rebalance callback. Must outlive the `RDKafkaClient` because the
     /// C callback holds an unretained pointer to it.
@@ -170,7 +170,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     // Private initializer, use factory method or convenience init to create KafkaConsumer
     /// Initialize a new ``KafkaConsumer``.
-    /// To listen to incoming messages, please subscribe to a list of topics using ``subscribe()``
+    /// To listen to incoming messages, subscribe to a list of topics using ``subscribe(topics:)``
     /// or assign the consumer to a particular topic + partition pair using ``assign(topic:partition:offset:)``.
     ///
     /// - Parameters:
@@ -831,7 +831,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// Check if the current partition assignment has been lost involuntarily.
     ///
     /// This is primarily useful when reacting to a rebalance event.
-    /// When partitions are lost (e.g., because `max.poll.interval.ms` was exceeded),
+    /// When partitions are lost (for example, because `max.poll.interval.ms` was exceeded),
     /// committing offsets for those partitions will fail because they may already
     /// be owned by another consumer in the group.
     ///
@@ -1211,7 +1211,7 @@ extension KafkaConsumer {
             }
         }
 
-        /// Returns the client if available, for cleanup purposes (e.g., final event drain).
+        /// Returns the client if available, for cleanup purposes (for example, final event drain).
         /// Unlike ``withClient()``, this does not fatalError in transitional states —
         /// it returns `nil` when no client is available.
         func clientForCleanup() -> RDKafkaClient? {

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -702,6 +702,7 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     /// Marks all messages up to the passed message in the topic as read.
+    ///
     /// Schedules a commit and returns immediately.
     /// Any errors encountered after scheduling the commit will be discarded.
     ///
@@ -735,6 +736,7 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     /// Marks all messages up to the passed message in the topic as read.
+    ///
     /// Awaits until the commit succeeds or an error is encountered.
     ///
     /// This method is only used for manual offset management.
@@ -759,6 +761,7 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     /// Schedules an asynchronous commit of all stored offsets.
+    ///
     /// Returns immediately. Any errors after scheduling are discarded.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
@@ -778,6 +781,7 @@ public final class KafkaConsumer: Sendable, Service {
     }
 
     /// Commits all stored offsets to the broker.
+    ///
     /// Awaits until the commit succeeds or encounters an error.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -37,7 +37,9 @@ extension KafkaConsumerEventsDelegate: NIOAsyncSequenceProducerDelegate {
 
 // MARK: - KafkaConsumerEvents
 
-/// An asynchronous sequence of ``KafkaConsumerEvent`` values emitted by Kafka.
+/// An asynchronous sequence of consumer events emitted by Kafka.
+///
+/// The sequence yields ``KafkaConsumerEvent`` values such as rebalance notifications and errors.
 public struct KafkaConsumerEvents: Sendable, AsyncSequence {
     /// The type of event the sequence yields.
     public typealias Element = KafkaConsumerEvent
@@ -45,7 +47,9 @@ public struct KafkaConsumerEvents: Sendable, AsyncSequence {
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaConsumerEventsDelegate>
     let wrappedSequence: WrappedSequence
 
-    /// An asynchronous iterator over ``KafkaConsumerEvent`` values emitted by Kafka.
+    /// An asynchronous iterator over consumer events emitted by Kafka.
+    ///
+    /// The iterator yields ``KafkaConsumerEvent`` values such as rebalance notifications and errors.
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
@@ -63,7 +67,9 @@ public struct KafkaConsumerEvents: Sendable, AsyncSequence {
 
 // MARK: - KafkaConsumerMessages
 
-/// An asynchronous sequence of ``KafkaConsumerMessage`` values received from the Kafka cluster.
+/// An asynchronous sequence of messages received from the Kafka cluster.
+///
+/// The sequence yields ``KafkaConsumerMessage`` values.
 public struct KafkaConsumerMessages: Sendable, AsyncSequence {
     typealias LockedMachine = NIOLockedValueBox<KafkaConsumer.StateMachine>
 
@@ -73,7 +79,9 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
     /// The type of message the sequence yields.
     public typealias Element = KafkaConsumerMessage
 
-    /// An asynchronous iterator over ``KafkaConsumerMessage`` values received from the Kafka cluster.
+    /// An asynchronous iterator over messages received from the Kafka cluster.
+    ///
+    /// The iterator yields ``KafkaConsumerMessage`` values.
     public struct AsyncIterator: AsyncIteratorProtocol {
         private let stateMachineHolder: MachineHolder
         let pollInterval: Duration
@@ -215,7 +223,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Creates a new ``KafkaConsumer``.
+    /// Creates a new consumer.
     ///
     /// This creates a consumer that does not listen to any events other than consumer messages.
     ///
@@ -257,7 +265,9 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
-    /// Creates a new ``KafkaConsumer`` and a ``KafkaConsumerEvents`` asynchronous sequence.
+    /// Creates a new consumer paired with an asynchronous event sequence.
+    ///
+    /// The returned tuple pairs a ``KafkaConsumer`` with its ``KafkaConsumerEvents`` sequence.
     ///
     /// Use the asynchronous sequence to consume events.
     ///
@@ -320,7 +330,7 @@ public final class KafkaConsumer: Sendable, Service {
         return (consumer, eventsSequence)
     }
 
-    /// Creates a new consumer from a `KafkaConsumerConfiguration`.
+    /// Creates a new consumer from a deprecated configuration value.
     ///
     /// This initializer is deprecated. Use ``init(config:logger:)`` instead.
     @available(*, deprecated, message: "Use init(config:logger:) instead")
@@ -334,7 +344,7 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
-    /// Creates a new consumer and an event sequence from a `KafkaConsumerConfiguration`.
+    /// Creates a new consumer and an event sequence from a deprecated configuration value.
     ///
     /// This method is deprecated. Use ``makeConsumerWithEvents(config:logger:)`` instead.
     @available(*, deprecated, message: "Use makeConsumerWithEvents(config:logger:) instead")
@@ -350,7 +360,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     // MARK: - Subscription Management
 
-    /// Subscribes to the given list of topics.
+    /// Subscribes to the list of topics you provide.
     ///
     /// This replaces any previous subscription. The consumer assigns partitions
     /// automatically using the consumer group. The consumer treats topic names prefixed
@@ -412,7 +422,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Pauses consumption for the given partitions.
+    /// Pauses consumption for the partitions you provide.
     ///
     /// Paused partitions remain in the consumer group and continue heartbeating
     /// but don't return messages from ``messages``.
@@ -433,7 +443,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Resumes consumption for the given partitions.
+    /// Resumes consumption for the partitions you provide.
     ///
     /// - Parameter topicPartitions: The partitions to resume.
     /// - Throws: A ``KafkaError`` if the consumer is closed or resuming failed.
@@ -492,7 +502,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Starts the ``KafkaConsumer``.
+    /// Starts the consumer.
     ///
     /// - Important: Call this method to drive the consumer. It runs until either the calling task is canceled or gracefully shut down.
     public func run() async throws {
@@ -727,7 +737,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Commits the offset of the given message synchronously.
+    /// Synchronously commits the offset of the message you provide.
     ///
     /// This method is deprecated. Use ``commit(_:)`` instead.
     @available(*, deprecated, renamed: "commit")
@@ -800,7 +810,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Retrieves the last-committed offsets for the given topic+partition pairs from the broker.
+    /// Retrieves the last-committed offsets from the broker for the topic+partition pairs you provide.
     ///
     /// Use this to monitor consumer lag and to verify that the broker received the
     /// committed offsets.
@@ -827,7 +837,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Retrieves the current positions (next offset to be fetched) for the given topic+partition pairs.
+    /// Retrieves the current positions (next offset to be fetched) for the topic+partition pairs you provide.
     ///
     /// The position reflects the consumer's in-memory position, which is the last consumed
     /// message's offset + 1. Use the position to compute consumer lag against the committed offsets.
@@ -869,12 +879,12 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Seeks to specific offsets for the given partitions.
+    /// Seeks to specific offsets for the partitions you provide.
     ///
     /// Use this to replay messages or to skip ahead. The partitions
     /// must already be assigned to this consumer (via subscription or manual assignment).
     ///
-    /// This call purges all pre-fetched messages for the given partitions.
+    /// This call purges all pre-fetched messages for the partitions you provide.
     ///
     /// - Parameters:
     ///   - topicPartitionOffsets: An array of ``KafkaTopicPartitionOffset`` specifying where to seek.

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -169,7 +169,7 @@ public final class KafkaConsumer: Sendable, Service {
     public let messages: KafkaConsumerMessages
 
     // Private initializer, use factory method or convenience init to create KafkaConsumer
-    /// Initialize a new ``KafkaConsumer``.
+    /// Creates a new ``KafkaConsumer``.
     /// To listen to incoming messages, subscribe to a list of topics using ``subscribe(topics:)``
     /// or assign the consumer to a particular topic + partition pair using ``assign(topic:partition:offset:)``.
     ///
@@ -207,7 +207,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Initialize a new ``KafkaConsumer``.
+    /// Creates a new ``KafkaConsumer``.
     ///
     /// This creates a consumer that does not listen to any events other than consumer messages.
     ///
@@ -249,7 +249,7 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
-    /// Initialize a new ``KafkaConsumer`` and a ``KafkaConsumerEvents`` asynchronous sequence.
+    /// Creates a new ``KafkaConsumer`` and a ``KafkaConsumerEvents`` asynchronous sequence.
     ///
     /// Use the asynchronous sequence to consume events.
     ///
@@ -336,7 +336,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     // MARK: - Subscription Management
 
-    /// Subscribe to the given list of topics.
+    /// Subscribes to the given list of topics.
     ///
     /// This replaces any previous subscription. The partition assignment happens
     /// automatically using the consumer's consumer group. Topic names prefixed
@@ -367,7 +367,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Unsubscribe from the current subscription.
+    /// Unsubscribes from the current subscription.
     ///
     /// Clears all topic subscriptions. The consumer leaves the consumer group
     /// and stops receiving messages. This triggers a rebalance event.
@@ -384,7 +384,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Get the current topic subscription.
+    /// Returns the current topic subscription.
     ///
     /// - Returns: An array of topic names or patterns the consumer is currently subscribed to.
     /// - Throws: A ``KafkaError`` if the consumer is closed or the query failed.
@@ -398,7 +398,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Pause consumption for the given partitions.
+    /// Pauses consumption for the given partitions.
     ///
     /// Paused partitions remain in the consumer group and continue heartbeating
     /// but will not return messages from ``messages``.
@@ -419,7 +419,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Resume consumption for the given partitions.
+    /// Resumes consumption for the given partitions.
     ///
     /// - Parameter topicPartitions: The partitions to resume.
     /// - Throws: A ``KafkaError`` if the consumer is closed or resuming failed.
@@ -456,7 +456,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Assign the``KafkaConsumer`` to a specific `partition` of a `topic`.
+    /// Assigns the ``KafkaConsumer`` to a specific `partition` of a `topic`.
     /// - Parameter topic: Name of the topic that this ``KafkaConsumer`` will read from.
     /// - Parameter partition: Partition that this ``KafkaConsumer`` will read from.
     /// - Parameter offset: The offset to start consuming from.
@@ -478,7 +478,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Start the ``KafkaConsumer``.
+    /// Starts the ``KafkaConsumer``.
     ///
     /// - Important: This method **must** be called and will run until either the calling task is cancelled or gracefully shut down.
     public func run() async throws {
@@ -653,7 +653,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Store the offset of a consumed message in the local offset store.
+    /// Stores the offset of a consumed message in the local offset store.
     ///
     /// This is used for **at-least-once** delivery semantics. The typical pattern is:
     /// 1. Set `enableAutoOffsetStore` to `false` in the consumer configuration.
@@ -687,7 +687,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Mark all messages up to the passed message in the topic as read.
+    /// Marks all messages up to the passed message in the topic as read.
     /// Schedules a commit and returns immediately.
     /// Any errors encountered after scheduling the commit will be discarded.
     ///
@@ -717,7 +717,7 @@ public final class KafkaConsumer: Sendable, Service {
         try await self.commit(message)
     }
 
-    /// Mark all messages up to the passed message in the topic as read.
+    /// Marks all messages up to the passed message in the topic as read.
     /// Awaits until the commit succeeds or an error is encountered.
     ///
     /// This method is only used for manual offset management.
@@ -741,7 +741,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Schedule an async commit of all stored offsets.
+    /// Schedules an asynchronous commit of all stored offsets.
     /// Returns immediately. Any errors after scheduling are discarded.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
@@ -760,7 +760,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Commit all stored offsets to the broker.
+    /// Commits all stored offsets to the broker.
     /// Awaits until the commit succeeds or an error is encountered.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
@@ -779,7 +779,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Retrieve the last-committed offsets for the given topic+partition pairs from the broker.
+    /// Retrieves the last-committed offsets for the given topic+partition pairs from the broker.
     ///
     /// This is useful for monitoring consumer lag and verifying that offsets have been
     /// successfully committed.
@@ -806,7 +806,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Retrieve the current positions (next offset to be fetched) for the given topic+partition pairs.
+    /// Retrieves the current positions (next offset to be fetched) for the given topic+partition pairs.
     ///
     /// The position reflects the consumer's in-memory position, which is the last consumed
     /// message's offset + 1. This is useful for computing consumer lag when compared with
@@ -849,7 +849,7 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Seek to specific offsets for the given partitions.
+    /// Seeks to specific offsets for the given partitions.
     ///
     /// This is useful for replaying messages or skipping ahead. The partitions
     /// must already be assigned to this consumer (via subscription or manual assignment).

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -226,6 +226,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// Creates a new consumer.
     ///
     /// This creates a consumer that does not listen to any events other than consumer messages.
+    /// To also receive events, use ``makeConsumerWithEvents(config:logger:)``.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
@@ -505,6 +506,8 @@ public final class KafkaConsumer: Sendable, Service {
     /// Starts the consumer.
     ///
     /// - Important: Call this method to drive the consumer. It runs until either the calling task is canceled or gracefully shut down.
+    ///
+    /// Stop the consumer with ``triggerGracefulShutdown()``.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -253,8 +253,8 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// Use the asynchronous sequence to consume events.
     ///
-    /// - Important: When the asynchronous sequence is deinited the consumer will be shut down and disallowed from sending more messages.
-    /// Additionally, make sure to consume the asynchronous sequence otherwise the events will be buffered in memory indefinitely.
+    /// - Important: When the asynchronous sequence is deinitialized, the consumer shuts down and stops accepting new messages.
+    ///   Additionally, consume the asynchronous sequence; otherwise the events buffer in memory indefinitely.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
@@ -401,7 +401,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// Pauses consumption for the given partitions.
     ///
     /// Paused partitions remain in the consumer group and continue heartbeating
-    /// but will not return messages from ``messages``.
+    /// but don't return messages from ``messages``.
     ///
     /// - Parameter topicPartitions: The partitions to pause.
     /// - Throws: A ``KafkaError`` if the consumer is closed or pausing failed.
@@ -480,7 +480,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Starts the ``KafkaConsumer``.
     ///
-    /// - Important: This method **must** be called and will run until either the calling task is cancelled or gracefully shut down.
+    /// - Important: This method **must** be called and runs until either the calling task is canceled or gracefully shut down.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()
@@ -659,11 +659,11 @@ public final class KafkaConsumer: Sendable, Service {
     /// 1. Set `enableAutoOffsetStore` to `false` in the consumer configuration.
     /// 2. Keep `enableAutoCommit` as `true` (the default).
     /// 3. After successfully processing a message, call `storeOffset(_:)`.
-    /// 4. The auto-commit timer will periodically commit stored offsets to the broker.
+    /// 4. The auto-commit timer periodically commits stored offsets to the broker.
     ///
     /// This ensures that only offsets for **successfully processed** messages are committed.
-    /// If the application crashes before calling `storeOffset`, the message will be
-    /// re-delivered on the next consumer start (at-least-once).
+    /// If the application crashes before calling `storeOffset`, the consumer re-delivers
+    /// the message on the next consumer start (at-least-once).
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoOffsetStore`` is not set to `false`.
     ///

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -22,7 +22,7 @@ public enum KafkaConsumerEvent: Sendable, Hashable {
     /// or initializing state on assign.
     case rebalance(KafkaConsumerRebalance)
 
-    /// An error reported by the Kafka client (e.g., broker disconnection, authentication failure).
+    /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
     case error(KafkaError)
 
     /// - Important: Always provide a `default` case when switching over this `enum`.

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -12,7 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An event delivered through the ``KafkaConsumerEvents`` asynchronous sequence.
+/// An event reported by a Kafka consumer, such as a rebalance notification or an error.
+///
+/// Delivered through ``KafkaConsumerEvents``.
 public enum KafkaConsumerEvent: Sendable, Hashable {
     /// A consumer group rebalance occurred.
     ///

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An enumeration representing events that can be received through the ``KafkaConsumerEvents`` asynchronous sequence.
+/// An event delivered through the ``KafkaConsumerEvents`` asynchronous sequence.
 public enum KafkaConsumerEvent: Sendable, Hashable {
     /// A consumer group rebalance occurred.
     ///

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -20,6 +20,7 @@ public struct KafkaTimestampType: Hashable, Sendable, CustomStringConvertible {
     /// The raw value corresponding to the librdkafka timestamp type.
     public let rawValue: Int32
 
+    /// Creates a timestamp type from its raw librdkafka value.
     public init(rawValue: Int32) {
         self.rawValue = rawValue
     }
@@ -37,6 +38,7 @@ public struct KafkaTimestampType: Hashable, Sendable, CustomStringConvertible {
         rawValue: Int32(RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME.rawValue)
     )
 
+    /// A textual representation of the timestamp type.
     public var description: String {
         switch self {
         case .createTime: return "createTime"

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -51,9 +51,9 @@ public struct KafkaTimestampType: Hashable, Sendable, CustomStringConvertible {
 
 /// A message received from the Kafka cluster.
 public struct KafkaConsumerMessage {
-    /// The topic that the message was received from.
+    /// The topic the consumer received the message from.
     public var topic: String
-    /// The partition that the message was received from.
+    /// The partition the consumer received the message from.
     public var partition: KafkaPartition
     /// The headers of the message.
     public var headers: [KafkaHeader]

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -66,7 +66,7 @@ public struct KafkaConsumerMessage {
     /// The type of timestamp on this message.
     public var timestampType: KafkaTimestampType
 
-    /// Initialize ``KafkaConsumerMessage`` from `rd_kafka_message_t` pointer.
+    /// Creates a ``KafkaConsumerMessage`` from an `rd_kafka_message_t` pointer.
     /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
     internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
         let rdKafkaMessage = messagePointer.pointee

--- a/Sources/Kafka/KafkaConsumerRebalance.swift
+++ b/Sources/Kafka/KafkaConsumerRebalance.swift
@@ -39,7 +39,7 @@ public struct KafkaConsumerRebalance: Sendable, Hashable {
     /// For ``Kind/error(_:)``: empty.
     public let partitions: [KafkaTopicPartition]
 
-    /// Create a rebalance event description.
+    /// Creates a rebalance event description.
     /// - Parameters:
     ///   - kind: Whether this is an assignment, revocation, or error.
     ///   - partitions: The partitions involved in this rebalance.

--- a/Sources/Kafka/KafkaConsumerRebalance.swift
+++ b/Sources/Kafka/KafkaConsumerRebalance.swift
@@ -24,8 +24,10 @@ public struct KafkaConsumerRebalance: Sendable, Hashable {
         case assign
         /// Partitions have been revoked from this consumer.
         case revoke
-        /// An unexpected error occurred during rebalance. All partitions have been
-        /// unassigned as a recovery measure. The associated string describes the error.
+        /// An unexpected error occurred during rebalance.
+        ///
+        /// All partitions have been unassigned as a recovery measure.
+        /// The associated string describes the error.
         case error(String)
     }
 

--- a/Sources/Kafka/KafkaConsumerRebalance.swift
+++ b/Sources/Kafka/KafkaConsumerRebalance.swift
@@ -20,13 +20,13 @@
 public struct KafkaConsumerRebalance: Sendable, Hashable {
     /// The kind of rebalance that occurred.
     public enum Kind: Sendable, Hashable {
-        /// New partitions have been assigned to this consumer.
+        /// Kafka assigned new partitions to this consumer.
         case assign
-        /// Partitions have been revoked from this consumer.
+        /// Kafka revoked partitions from this consumer.
         case revoke
         /// An unexpected error occurred during rebalance.
         ///
-        /// All partitions have been unassigned as a recovery measure.
+        /// Kafka unassigned all partitions as a recovery measure.
         /// The associated string describes the error.
         case error(String)
     }

--- a/Sources/Kafka/KafkaDeliveryReport.swift
+++ b/Sources/Kafka/KafkaDeliveryReport.swift
@@ -18,18 +18,18 @@ import Crdkafka
 public struct KafkaDeliveryReport: Sendable, Hashable {
     /// The outcome of a producer's attempt to deliver a message to the Kafka cluster.
     public enum Status: Sendable, Hashable {
-        /// The message has been successfully acknowledged by the Kafka cluster.
+        /// The Kafka cluster successfully acknowledged the message.
         case acknowledged(message: KafkaAcknowledgedMessage)
-        /// The message failed to be acknowledged by the Kafka cluster and encountered an error.
+        /// The Kafka cluster failed to acknowledge the message and encountered an error.
         case failure(KafkaError)
     }
 
     /// The ``Status`` of a Kafka producer message after attempting to send it.
     public var status: Status
 
-    /// The unique identifier assigned by the ``KafkaProducer`` when the message was sent to Kafka.
+    /// The unique identifier the ``KafkaProducer`` assigned when sending the message to Kafka.
     ///
-    /// The same identifier is returned by ``KafkaProducer/send(_:)`` and can be used to correlate
+    /// ``KafkaProducer/send(_:)`` returns the same identifier, which correlates
     /// a sent message with a delivery report.
     public var id: KafkaProducerMessageID
 

--- a/Sources/Kafka/KafkaDeliveryReport.swift
+++ b/Sources/Kafka/KafkaDeliveryReport.swift
@@ -28,6 +28,7 @@ public struct KafkaDeliveryReport: Sendable, Hashable {
     public var status: Status
 
     /// The unique identifier assigned by the ``KafkaProducer`` when the message was sent to Kafka.
+    ///
     /// The same identifier is returned by ``KafkaProducer/send(_:)`` and can be used to correlate
     /// a sent message with a delivery report.
     public var id: KafkaProducerMessageID

--- a/Sources/Kafka/KafkaDeliveryReport.swift
+++ b/Sources/Kafka/KafkaDeliveryReport.swift
@@ -16,6 +16,7 @@ import Crdkafka
 
 /// A delivery report for a message the producer sent to the Kafka cluster.
 public struct KafkaDeliveryReport: Sendable, Hashable {
+    /// The outcome of a producer's attempt to deliver a message to the Kafka cluster.
     public enum Status: Sendable, Hashable {
         /// The message has been successfully acknowledged by the Kafka cluster.
         case acknowledged(message: KafkaAcknowledgedMessage)

--- a/Sources/Kafka/KafkaDeliveryReport.swift
+++ b/Sources/Kafka/KafkaDeliveryReport.swift
@@ -24,10 +24,10 @@ public struct KafkaDeliveryReport: Sendable, Hashable {
         case failure(KafkaError)
     }
 
-    /// The ``Status`` of a Kafka producer message after attempting to send it.
+    /// The delivery status of the producer message.
     public var status: Status
 
-    /// The unique identifier the ``KafkaProducer`` assigned when sending the message to Kafka.
+    /// The unique identifier the producer assigned when sending the message to Kafka.
     ///
     /// ``KafkaProducer/send(_:)`` returns the same identifier, which correlates
     /// a sent message with a delivery report.

--- a/Sources/Kafka/KafkaDeliveryReport.swift
+++ b/Sources/Kafka/KafkaDeliveryReport.swift
@@ -14,7 +14,7 @@
 
 import Crdkafka
 
-/// A delivery report for a message that was sent to the Kafka cluster.
+/// A delivery report for a message the producer sent to the Kafka cluster.
 public struct KafkaDeliveryReport: Sendable, Hashable {
     public enum Status: Sendable, Hashable {
         /// The message has been successfully acknowledged by the Kafka cluster.

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -23,7 +23,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
 
     // MARK: - RDKafkaCode
 
-    /// A type-safe wrapper around librdkafka's `rd_kafka_resp_err_t` error codes.
+    /// A type-safe representation of a librdkafka `rd_kafka_resp_err_t` error code.
     ///
     /// Use the static constants (for example, `.allBrokersDown` or `.authentication`) to match
     /// against the ``KafkaError/rdKafkaCode`` property without importing Crdkafka.
@@ -72,7 +72,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
 
     private var backing: Backing
 
-    /// Represents the kind of error that was encountered.
+    /// The kind of error that was encountered.
     public var code: ErrorCode {
         get {
             self.backing.code
@@ -303,10 +303,10 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
 }
 
 extension KafkaError {
-    /// Represents the kind of error.
+    /// The high-level classification of a Kafka error.
     ///
     /// The same error may be thrown from more than one place for more than one reason.
-    /// This type represents only a relatively high-level error:
+    /// This type captures only a relatively high-level error:
     /// use the string representation of ``KafkaError`` to get more details about the specific cause.
     public struct ErrorCode: Hashable, Sendable, CustomStringConvertible {
         fileprivate enum BackingCode {

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -91,7 +91,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
         self.backing.rdKafkaCode
     }
 
-    /// Whether this error is fatal to the client instance.
+    /// A Boolean value that indicates whether the error is fatal to the client instance.
     ///
     /// A fatal error means the client instance is no longer usable and must be
     /// destroyed and re-created. Always `false` for errors that do not originate
@@ -100,7 +100,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
         self.backing.isFatal
     }
 
-    /// Whether this error is retriable.
+    /// A Boolean value that indicates whether the error is retriable.
     ///
     /// A retriable error indicates the operation may succeed if retried.
     /// Always `false` for errors that do not originate from librdkafka's

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -31,6 +31,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
         /// The raw `Int32` value corresponding to the librdkafka error code.
         public let rawValue: Int32
 
+        /// Creates a librdkafka error code from its raw `Int32` value.
         public init(rawValue: Int32) {
             self.rawValue = rawValue
         }
@@ -64,6 +65,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
         /// No error.
         public static let noError = RDKafkaCode(rawValue: 0)
 
+        /// A textual representation of the librdkafka error code, including its name and numeric value.
         public var description: String {
             let name = String(cString: rd_kafka_err2str(rd_kafka_resp_err_t(rawValue: self.rawValue)))
             return "\(name) (code: \(self.rawValue))"
@@ -121,6 +123,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
         self.backing.line
     }
 
+    /// A textual representation of the error, including its code, reason, and originating source location.
     public var description: String {
         "KafkaError.\(self.code): \(self.reason) \(self.file):\(self.line)"
     }
@@ -343,6 +346,7 @@ extension KafkaError {
         /// Deleting a topic failed.
         public static let topicDeletionFailed = ErrorCode(.topicDeletion)
 
+        /// A textual representation of the error code.
         public var description: String {
             String(describing: self.backingCode)
         }
@@ -411,10 +415,12 @@ extension KafkaError {
 // MARK: - KafkaError + Hashable
 
 extension KafkaError: Hashable {
+    /// Returns a Boolean value that indicates whether two errors are equal.
     public static func == (lhs: KafkaError, rhs: KafkaError) -> Bool {
         lhs.backing == rhs.backing
     }
 
+    /// Hashes the essential components of the error by feeding them into the given hasher.
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.backing)
     }

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -14,7 +14,7 @@
 
 import Crdkafka
 
-/// An error that can occur on `Kafka` operations
+/// An error that can occur on `Kafka` operations.
 ///
 /// - Note: `Hashable` conformance considers both the ``KafkaError/code``
 ///   and the ``KafkaError/rdKafkaCode``.
@@ -25,7 +25,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
 
     /// A type-safe wrapper around librdkafka's `rd_kafka_resp_err_t` error codes.
     ///
-    /// Use the static constants (e.g., `.allBrokersDown`, `.authentication`) to match
+    /// Use the static constants (for example, `.allBrokersDown` or `.authentication`) to match
     /// against the ``KafkaError/rdKafkaCode`` property without importing Crdkafka.
     public struct RDKafkaCode: Hashable, Sendable, CustomStringConvertible {
         /// The raw `Int32` value corresponding to the librdkafka error code.
@@ -86,7 +86,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
     /// The underlying librdkafka error code, if this error originated from librdkafka.
     ///
     /// Returns `nil` for errors that do not wrap a `rd_kafka_resp_err_t`
-    /// (e.g., pure configuration or lifecycle errors).
+    /// (for example, pure configuration or lifecycle errors).
     public var rdKafkaCode: RDKafkaCode? {
         self.backing.rdKafkaCode
     }

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -165,7 +165,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
         )
     }
 
-    /// Create a ``KafkaError`` from a rich `rd_kafka_error_t*` error.
+    /// Creates a ``KafkaError`` from a rich `rd_kafka_error_t*` error.
     ///
     /// Extracts the error code, reason string, isFatal, and isRetriable flags
     /// before destroying the error object. This preserves the full error metadata

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -14,7 +14,7 @@
 
 import Crdkafka
 
-/// An error that can occur on `Kafka` operations.
+/// An error that can occur during Kafka operations.
 ///
 /// - Note: `Hashable` conformance considers both the ``KafkaError/code``
 ///   and the ``KafkaError/rdKafkaCode``.
@@ -28,10 +28,10 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
     /// Use the static constants (for example, `.allBrokersDown` or `.authentication`) to match
     /// against the ``KafkaError/rdKafkaCode`` property without importing Crdkafka.
     public struct RDKafkaCode: Hashable, Sendable, CustomStringConvertible {
-        /// The raw `Int32` value corresponding to the librdkafka error code.
+        /// The raw 32-bit value corresponding to the librdkafka error code.
         public let rawValue: Int32
 
-        /// Creates a librdkafka error code from its raw `Int32` value.
+        /// Creates a librdkafka error code from its raw 32-bit value.
         public init(rawValue: Int32) {
             self.rawValue = rawValue
         }

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -171,7 +171,7 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
     /// before destroying the error object. This preserves the full error metadata
     /// that is only available on the rich error type.
     ///
-    /// - Parameter error: A non-nil `rd_kafka_error_t*` pointer. Will be destroyed after extraction.
+    /// - Parameter error: A non-nil `rd_kafka_error_t*` pointer. The pointer is destroyed after extraction.
     static func rdKafkaError(
         wrapping error: OpaquePointer,
         file: String = #fileID,

--- a/Sources/Kafka/KafkaError.swift
+++ b/Sources/Kafka/KafkaError.swift
@@ -308,9 +308,9 @@ public struct KafkaError: Error, CustomStringConvertible, @unchecked Sendable {
 extension KafkaError {
     /// The high-level classification of a Kafka error.
     ///
-    /// The same error may be thrown from more than one place for more than one reason.
+    /// The same error may originate from more than one place for more than one reason.
     /// This type captures only a relatively high-level error:
-    /// use the string representation of ``KafkaError`` to get more details about the specific cause.
+    /// use the string representation of ``KafkaError`` for more details about the specific cause.
     public struct ErrorCode: Hashable, Sendable, CustomStringConvertible {
         fileprivate enum BackingCode {
             case rdKafkaError

--- a/Sources/Kafka/KafkaHeader.swift
+++ b/Sources/Kafka/KafkaHeader.swift
@@ -14,8 +14,9 @@
 
 import NIOCore
 
-/// A structure representing a header for a Kafka message.
-/// Headers are key-value pairs that can be attached to Kafka messages to provide additional metadata.
+/// A header attached to a Kafka message.
+///
+/// Headers are key-value pairs that carry additional metadata alongside a Kafka message.
 public struct KafkaHeader: Sendable, Hashable {
     /// The key associated with the header.
     public var key: String

--- a/Sources/Kafka/KafkaHeader.swift
+++ b/Sources/Kafka/KafkaHeader.swift
@@ -23,7 +23,7 @@ public struct KafkaHeader: Sendable, Hashable {
     /// The value associated with the header.
     public var value: ByteBuffer?
 
-    /// Initializes a new Kafka header with the provided key and optional value.
+    /// Creates a new Kafka header with the given key and optional value.
     ///
     /// - Parameters:
     ///   - key: The key associated with the header.

--- a/Sources/Kafka/KafkaHeader.swift
+++ b/Sources/Kafka/KafkaHeader.swift
@@ -24,7 +24,7 @@ public struct KafkaHeader: Sendable, Hashable {
     /// The value associated with the header.
     public var value: ByteBuffer?
 
-    /// Creates a new Kafka header with the given key and optional value.
+    /// Creates a new Kafka header with the key and optional value you provide.
     ///
     /// - Parameters:
     ///   - key: The key associated with the header.

--- a/Sources/Kafka/KafkaOffset.swift
+++ b/Sources/Kafka/KafkaOffset.swift
@@ -14,7 +14,7 @@
 
 import Crdkafka
 
-/// Message offset on a Kafka partition queue.
+/// A message offset within a Kafka partition queue.
 public struct KafkaOffset: RawRepresentable {
     public var rawValue: Int
 

--- a/Sources/Kafka/KafkaOffset.swift
+++ b/Sources/Kafka/KafkaOffset.swift
@@ -33,7 +33,7 @@ public struct KafkaOffset: RawRepresentable {
     /// Start consuming from offset retrieved from offset store.
     public static let storedOffset = KafkaOffset(rawValue: Int(RD_KAFKA_OFFSET_STORED))
 
-    /// Start consuming with the `count` latest messages.
+    /// Start consuming with the latest messages of the topic.
     ///
     /// Example: Current end offset is at `12345` and `count = 200`.
     /// This means start reading offset from offset `12345 - 200 = 12145`.

--- a/Sources/Kafka/KafkaOffset.swift
+++ b/Sources/Kafka/KafkaOffset.swift
@@ -34,6 +34,7 @@ public struct KafkaOffset: RawRepresentable {
     public static let storedOffset = KafkaOffset(rawValue: Int(RD_KAFKA_OFFSET_STORED))
 
     /// Start consuming with the `count` latest messages.
+    ///
     /// Example: Current end offset is at `12345` and `count = 200`.
     /// This means start reading offset from offset `12345 - 200 = 12145`.
     public static func tail(_ count: Int) -> KafkaOffset {

--- a/Sources/Kafka/KafkaOffset.swift
+++ b/Sources/Kafka/KafkaOffset.swift
@@ -16,8 +16,10 @@ import Crdkafka
 
 /// A message offset within a Kafka partition queue.
 public struct KafkaOffset: RawRepresentable {
+    /// The raw integer value of the offset.
     public var rawValue: Int
 
+    /// Creates a Kafka offset from its raw integer value.
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }

--- a/Sources/Kafka/KafkaOffset.swift
+++ b/Sources/Kafka/KafkaOffset.swift
@@ -22,10 +22,10 @@ public struct KafkaOffset: RawRepresentable {
         self.rawValue = rawValue
     }
 
-    /// Start consuming from the beginning of the Kafka partition queue i.e. the oldest message.
+    /// Start consuming from the beginning of the Kafka partition queue, that is, the oldest message.
     public static let beginning = KafkaOffset(rawValue: Int(RD_KAFKA_OFFSET_BEGINNING))
 
-    /// Start consuming from the end of the Kafka partition queue i.e. wait for next message to be produced.
+    /// Start consuming from the end of the Kafka partition queue, that is, wait for the next message to be produced.
     public static let end = KafkaOffset(rawValue: Int(RD_KAFKA_OFFSET_END))
 
     /// Start consuming from offset retrieved from offset store.

--- a/Sources/Kafka/KafkaPartition.swift
+++ b/Sources/Kafka/KafkaPartition.swift
@@ -14,7 +14,7 @@
 
 import Crdkafka
 
-/// Type for representing the id of a Kafka Partition.
+/// The identifier of a Kafka partition.
 public struct KafkaPartition: RawRepresentable {
     public var rawValue: Int {
         didSet {
@@ -33,7 +33,9 @@ public struct KafkaPartition: RawRepresentable {
         self.rawValue = rawValue
     }
 
-    /// Automatically assign a partition using the topic's partitioner function.
+    /// A sentinel value that defers partition assignment to the topic's partitioner function.
+    ///
+    /// When you set this value, the partition is assigned automatically using the topic's partitioner function.
     public static let unassigned = KafkaPartition(rawValue: Int(RD_KAFKA_PARTITION_UA))
 }
 

--- a/Sources/Kafka/KafkaPartition.swift
+++ b/Sources/Kafka/KafkaPartition.swift
@@ -16,6 +16,7 @@ import Crdkafka
 
 /// The identifier of a Kafka partition.
 public struct KafkaPartition: RawRepresentable {
+    /// The raw integer identifier of the partition.
     public var rawValue: Int {
         didSet {
             precondition(
@@ -25,6 +26,9 @@ public struct KafkaPartition: RawRepresentable {
         }
     }
 
+    /// Creates a partition identifier from its raw integer value.
+    ///
+    /// The raw value must fall within the valid range `0...Int32.max` or equal the unassigned sentinel value.
     public init(rawValue: Int) {
         precondition(
             0...Int(Int32.max) ~= rawValue || rawValue == RD_KAFKA_PARTITION_UA,

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -147,8 +147,8 @@ public final class KafkaProducer: Service, Sendable {
     ///
     /// Use the asynchronous sequence to consume events.
     ///
-    /// - Important: When the asynchronous sequence is deinited the producer will be shut down and disallowed from sending more messages.
-    /// Additionally, make sure to consume the asynchronous sequence otherwise the events will be buffered in memory indefinitely.
+    /// - Important: When the asynchronous sequence is deinitialized, the producer shuts down and stops accepting new messages.
+    ///   Additionally, consume the asynchronous sequence; otherwise the events buffer in memory indefinitely.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
@@ -228,7 +228,7 @@ public final class KafkaProducer: Service, Sendable {
 
     /// Starts the ``KafkaProducer``.
     ///
-    /// - Important: This method **must** be called and will run until either the calling task is cancelled or gracefully shut down.
+    /// - Important: This method **must** be called and runs until either the calling task is canceled or gracefully shut down.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()
@@ -328,7 +328,7 @@ public final class KafkaProducer: Service, Sendable {
     ///
     /// This method does not wait until the message is sent and acknowledged by the cluster.
     /// Instead, it buffers the message and returns immediately.
-    /// The message will be sent out with the next batch of messages.
+    /// The producer sends the message with the next batch of messages.
     ///
     /// - Parameter message: The ``KafkaProducerMessage`` to send.
     /// - Returns: Unique ``KafkaProducerMessageID`` matching the ``KafkaDeliveryReport/id`` property

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -66,7 +66,7 @@ public struct KafkaProducerEvents: Sendable, AsyncSequence {
 
 // MARK: - KafkaProducer
 
-/// Send messages to the Kafka cluster.
+/// Sends messages to the Kafka cluster.
 /// - Note: When messages get published to a non-existent topic, a new topic is created using the default topic configuration
 ///   (based on topic-level configuration properties set on `KafkaProducerConfig`).
 public final class KafkaProducer: Service, Sendable {
@@ -86,7 +86,7 @@ public final class KafkaProducer: Service, Sendable {
     private let logger: Logger
 
     // Private initializer, use factory method or convenience init to create KafkaProducer
-    /// Initialize a new ``KafkaProducer``.
+    /// Creates a new ``KafkaProducer``.
     ///
     /// - Parameter stateMachine: The ``KafkaProducer/StateMachine`` instance associated with the ``KafkaProducer``.
     /// - Parameter config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
@@ -102,7 +102,7 @@ public final class KafkaProducer: Service, Sendable {
         self.logger = logger
     }
 
-    /// Initialize a new ``KafkaProducer``.
+    /// Creates a new ``KafkaProducer``.
     ///
     /// This creates a producer without listening for events.
     ///
@@ -143,7 +143,7 @@ public final class KafkaProducer: Service, Sendable {
         )
     }
 
-    /// Initialize a new ``KafkaProducer`` and a ``KafkaProducerEvents`` asynchronous sequence.
+    /// Creates a new ``KafkaProducer`` and a ``KafkaProducerEvents`` asynchronous sequence.
     ///
     /// Use the asynchronous sequence to consume events.
     ///
@@ -226,7 +226,7 @@ public final class KafkaProducer: Service, Sendable {
         )
     }
 
-    /// Start the ``KafkaProducer``.
+    /// Starts the ``KafkaProducer``.
     ///
     /// - Important: This method **must** be called and will run until either the calling task is cancelled or gracefully shut down.
     public func run() async throws {
@@ -324,7 +324,7 @@ public final class KafkaProducer: Service, Sendable {
         self.stateMachine.withLockedValue { $0.finish() }
     }
 
-    /// Send a ``KafkaProducerMessage`` to the Kafka cluster.
+    /// Sends a ``KafkaProducerMessage`` to the Kafka cluster.
     ///
     /// This method does not wait until the message is sent and acknowledged by the cluster.
     /// Instead, it buffers the message and returns immediately.
@@ -348,7 +348,7 @@ public final class KafkaProducer: Service, Sendable {
         }
     }
 
-    /// Send a ``KafkaProducerMessage`` to the Kafka cluster and await the delivery report.
+    /// Sends a ``KafkaProducerMessage`` to the Kafka cluster and await the delivery report.
     ///
     /// Unlike ``send(_:)``, this method suspends until the broker acknowledges (or rejects)
     /// the message. The returned ``KafkaDeliveryReport`` contains the acknowledgment status,

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -43,14 +43,14 @@ extension KafkaProducerCloseOnTerminate: NIOAsyncSequenceProducerDelegate {
 
 // MARK: - KafkaProducerEvents
 
-/// `AsyncSequence` implementation for handling ``KafkaProducerEvent``s emitted by Kafka.
+/// An asynchronous sequence of ``KafkaProducerEvent`` values emitted by Kafka.
 public struct KafkaProducerEvents: Sendable, AsyncSequence {
     public typealias Element = KafkaProducerEvent
     typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaProducerCloseOnTerminate>
     let wrappedSequence: WrappedSequence
 
-    /// `AsyncIteratorProtocol` implementation for handling ``KafkaProducerEvent``s emitted by Kafka.
+    /// An asynchronous iterator over ``KafkaProducerEvent`` values emitted by Kafka.
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
@@ -316,10 +316,9 @@ public final class KafkaProducer: Service, Sendable {
         }
     }
 
-    /// Method to shutdown the ``KafkaProducer``.
+    /// Shuts the ``KafkaProducer`` down gracefully.
     ///
-    /// This method flushes any buffered messages and waits until a callback is received for all of them.
-    /// Afterwards, it shuts down the connection to Kafka and cleans any remaining state up.
+    /// Flushes any buffered messages and waits until the producer receives a callback for each one. After flushing, this method shuts down the connection to Kafka and cleans up any remaining state.
     public func triggerGracefulShutdown() {
         self.stateMachine.withLockedValue { $0.finish() }
     }

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -45,6 +45,7 @@ extension KafkaProducerCloseOnTerminate: NIOAsyncSequenceProducerDelegate {
 
 /// An asynchronous sequence of ``KafkaProducerEvent`` values emitted by Kafka.
 public struct KafkaProducerEvents: Sendable, AsyncSequence {
+    /// The type of event the sequence yields.
     public typealias Element = KafkaProducerEvent
     typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaProducerCloseOnTerminate>
@@ -54,11 +55,13 @@ public struct KafkaProducerEvents: Sendable, AsyncSequence {
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
+        /// Returns the next producer event, or `nil` if the sequence has finished.
         public mutating func next() async -> Element? {
             await self.wrappedIterator.next()
         }
     }
 
+    /// Returns an asynchronous iterator over the producer event sequence.
     public func makeAsyncIterator() -> AsyncIterator {
         AsyncIterator(wrappedIterator: self.wrappedSequence.makeAsyncIterator())
     }
@@ -204,6 +207,9 @@ public final class KafkaProducer: Service, Sendable {
         return (producer, eventsSequence)
     }
 
+    /// Creates a new producer from a `KafkaProducerConfiguration`.
+    ///
+    /// This initializer is deprecated. Use ``init(config:logger:)`` instead.
     @available(*, deprecated, message: "Use init(config:logger:) instead")
     public convenience init(
         configuration: KafkaProducerConfiguration,
@@ -215,6 +221,9 @@ public final class KafkaProducer: Service, Sendable {
         )
     }
 
+    /// Creates a new producer and an event sequence from a `KafkaProducerConfiguration`.
+    ///
+    /// This method is deprecated. Use ``makeProducerWithEvents(config:logger:)`` instead.
     @available(*, deprecated, message: "Use makeProducerWithEvents(config:logger:) instead")
     public static func makeProducerWithEvents(
         configuration: KafkaProducerConfiguration,

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -113,6 +113,7 @@ public final class KafkaProducer: Service, Sendable {
     /// Creates a new producer.
     ///
     /// This creates a producer without listening for events.
+    /// To also receive events, use ``makeProducerWithEvents(config:logger:)``.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
@@ -245,6 +246,8 @@ public final class KafkaProducer: Service, Sendable {
     /// Starts the producer.
     ///
     /// - Important: Call this method to drive the producer. It runs until either the calling task is canceled or gracefully shut down.
+    ///
+    /// Stop the producer with ``triggerGracefulShutdown()``.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()
@@ -335,6 +338,8 @@ public final class KafkaProducer: Service, Sendable {
     /// Shuts the producer down gracefully.
     ///
     /// Flushes any buffered messages and waits until the producer receives a callback for each one. After flushing, this method shuts down the connection to Kafka and cleans up any remaining state.
+    ///
+    /// Pairs with ``run()``.
     public func triggerGracefulShutdown() {
         self.stateMachine.withLockedValue { $0.finish() }
     }
@@ -344,6 +349,8 @@ public final class KafkaProducer: Service, Sendable {
     /// This method does not wait until the message is sent and acknowledged by the cluster.
     /// Instead, it buffers the message and returns immediately.
     /// The producer sends the message with the next batch of messages.
+    ///
+    /// For acknowledged delivery, use ``sendAndAwait(_:)``.
     ///
     /// - Parameter message: The ``KafkaProducerMessage`` to send.
     /// - Returns: Unique ``KafkaProducerMessageID`` matching the ``KafkaDeliveryReport/id`` property

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -534,7 +534,7 @@ extension KafkaProducer {
         /// Returns the next action to be taken when wanting to poll.
         /// - Returns: The next action to be taken, either polling or terminating the poll loop.
         ///
-        /// - Important: This function throws a `fatalError` if called while in the `.initializing` state.
+        /// - Important: This function traps with a `fatalError` if called while in the `.uninitialized` state.
         mutating func nextPollLoopAction() -> PollLoopAction {
             switch self.state {
             case .uninitialized:
@@ -624,7 +624,7 @@ extension KafkaProducer {
 
         /// Get action to be taken when wanting to do close the producer.
         ///
-        /// - Important: This function throws a `fatalError` if called while in the `.initializing` state.
+        /// - Important: This function traps with a `fatalError` if called while in the `.uninitialized` state.
         mutating func finish() {
             switch self.state {
             case .uninitialized:

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -70,6 +70,7 @@ public struct KafkaProducerEvents: Sendable, AsyncSequence {
 // MARK: - KafkaProducer
 
 /// Sends messages to the Kafka cluster.
+///
 /// - Note: When messages get published to a non-existent topic, a new topic is created using the default topic configuration
 ///   (based on topic-level configuration properties set on `KafkaProducerConfig`).
 public final class KafkaProducer: Service, Sendable {

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -228,7 +228,7 @@ public final class KafkaProducer: Service, Sendable {
 
     /// Starts the ``KafkaProducer``.
     ///
-    /// - Important: This method **must** be called and runs until either the calling task is canceled or gracefully shut down.
+    /// - Important: Call this method to drive the producer. It runs until either the calling task is canceled or gracefully shut down.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()
@@ -296,7 +296,7 @@ public final class KafkaProducer: Service, Sendable {
     /// Match delivery reports against pending `sendAndAwait` continuations.
     ///
     /// For each report, if a continuation is registered for that message ID, resume it.
-    /// ALL reports are returned — they should be yielded to the events sequence regardless
+    /// All reports are returned; the producer yields them to the events sequence regardless
     /// of whether a continuation was resumed. This ensures the events sequence is a complete
     /// log of all delivery reports, even for messages sent via `sendAndAwait`.
     private func resumeContinuations(for reports: [KafkaDeliveryReport]) {

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -43,7 +43,9 @@ extension KafkaProducerCloseOnTerminate: NIOAsyncSequenceProducerDelegate {
 
 // MARK: - KafkaProducerEvents
 
-/// An asynchronous sequence of ``KafkaProducerEvent`` values emitted by Kafka.
+/// An asynchronous sequence of producer events emitted by Kafka.
+///
+/// The sequence yields ``KafkaProducerEvent`` values such as delivery reports and errors.
 public struct KafkaProducerEvents: Sendable, AsyncSequence {
     /// The type of event the sequence yields.
     public typealias Element = KafkaProducerEvent
@@ -51,7 +53,9 @@ public struct KafkaProducerEvents: Sendable, AsyncSequence {
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaProducerCloseOnTerminate>
     let wrappedSequence: WrappedSequence
 
-    /// An asynchronous iterator over ``KafkaProducerEvent`` values emitted by Kafka.
+    /// An asynchronous iterator over producer events emitted by Kafka.
+    ///
+    /// The iterator yields ``KafkaProducerEvent`` values such as delivery reports and errors.
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
@@ -106,7 +110,7 @@ public final class KafkaProducer: Service, Sendable {
         self.logger = logger
     }
 
-    /// Creates a new ``KafkaProducer``.
+    /// Creates a new producer.
     ///
     /// This creates a producer without listening for events.
     ///
@@ -147,7 +151,9 @@ public final class KafkaProducer: Service, Sendable {
         )
     }
 
-    /// Creates a new ``KafkaProducer`` and a ``KafkaProducerEvents`` asynchronous sequence.
+    /// Creates a new producer paired with an asynchronous event sequence.
+    ///
+    /// The returned tuple pairs a ``KafkaProducer`` with its ``KafkaProducerEvents`` sequence.
     ///
     /// Use the asynchronous sequence to consume events.
     ///
@@ -208,7 +214,7 @@ public final class KafkaProducer: Service, Sendable {
         return (producer, eventsSequence)
     }
 
-    /// Creates a new producer from a `KafkaProducerConfiguration`.
+    /// Creates a new producer from a deprecated configuration value.
     ///
     /// This initializer is deprecated. Use ``init(config:logger:)`` instead.
     @available(*, deprecated, message: "Use init(config:logger:) instead")
@@ -222,7 +228,7 @@ public final class KafkaProducer: Service, Sendable {
         )
     }
 
-    /// Creates a new producer and an event sequence from a `KafkaProducerConfiguration`.
+    /// Creates a new producer and an event sequence from a deprecated configuration value.
     ///
     /// This method is deprecated. Use ``makeProducerWithEvents(config:logger:)`` instead.
     @available(*, deprecated, message: "Use makeProducerWithEvents(config:logger:) instead")
@@ -236,7 +242,7 @@ public final class KafkaProducer: Service, Sendable {
         )
     }
 
-    /// Starts the ``KafkaProducer``.
+    /// Starts the producer.
     ///
     /// - Important: Call this method to drive the producer. It runs until either the calling task is canceled or gracefully shut down.
     public func run() async throws {
@@ -326,14 +332,14 @@ public final class KafkaProducer: Service, Sendable {
         }
     }
 
-    /// Shuts the ``KafkaProducer`` down gracefully.
+    /// Shuts the producer down gracefully.
     ///
     /// Flushes any buffered messages and waits until the producer receives a callback for each one. After flushing, this method shuts down the connection to Kafka and cleans up any remaining state.
     public func triggerGracefulShutdown() {
         self.stateMachine.withLockedValue { $0.finish() }
     }
 
-    /// Sends a ``KafkaProducerMessage`` to the Kafka cluster.
+    /// Sends a message to the Kafka cluster.
     ///
     /// This method does not wait until the message is sent and acknowledged by the cluster.
     /// Instead, it buffers the message and returns immediately.
@@ -357,7 +363,7 @@ public final class KafkaProducer: Service, Sendable {
         }
     }
 
-    /// Sends a ``KafkaProducerMessage`` to the Kafka cluster and await the delivery report.
+    /// Sends a message to the Kafka cluster and awaits the delivery report.
     ///
     /// Unlike ``send(_:)``, this method suspends until the broker acknowledges (or rejects)
     /// the message. The returned ``KafkaDeliveryReport`` contains the acknowledgment status,

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -71,7 +71,7 @@ public struct KafkaProducerEvents: Sendable, AsyncSequence {
 
 /// Sends messages to the Kafka cluster.
 ///
-/// - Note: When messages get published to a non-existent topic, a new topic is created using the default topic configuration
+/// - Note: When messages get published to a nonexistent topic, a new topic is created using the default topic configuration
 ///   (based on topic-level configuration properties set on `KafkaProducerConfig`).
 public final class KafkaProducer: Service, Sendable {
     typealias Producer = NIOAsyncSequenceProducer<
@@ -306,8 +306,8 @@ public final class KafkaProducer: Service, Sendable {
     /// Match delivery reports against pending `sendAndAwait` continuations.
     ///
     /// For each report, if a continuation is registered for that message ID, resume it.
-    /// All reports are returned; the producer yields them to the events sequence regardless
-    /// of whether a continuation was resumed. This ensures the events sequence is a complete
+    /// Returns all reports; the producer yields them to the events sequence regardless
+    /// of whether it resumed a continuation. This ensures the events sequence is a complete
     /// log of all delivery reports, even for messages sent via `sendAndAwait`.
     private func resumeContinuations(for reports: [KafkaDeliveryReport]) {
         for report in reports {
@@ -479,8 +479,8 @@ extension KafkaProducer {
                 source: Producer.Source?,
                 topicHandles: RDKafkaTopicHandles
             )
-            /// Producer is still running but the event asynchronous sequence was terminated.
-            /// All incoming events will be dropped.
+            /// The producer is still running but the events asynchronous sequence terminated.
+            /// The producer drops all incoming events.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             case eventConsumptionFinished(client: RDKafkaClient)
@@ -610,8 +610,8 @@ extension KafkaProducer {
             case finishSource(source: Producer.Source?)
         }
 
-        /// The events asynchronous sequence was terminated.
-        /// All incoming events will be dropped.
+        /// The events asynchronous sequence terminated.
+        /// The producer drops all incoming events.
         mutating func stopConsuming() -> StopConsumingAction? {
             switch self.state {
             case .uninitialized:

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -19,7 +19,7 @@ import ServiceLifecycle
 
 // MARK: - KafkaProducerCloseOnTerminate
 
-/// `NIOAsyncSequenceProducerDelegate` that terminates the closes the producer when
+/// `NIOAsyncSequenceProducerDelegate` that terminates and closes the producer when
 /// `didTerminate()` is invoked.
 internal struct KafkaProducerCloseOnTerminate: Sendable {
     let stateMachine: NIOLockedValueBox<KafkaProducer.StateMachine>
@@ -50,7 +50,7 @@ public struct KafkaProducerEvents: Sendable, AsyncSequence {
     typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaProducerCloseOnTerminate>
     let wrappedSequence: WrappedSequence
 
-    /// `AsynceIteratorProtocol` implementation for handling ``KafkaProducerEvent``s emitted by Kafka.
+    /// `AsyncIteratorProtocol` implementation for handling ``KafkaProducerEvent``s emitted by Kafka.
     public struct AsyncIterator: AsyncIteratorProtocol {
         var wrappedIterator: WrappedSequence.AsyncIterator
 
@@ -331,7 +331,7 @@ public final class KafkaProducer: Service, Sendable {
     /// The message will be sent out with the next batch of messages.
     ///
     /// - Parameter message: The ``KafkaProducerMessage`` to send.
-    /// - Returns: Unique ``KafkaProducerMessageID``matching the ``KafkaDeliveryReport/id`` property
+    /// - Returns: Unique ``KafkaProducerMessageID`` matching the ``KafkaDeliveryReport/id`` property
     /// of the corresponding ``KafkaDeliveryReport``.
     /// - Throws: A ``KafkaError`` if sending the message failed.
     @discardableResult
@@ -460,7 +460,7 @@ extension KafkaProducer {
             case uninitialized
             /// The ``KafkaProducer`` has started and is ready to use.
             ///
-            /// - Parameter messageIDCounter:Used to incrementally assign unique IDs to messages.
+            /// - Parameter messageIDCounter: Used to incrementally assign unique IDs to messages.
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
             /// - Parameter topicHandles: Class containing all topic names with their respective `rd_kafka_topic_t` pointer.
@@ -648,7 +648,7 @@ extension KafkaProducer {
         /// Initialize a continuation slot.
         ///
         /// Pre-allocates the slot so `cancelContinuation` can safely detect
-        /// if it's cancelling an active request versus a stale ID.
+        /// if it's canceling an active request versus a stale ID.
         mutating func initializeContinuation(for messageID: UInt) {
             self.pendingContinuations[messageID] = .initialized
         }

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -16,7 +16,7 @@
 public enum KafkaProducerEvent: Sendable, Hashable {
     /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
     case deliveryReports([KafkaDeliveryReport])
-    /// An error reported by the Kafka client (e.g., broker disconnection, authentication failure).
+    /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
     case error(KafkaError)
     /// - Important: Always provide a `default` case when switching over this `enum`.
     case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -12,7 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An event delivered through the ``KafkaProducerEvents`` asynchronous sequence.
+/// An event reported by a Kafka producer, such as a delivery report or an error.
+///
+/// Delivered through ``KafkaProducerEvents``.
 public enum KafkaProducerEvent: Sendable, Hashable {
     /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
     case deliveryReports([KafkaDeliveryReport])

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An enumeration representing events that can be received through the ``KafkaProducerEvents`` asynchronous sequence.
+/// An event delivered through the ``KafkaProducerEvents`` asynchronous sequence.
 public enum KafkaProducerEvent: Sendable, Hashable {
     /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
     case deliveryReports([KafkaDeliveryReport])

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -15,7 +15,7 @@
 import Crdkafka
 import NIOCore
 
-/// A message that the ``KafkaProducer`` sends to the Kafka cluster.
+/// A message a producer sends to the Kafka cluster.
 public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContiguousBytes> {
     /// The topic the producer sends the message to.
     public var topic: String
@@ -39,7 +39,9 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
     /// The value of the message to send.
     public var value: Value
 
-    /// Create a new ``KafkaProducerMessage`` with a ``KafkaContiguousBytes`` key and value.
+    /// Creates a producer message with key and value content.
+    ///
+    /// Both `key` and `value` must conform to ``KafkaContiguousBytes``.
     ///
     /// - Parameters:
     ///     - topic: The topic the producer sends the message to. The ``KafkaProducer`` creates the topic if it doesn't exist.
@@ -63,7 +65,9 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
 }
 
 extension KafkaProducerMessage where Key == Never {
-    /// Create a new ``KafkaProducerMessage`` with a ``KafkaContiguousBytes`` value.
+    /// Creates a producer message with value content and no key.
+    ///
+    /// The `value` must conform to ``KafkaContiguousBytes``.
     ///
     /// - Parameters:
     ///     - topic: The topic the producer sends the message to. The ``KafkaProducer`` creates the topic if it doesn't exist.

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -15,7 +15,7 @@
 import Crdkafka
 import NIOCore
 
-/// Message that is sent by the ``KafkaProducer``.
+/// A message that the ``KafkaProducer`` sends to the Kafka cluster.
 public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContiguousBytes> {
     /// The topic the producer sends the message to.
     public var topic: String

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -21,6 +21,7 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
     public var topic: String
 
     /// The partition the producer sends the message to.
+    ///
     /// Defaults to ``KafkaPartition/unassigned``.
     /// When unassigned, the topic's partitioner function selects a partition automatically.
     public var partition: KafkaPartition
@@ -29,6 +30,7 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
     public var headers: [KafkaHeader]
 
     /// The optional key associated with the message.
+    ///
     /// If the ``KafkaPartition`` is ``KafkaPartition/unassigned``, the ``KafkaProducerMessage/key`` is used to ensure
     /// that two ``KafkaProducerMessage``s with the same key still get sent to the same ``KafkaPartition``.
     public var key: Key?

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -31,11 +31,12 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
 
     /// The optional key associated with the message.
     ///
-    /// If the ``KafkaPartition`` is ``KafkaPartition/unassigned``, the ``KafkaProducerMessage/key`` is used to ensure
-    /// that two ``KafkaProducerMessage``s with the same key still get sent to the same ``KafkaPartition``.
+    /// If the ``KafkaPartition`` is ``KafkaPartition/unassigned``, the producer uses
+    /// ``KafkaProducerMessage/key`` to ensure that two ``KafkaProducerMessage``s with
+    /// the same key route to the same ``KafkaPartition``.
     public var key: Key?
 
-    /// The value of the message to be sent.
+    /// The value of the message to send.
     public var value: Value
 
     /// Create a new ``KafkaProducerMessage`` with a ``KafkaContiguousBytes`` key and value.

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -17,12 +17,12 @@ import NIOCore
 
 /// Message that is sent by the ``KafkaProducer``.
 public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContiguousBytes> {
-    /// The topic to which the message will be sent.
+    /// The topic the producer sends the message to.
     public var topic: String
 
-    /// The partition to which the message will be sent.
+    /// The partition the producer sends the message to.
     /// Defaults to ``KafkaPartition/unassigned``.
-    /// This means the message will be automatically assigned a partition using the topic's partitioner function.
+    /// When unassigned, the topic's partitioner function selects a partition automatically.
     public var partition: KafkaPartition
 
     /// The headers of the message.
@@ -39,10 +39,10 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
     /// Create a new ``KafkaProducerMessage`` with a ``KafkaContiguousBytes`` key and value.
     ///
     /// - Parameters:
-    ///     - topic: The topic the message will be sent to. Topics may be created by the ``KafkaProducer`` if nonexistent.
-    ///     - partition: The topic partition the message will be sent to. If not set explicitly, the partition will be assigned automatically.
+    ///     - topic: The topic the producer sends the message to. The ``KafkaProducer`` creates the topic if it doesn't exist.
+    ///     - partition: The topic partition the producer sends the message to. If you don't set this explicitly, the producer assigns the partition automatically.
     ///     - headers: The headers of the message.
-    ///     - key: Used to guarantee that messages with the same key will be sent to the same partition so that their order is preserved.
+    ///     - key: Guarantees that messages with the same key go to the same partition, preserving their order.
     ///     - value: The message's value.
     public init(
         topic: String,
@@ -63,8 +63,8 @@ extension KafkaProducerMessage where Key == Never {
     /// Create a new ``KafkaProducerMessage`` with a ``KafkaContiguousBytes`` value.
     ///
     /// - Parameters:
-    ///     - topic: The topic the message will be sent to. Topics may be created by the ``KafkaProducer`` if nonexistent.
-    ///     - partition: The topic partition the message will be sent to. If not set explicitly, the partition will be assigned automatically.
+    ///     - topic: The topic the producer sends the message to. The ``KafkaProducer`` creates the topic if it doesn't exist.
+    ///     - partition: The topic partition the producer sends the message to. If you don't set this explicitly, the producer assigns the partition automatically.
     ///     - headers: The headers of the message.
     ///     - value: The message body.
     public init(

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -15,7 +15,7 @@
 import Crdkafka
 import NIOCore
 
-/// Message that is sent by the `KafkaProducer`
+/// Message that is sent by the ``KafkaProducer``.
 public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContiguousBytes> {
     /// The topic to which the message will be sent.
     public var topic: String
@@ -36,10 +36,10 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
     /// The value of the message to be sent.
     public var value: Value
 
-    /// Create a new `KafkaProducerMessage` with a ``KafkaContiguousBytes`` key and value.
+    /// Create a new ``KafkaProducerMessage`` with a ``KafkaContiguousBytes`` key and value.
     ///
     /// - Parameters:
-    ///     - topic: The topic the message will be sent to. Topics may be created by the `KafkaProducer` if non-existent.
+    ///     - topic: The topic the message will be sent to. Topics may be created by the ``KafkaProducer`` if nonexistent.
     ///     - partition: The topic partition the message will be sent to. If not set explicitly, the partition will be assigned automatically.
     ///     - headers: The headers of the message.
     ///     - key: Used to guarantee that messages with the same key will be sent to the same partition so that their order is preserved.
@@ -60,10 +60,10 @@ public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContig
 }
 
 extension KafkaProducerMessage where Key == Never {
-    /// Create a new `KafkaProducerMessage` with a ``KafkaContiguousBytes`` value.
+    /// Create a new ``KafkaProducerMessage`` with a ``KafkaContiguousBytes`` value.
     ///
     /// - Parameters:
-    ///     - topic: The topic the message will be sent to. Topics may be created by the `KafkaProducer` if non-existent.
+    ///     - topic: The topic the message will be sent to. Topics may be created by the ``KafkaProducer`` if nonexistent.
     ///     - partition: The topic partition the message will be sent to. If not set explicitly, the partition will be assigned automatically.
     ///     - headers: The headers of the message.
     ///     - value: The message body.

--- a/Sources/Kafka/KafkaProducerMessageID.swift
+++ b/Sources/Kafka/KafkaProducerMessageID.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An identifier for a message produced by a ``KafkaProducer``.
+/// An identifier for a message produced by a Kafka producer.
 ///
 /// Use a ``KafkaProducerMessageID`` to correlate an incoming ``KafkaDeliveryReport`` with the
 /// corresponding ``KafkaProducer/send(_:)`` call that produced it.

--- a/Sources/Kafka/KafkaProducerMessageID.swift
+++ b/Sources/Kafka/KafkaProducerMessageID.swift
@@ -12,9 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// ID of message produced by the ``KafkaProducer``.
-/// The ``KafkaProducerMessageID`` can be used to relate incoming ``KafkaDeliveryReport``s
-/// with their corresponding ``KafkaProducer/send(_:)`` invocation.
+/// An identifier for a message produced by a ``KafkaProducer``.
+///
+/// Use a ``KafkaProducerMessageID`` to correlate an incoming ``KafkaDeliveryReport`` with the
+/// corresponding ``KafkaProducer/send(_:)`` call that produced it.
 public struct KafkaProducerMessageID {
     internal var rawValue: UInt
 

--- a/Sources/Kafka/KafkaProducerMessageID.swift
+++ b/Sources/Kafka/KafkaProducerMessageID.swift
@@ -27,6 +27,7 @@ public struct KafkaProducerMessageID {
 // MARK: - KafkaProducerMessageID + CustomStringConvertible
 
 extension KafkaProducerMessageID: CustomStringConvertible {
+    /// A textual representation of the producer message identifier.
     public var description: String {
         String(self.rawValue)
     }
@@ -39,6 +40,7 @@ extension KafkaProducerMessageID: Hashable {}
 // MARK: - KafkaProducerMessageID + Comparable
 
 extension KafkaProducerMessageID: Comparable {
+    /// Returns a Boolean value that indicates whether the first identifier is ordered before the second.
     public static func < (lhs: KafkaProducerMessageID, rhs: KafkaProducerMessageID) -> Bool {
         lhs.rawValue < rhs.rawValue
     }

--- a/Sources/Kafka/KafkaTopicPartition.swift
+++ b/Sources/Kafka/KafkaTopicPartition.swift
@@ -20,7 +20,7 @@ public struct KafkaTopicPartition: Sendable, Hashable {
     /// The partition within the topic.
     public var partition: KafkaPartition
 
-    /// Create a new ``KafkaTopicPartition``.
+    /// Creates a new ``KafkaTopicPartition``.
     ///
     /// - Parameters:
     ///   - topic: The name of the Kafka topic.

--- a/Sources/Kafka/KafkaTopicPartition.swift
+++ b/Sources/Kafka/KafkaTopicPartition.swift
@@ -20,7 +20,7 @@ public struct KafkaTopicPartition: Sendable, Hashable {
     /// The partition within the topic.
     public var partition: KafkaPartition
 
-    /// Creates a new ``KafkaTopicPartition``.
+    /// Creates a topic-partition pair from a topic name and partition.
     ///
     /// - Parameters:
     ///   - topic: The name of the Kafka topic.

--- a/Sources/Kafka/KafkaTopicPartitionOffset.swift
+++ b/Sources/Kafka/KafkaTopicPartitionOffset.swift
@@ -32,7 +32,7 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
     /// The partition within the topic (convenience accessor).
     public var partition: KafkaPartition { self.topicPartition.partition }
 
-    /// Create a new ``KafkaTopicPartitionOffset``.
+    /// Creates a new ``KafkaTopicPartitionOffset``.
     ///
     /// - Parameters:
     ///   - topic: The name of the Kafka topic.
@@ -43,7 +43,7 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
         self.offset = offset
     }
 
-    /// Create a new ``KafkaTopicPartitionOffset`` from an existing ``KafkaTopicPartition``.
+    /// Creates a new ``KafkaTopicPartitionOffset`` from an existing ``KafkaTopicPartition``.
     ///
     /// - Parameters:
     ///   - topicPartition: The topic and partition.

--- a/Sources/Kafka/KafkaTopicPartitionOffset.swift
+++ b/Sources/Kafka/KafkaTopicPartitionOffset.swift
@@ -26,10 +26,14 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
     /// a `nil` value indicates that no committed offset or position exists.
     public var offset: KafkaOffset?
 
-    /// The name of the Kafka topic (convenience accessor).
+    /// The name of the Kafka topic.
+    ///
+    /// This is a convenience accessor for the underlying ``KafkaTopicPartition/topic``.
     public var topic: String { self.topicPartition.topic }
 
-    /// The partition within the topic (convenience accessor).
+    /// The partition within the topic.
+    ///
+    /// This is a convenience accessor for the underlying ``KafkaTopicPartition/partition``.
     public var partition: KafkaPartition { self.topicPartition.partition }
 
     /// Creates a new ``KafkaTopicPartitionOffset``.

--- a/Sources/Kafka/KafkaTopicPartitionOffset.swift
+++ b/Sources/Kafka/KafkaTopicPartitionOffset.swift
@@ -28,12 +28,12 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
 
     /// The name of the Kafka topic.
     ///
-    /// This is a convenience accessor for the underlying ``KafkaTopicPartition/topic``.
+    /// A convenience accessor for the underlying ``KafkaTopicPartition/topic``.
     public var topic: String { self.topicPartition.topic }
 
     /// The partition within the topic.
     ///
-    /// This is a convenience accessor for the underlying ``KafkaTopicPartition/partition``.
+    /// A convenience accessor for the underlying ``KafkaTopicPartition/partition``.
     public var partition: KafkaPartition { self.topicPartition.partition }
 
     /// Creates a new ``KafkaTopicPartitionOffset``.

--- a/Sources/Kafka/KafkaTopicPartitionOffset.swift
+++ b/Sources/Kafka/KafkaTopicPartitionOffset.swift
@@ -14,8 +14,8 @@
 
 /// A topic-partition pair with an associated offset.
 ///
-/// Used as both input (e.g., for ``KafkaConsumer/seek(topicPartitionOffsets:timeout:)``) and output
-/// (e.g., from ``KafkaConsumer/committed(topicPartitions:timeout:)`` and ``KafkaConsumer/position(topicPartitions:)``).
+/// Used as both input (for example, ``KafkaConsumer/seek(topicPartitionOffsets:timeout:)``) and output
+/// (for example, ``KafkaConsumer/committed(topicPartitions:timeout:)`` and ``KafkaConsumer/position(topicPartitions:)``).
 public struct KafkaTopicPartitionOffset: Sendable, Hashable {
     /// The topic and partition.
     public var topicPartition: KafkaTopicPartition

--- a/Sources/Kafka/KafkaTopicPartitionOffset.swift
+++ b/Sources/Kafka/KafkaTopicPartitionOffset.swift
@@ -36,7 +36,7 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
     /// A convenience accessor for the underlying ``KafkaTopicPartition/partition``.
     public var partition: KafkaPartition { self.topicPartition.partition }
 
-    /// Creates a new ``KafkaTopicPartitionOffset``.
+    /// Creates a topic-partition-offset triple from a topic name, partition, and offset.
     ///
     /// - Parameters:
     ///   - topic: The name of the Kafka topic.
@@ -47,7 +47,9 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
         self.offset = offset
     }
 
-    /// Creates a new ``KafkaTopicPartitionOffset`` from an existing ``KafkaTopicPartition``.
+    /// Creates a topic-partition-offset triple from an existing topic-partition pair and an offset.
+    ///
+    /// Use this initializer when you already have a ``KafkaTopicPartition`` value.
     ///
     /// - Parameters:
     ///   - topicPartition: The topic and partition.

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -731,8 +731,8 @@ public final class RDKafkaClient: Sendable {
         }
     }
 
-    /// Non-blocking "fire-and-forget" commit of a `message`'s offset to Kafka.
-    /// Schedules a commit and returns immediately.
+    /// Schedules a non-blocking, fire-and-forget commit of the message's offset to Kafka.
+    ///
     /// The client discards any errors encountered after scheduling the commit.
     ///
     /// - Parameter message: Last received message to mark as read.

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -20,14 +20,14 @@ import NIOCore
 
 import class Foundation.JSONDecoder
 
-/// Base class for ``KafkaProducer`` and ``KafkaConsumer``,
-/// which is used to handle the connection to the Kafka ecosystem.
+/// Base class for ``KafkaProducer`` and ``KafkaConsumer``
+/// that handles the connection to the Kafka ecosystem.
 @_spi(Internal)
 public final class RDKafkaClient: Sendable {
     // Default size for Strings returned from C API
     static let stringSize = 1024
 
-    /// Shared concurrent queue for offloading blocking C calls (e.g., `rd_kafka_committed`,
+    /// Shared concurrent queue for offloading blocking C calls (for example, `rd_kafka_committed`,
     /// `rd_kafka_seek_partitions`, `rd_kafka_flush`) so they don't block Swift Concurrency's
     /// cooperative thread pool. Concurrent so independent operations can run in parallel.
     private static let blockingQueue = DispatchQueue(
@@ -117,9 +117,9 @@ public final class RDKafkaClient: Sendable {
 
     /// Produce a message to the Kafka cluster.
     ///
-    /// - Parameter message: The ``KafkaProducerMessage`` that is sent to the KafkaCluster.
-    /// - Parameter newMessageID: ID that was assigned to the `message`.
-    /// - Parameter topicHandles: Topic handles that this client uses to produce new messages
+    /// - Parameter message: The ``KafkaProducerMessage`` to send to the KafkaCluster.
+    /// - Parameter newMessageID: ID assigned to the `message`.
+    /// - Parameter topicHandles: Topic handles that this client uses to produce new messages.
     func produce<Key, Value>(
         message: KafkaProducerMessage<Key, Value>,
         newMessageID: UInt,
@@ -226,7 +226,7 @@ public final class RDKafkaClient: Sendable {
 
     /// Scoped accessor that enables safe access to a ``KafkaProducerMessage``'s key and value raw buffers.
     /// - Warning: Do not escape the pointer from the closure for later use.
-    /// - Parameter body: The closure will use the pointer.
+    /// - Parameter body: The closure that uses the pointer.
     @discardableResult
     private static func withMessageKeyAndValueBuffer<T, Key, Value>(
         for message: KafkaProducerMessage<Key, Value>,
@@ -245,7 +245,7 @@ public final class RDKafkaClient: Sendable {
 
     /// Scoped accessor that enables safe access the underlying memory of an array of ``KafkaHeader``s.
     /// - Warning: Do not escape the pointer from the closure for later use.
-    /// - Parameter body: The closure will use the pointer.
+    /// - Parameter body: The closure that uses the pointer.
     @discardableResult
     private static func withKafkaCHeaders<T>(
         for headers: [KafkaHeader],
@@ -360,7 +360,7 @@ public final class RDKafkaClient: Sendable {
     ///
     /// Drains the queue, handling internal events (log, offset commit) and
     /// returning only events relevant to a consumer. Producer-only events
-    /// (e.g., delivery reports) are handled internally but never surfaced.
+    /// (for example, delivery reports) are handled internally but never surfaced.
     ///
     /// - Parameter maxEvents: Maximum number of events to serve in one invocation.
     func consumerEventPoll(maxEvents: Int = 100) -> [ConsumerPollEvent] {
@@ -700,13 +700,13 @@ public final class RDKafkaClient: Sendable {
     ///
     /// This does **not** commit the offset to the broker. Instead, it marks the offset
     /// in the local in-memory store. When `enable.auto.commit` is `true` (the default),
-    /// the auto-commit timer will periodically commit these stored offsets to the broker.
+    /// the auto-commit timer periodically commits these stored offsets to the broker.
     ///
-    /// This method is intended to be used with `enable.auto.offset.store` set to `false`,
-    /// allowing the application to store offsets only **after** successful message processing.
+    /// Use this method with `enable.auto.offset.store` set to `false` to store offsets
+    /// only **after** successful message processing.
     /// This is the recommended pattern for at-least-once delivery semantics.
     ///
-    /// - Parameter message: The message whose offset should be stored.
+    /// - Parameter message: The message whose offset to store.
     /// - Throws: A ``KafkaError`` if storing the offset failed.
     func storeOffset(_ message: KafkaConsumerMessage) throws {
         // rd_kafka_offsets_store expects the offset of the *next* message to consume,
@@ -733,9 +733,9 @@ public final class RDKafkaClient: Sendable {
 
     /// Non-blocking "fire-and-forget" commit of a `message`'s offset to Kafka.
     /// Schedules a commit and returns immediately.
-    /// Any errors encountered after scheduling the commit will be discarded.
+    /// The client discards any errors encountered after scheduling the commit.
     ///
-    /// - Parameter message: Last received message that shall be marked as read.
+    /// - Parameter message: Last received message to mark as read.
     /// - Throws: A ``KafkaError`` if scheduling the commit failed.
     func scheduleCommit(_ message: KafkaConsumerMessage) throws {
         // The offset committed is always the offset of the next requested message.
@@ -1002,11 +1002,11 @@ public final class RDKafkaClient: Sendable {
     /// Seek consumer for partitions to the per-partition offset.
     ///
     /// The offset may be either absolute (>= 0) or a logical offset
-    /// (e.g., `.beginning`, `.end`, `.storedOffset`).
+    /// (for example, `.beginning`, `.end`, `.storedOffset`).
     ///
-    /// This call will purge all pre-fetched messages for the given partitions.
-    /// Repeated use of seek may lead to increased network usage as messages
-    /// are re-fetched from the broker.
+    /// This call purges all pre-fetched messages for the given partitions.
+    /// Repeated use of seek may lead to increased network usage as the client
+    /// re-fetches messages from the broker.
     ///
     /// - Important: Seek must only be performed for already assigned/consumed partitions.
     ///
@@ -1060,7 +1060,7 @@ public final class RDKafkaClient: Sendable {
 
     /// Scoped accessor that enables safe access to the pointer of the client's Kafka handle.
     /// - Warning: Do not escape the pointer from the closure for later use.
-    /// - Parameter body: The closure will use the Kafka handle pointer.
+    /// - Parameter body: The closure that uses the Kafka handle pointer.
     @discardableResult
     func withKafkaHandlePointer<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {
         try body(self.kafkaHandle.pointer)

--- a/Sources/Kafka/RDKafka/RDKafkaStatistics.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaStatistics.swift
@@ -25,8 +25,8 @@ struct RDKafkaStatistics: Hashable, Codable {
     let totalKafkaBrokerResponsesSize: Int?
     let totalKafkaBrokerMessagesSent: Int?
     let totalKafkaBrokerMessagesBytesSent: Int?
-    let totalKafkaBrokerMessagesRecieved: Int?
-    let totalKafkaBrokerMessagesBytesRecieved: Int?
+    let totalKafkaBrokerMessagesReceived: Int?
+    let totalKafkaBrokerMessagesBytesReceived: Int?
 
     enum CodingKeys: String, CodingKey {
         case queuedOperation = "replyq"
@@ -39,7 +39,7 @@ struct RDKafkaStatistics: Hashable, Codable {
         case totalKafkaBrokerResponsesSize = "rx_bytes"
         case totalKafkaBrokerMessagesSent = "txmsgs"
         case totalKafkaBrokerMessagesBytesSent = "txmsg_bytes"
-        case totalKafkaBrokerMessagesRecieved = "rxmsgs"
-        case totalKafkaBrokerMessagesBytesRecieved = "rxmsg_bytes"
+        case totalKafkaBrokerMessagesReceived = "rxmsgs"
+        case totalKafkaBrokerMessagesBytesReceived = "rxmsg_bytes"
     }
 }

--- a/Sources/Kafka/RDKafka/RDKafkaTopicHandles.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaTopicHandles.swift
@@ -39,7 +39,7 @@ internal final class RDKafkaTopicHandles: Sendable {
     /// Scoped accessor that enables safe access to the pointer of the topic's handle.
     /// - Warning: Do not escape the pointer from the closure for later use.
     /// - Parameter topic: The name of the topic that is addressed.
-    /// - Parameter body: The closure will use the topic handle pointer.
+    /// - Parameter body: The closure that uses the topic handle pointer.
     @discardableResult
     func withTopicHandlePointer<T>(
         topic: String,

--- a/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
@@ -69,7 +69,7 @@ final class RDKafkaTopicPartitionList: @unchecked Sendable {
 
     /// Scoped accessor that enables safe access to the pointer of the underlying `rd_kafka_topic_partition_t`.
     /// - Warning: Do not escape the pointer from the closure for later use.
-    /// - Parameter body: The closure will use the pointer.
+    /// - Parameter body: The closure that uses the pointer.
     @discardableResult
     func withListPointer<T>(_ body: (UnsafeMutablePointer<rd_kafka_topic_partition_list_t>) throws -> T) rethrows -> T {
         try body(self._internal)

--- a/Sources/Kafka/RDKafka/RebalanceContext.swift
+++ b/Sources/Kafka/RDKafka/RebalanceContext.swift
@@ -249,14 +249,14 @@ extension RDKafkaConfig {
     /// Register the rebalance callback and opaque pointer on a config.
     ///
     /// - Important: `rd_kafka_conf_set_opaque` sets a **single** opaque pointer per config.
-    ///   All C callbacks that receive `void* opaque` (rebalance, offset commit, error, etc.)
+    ///   All C callbacks that receive `void* opaque` (rebalance, offset commit, error, and so on)
     ///   share this one slot. Currently only the rebalance callback uses it. If a future
     ///   callback also needs the opaque, introduce a wrapper struct that multiplexes
-    ///   (e.g., a context holding both rebalance and other callback contexts).
+    ///   (for example, a context holding both rebalance and other callback contexts).
     ///
     /// - Parameters:
     ///   - configPointer: The `rd_kafka_conf_t` to configure.
-    ///   - context: The `RebalanceContext` that will receive callbacks.
+    ///   - context: The `RebalanceContext` that receives callbacks.
     static func setRebalanceCallback(
         configPointer: OpaquePointer,
         context: RebalanceContext

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -1,3 +1,5 @@
 API breakage: enumelement KafkaConsumerEvent.rebalance has been added as a new enum case
 API breakage: enumelement KafkaConsumerEvent.error has been added as a new enum case
 API breakage: enumelement KafkaProducerEvent.error has been added as a new enum case
+API breakage: var KafkaConfiguration.ConsumerMetrics.totalKafkaBrokerMessagesRecieved has been removed
+API breakage: var KafkaConfiguration.ConsumerMetrics.totalKafkaBrokerMessagesBytesRecieved has been removed


### PR DESCRIPTION
Add Documentation Catalog for swift-kafka-client

### Motivation:

Adds a documentation catalog to collect the documentation together (beyond the default rendering) and apply updates to doc comments, abstracts, etc to align with Apple's writing guidelines for API documentation.

### Modifications:

- **adds DocC catalog and quick pass runthrough to resolve warnings with default documentation builds**
- **updating doc comments to reflect underlying impl**
- **update wording to more direct style in articles and section headings**
- **switch to imperative phrasing**
- **future -> present tense**
- **referencing Boolean abstracts per guidelines**
- **bold emphasis cleanup (per guidelines)**
- **rephrase passive voice to active voice**
- **reworking abstracts**
- **add missing docs**

### Result:

Documentation build completes without warnings, and content is more aligned to skim-reading for easier consumption.
