### PR TITLE
Add structured logging with metadata enrichment

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.1.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
         .package(url: "https://github.com/apple/swift-metrics", from: "2.4.1"),
         // The zstd Swift package produces warnings that we cannot resolve:
         // https://github.com/facebook/zstd/issues/3328

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -206,7 +206,15 @@ public final class KafkaConsumer: Sendable, Service {
     ) throws {
         self.config = config
         self.stateMachine = stateMachine
-        self.logger = logger
+        var enrichedLogger = logger
+        if let clientId = config.clientId {
+            enrichedLogger[metadataKey: KafkaLoggingKeys.clientId] = "\(clientId)"
+        }
+        if let groupId = config.groupId {
+            enrichedLogger[metadataKey: KafkaLoggingKeys.groupId] = "\(groupId)"
+        }
+        enrichedLogger[metadataKey: KafkaLoggingKeys.clientType] = "consumer"
+        self.logger = enrichedLogger
         self.eventsSource = eventsSource
         self.rebalanceContext = rebalanceContext
 
@@ -221,6 +229,13 @@ public final class KafkaConsumer: Sendable, Service {
                 rebalanceContext: rebalanceContext
             )
         }
+
+        self.logger.debug(
+            "Kafka consumer initialized",
+            metadata: [
+                KafkaLoggingKeys.bootstrapServers: "\(config.bootstrapServers?.joined(separator: ",") ?? "default")"
+            ]
+        )
     }
 
     /// Creates a new consumer.
@@ -376,6 +391,8 @@ public final class KafkaConsumer: Sendable, Service {
             return
         }
 
+        self.logger.debug("Subscribing to topics", metadata: [KafkaLoggingKeys.topics: "\(topics)"])
+
         let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
         switch action {
         case .client(let client):
@@ -403,6 +420,8 @@ public final class KafkaConsumer: Sendable, Service {
         let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
         switch action {
         case .client(let client):
+            let currentTopics = (try? client.subscription()) ?? []
+            self.logger.debug("Unsubscribing from all topics", metadata: [KafkaLoggingKeys.topics: "\(currentTopics)"])
             try client.unsubscribe()
         case .throwClosedError:
             throw KafkaError.connectionClosed(reason: "Consumer is closed")
@@ -554,7 +573,7 @@ public final class KafkaConsumer: Sendable, Service {
                 do {
                     try client.consumerClose()
                 } catch {
-                    self.logger.error("Closing KafkaConsumer failed", metadata: ["error": "\(error)"])
+                    self.logger.info("Closing KafkaConsumer failed", error: error)
                     self.stateMachine.withLockedValue { $0.closeFailed() }
                 }
                 self.pollAndDrainEvents(client: client)
@@ -571,6 +590,7 @@ public final class KafkaConsumer: Sendable, Service {
                 if let client {
                     self.finalDrain(client: client)
                 }
+                self.logger.debug("Kafka consumer shut down")
                 return
             }
         }
@@ -587,9 +607,9 @@ public final class KafkaConsumer: Sendable, Service {
                 if let source = self.eventsSource {
                     _ = source.yield(.error(kafkaError))
                 }
-                self.logger.error(
+                self.logger.info(
                     "Kafka client error",
-                    metadata: ["error": "\(kafkaError)"]
+                    error: kafkaError
                 )
             }
         }
@@ -615,11 +635,11 @@ public final class KafkaConsumer: Sendable, Service {
             if let source = self.eventsSource {
                 _ = source.yield(.rebalance(rebalance))
             }
-            self.logger.info(
+            self.logger.debug(
                 "Consumer rebalance",
                 metadata: [
-                    "kind": "\(rebalance.kind)",
-                    "partitions": "\(rebalance.partitions.map { "\($0.topic):\($0.partition)" })",
+                    KafkaLoggingKeys.rebalanceKind: "\(rebalance.kind)",
+                    KafkaLoggingKeys.partitions: "\(rebalance.partitions.map { "\($0.topic):\($0.partition)" })",
                 ]
             )
         }
@@ -642,9 +662,9 @@ public final class KafkaConsumer: Sendable, Service {
                 if let source = self.eventsSource {
                     _ = source.yield(.error(kafkaError))
                 }
-                self.logger.error(
+                self.logger.info(
                     "Kafka client error",
-                    metadata: ["error": "\(kafkaError)"]
+                    error: kafkaError
                 )
             }
         }
@@ -670,11 +690,11 @@ public final class KafkaConsumer: Sendable, Service {
             if let source = self.eventsSource {
                 _ = source.yield(.rebalance(rebalance))
             }
-            self.logger.info(
+            self.logger.debug(
                 "Consumer rebalance",
                 metadata: [
-                    "kind": "\(rebalance.kind)",
-                    "partitions": "\(rebalance.partitions.map { "\($0.topic):\($0.partition)" })",
+                    KafkaLoggingKeys.rebalanceKind: "\(rebalance.kind)",
+                    KafkaLoggingKeys.partitions: "\(rebalance.partitions.map { "\($0.topic):\($0.partition)" })",
                 ]
             )
         }
@@ -915,6 +935,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// - Note: Invoking this method isn't always needed; the ``KafkaConsumer`` already shuts down when consumption of ``KafkaConsumerMessages`` ends.
     public func triggerGracefulShutdown() {
+        self.logger.debug("Kafka consumer shutting down")
         let action = self.stateMachine.withLockedValue { $0.finish() }
         switch action {
         case .triggerGracefulShutdown(let client):
@@ -934,11 +955,10 @@ public final class KafkaConsumer: Sendable, Service {
         do {
             try client.consumerClose()
         } catch {
-            if let error = error as? KafkaError {
-                logger.error("Closing KafkaConsumer failed: \(error.description)")
-            } else {
-                logger.error("Caught unknown error: \(error)")
-            }
+            logger.info(
+                "Closing KafkaConsumer failed",
+                error: error
+            )
         }
     }
 }

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -107,7 +107,19 @@ public final class KafkaProducer: Service, Sendable {
     ) {
         self.stateMachine = stateMachine
         self.config = config
-        self.logger = logger
+        var enrichedLogger = logger
+        if let clientId = config.clientId {
+            enrichedLogger[metadataKey: KafkaLoggingKeys.clientId] = "\(clientId)"
+        }
+        enrichedLogger[metadataKey: KafkaLoggingKeys.clientType] = "producer"
+        self.logger = enrichedLogger
+
+        self.logger.debug(
+            "Kafka producer initialized",
+            metadata: [
+                KafkaLoggingKeys.bootstrapServers: "\(config.bootstrapServers?.joined(separator: ",") ?? "default")"
+            ]
+        )
     }
 
     /// Creates a new producer.
@@ -269,9 +281,9 @@ public final class KafkaProducer: Service, Sendable {
                     case .deliveryReport(let reports):
                         self.resumeContinuations(for: reports)
                     case .error(let kafkaError):
-                        self.logger.error(
+                        self.logger.info(
                             "Kafka client error",
-                            metadata: ["error": "\(kafkaError)"]
+                            error: kafkaError
                         )
                     }
                 }
@@ -287,9 +299,9 @@ public final class KafkaProducer: Service, Sendable {
                         _ = source?.yield(.deliveryReports(reports))
                     case .error(let kafkaError):
                         _ = source?.yield(.error(kafkaError))
-                        self.logger.error(
+                        self.logger.info(
                             "Kafka client error",
-                            metadata: ["error": "\(kafkaError)"]
+                            error: kafkaError
                         )
                     }
                 }
@@ -303,10 +315,24 @@ public final class KafkaProducer: Service, Sendable {
                     source?.finish()
                     self.stateMachine.withLockedValue { $0.failPendingContinuations() }
                 }
-                try await client.flush(timeoutMilliseconds: Int32(self.config.shutdownFlushTimeoutMs))
+                self.logger.trace("Flushing outstanding messages before shutdown")
+                do {
+                    try await client.flush(timeoutMilliseconds: Int32(self.config.shutdownFlushTimeoutMs))
+                } catch {
+                    self.logger.info(
+                        "Flush timed out during shutdown, some messages may not have been delivered",
+                        error: error,
+                        metadata: [
+                            KafkaLoggingKeys.timeoutMs: "\(self.config.shutdownFlushTimeoutMs)"
+                        ]
+                    )
+                    throw error
+                }
+                self.logger.debug("Kafka producer shut down")
                 return
             case .terminatePollLoop:
                 self.stateMachine.withLockedValue { $0.failPendingContinuations() }
+                self.logger.debug("Kafka producer shut down")
                 return
             }
         }
@@ -320,6 +346,19 @@ public final class KafkaProducer: Service, Sendable {
     /// log of all delivery reports, even for messages sent via `sendAndAwait`.
     private func resumeContinuations(for reports: [KafkaDeliveryReport]) {
         for report in reports {
+            switch report.status {
+            case .acknowledged:
+                break
+            case .failure(let error):
+                self.logger.debug(
+                    "Message delivery failed",
+                    error: error,
+                    metadata: [
+                        KafkaLoggingKeys.messageId: "\(report.id.rawValue)"
+                    ]
+                )
+            }
+
             let continuation: CheckedContinuation<KafkaDeliveryReport, Error>? =
                 self.stateMachine.withLockedValue {
                     $0.removeContinuation(for: report.id.rawValue)
@@ -341,6 +380,7 @@ public final class KafkaProducer: Service, Sendable {
     ///
     /// Pairs with ``run()``.
     public func triggerGracefulShutdown() {
+        self.logger.debug("Kafka producer shutting down")
         self.stateMachine.withLockedValue { $0.finish() }
     }
 
@@ -361,11 +401,20 @@ public final class KafkaProducer: Service, Sendable {
         let action = try self.stateMachine.withLockedValue { try $0.send() }
         switch action {
         case .send(let client, let newMessageID, let topicHandles):
-            try client.produce(
-                message: message,
-                newMessageID: newMessageID,
-                topicHandles: topicHandles
-            )
+            do {
+                try client.produce(
+                    message: message,
+                    newMessageID: newMessageID,
+                    topicHandles: topicHandles
+                )
+            } catch {
+                self.logger.info(
+                    "Failed to produce message",
+                    error: error,
+                    metadata: [KafkaLoggingKeys.topic: "\(message.topic)"]
+                )
+                throw error
+            }
             return KafkaProducerMessageID(rawValue: newMessageID)
         }
     }

--- a/Sources/Kafka/Utilities/KafkaLoggingKeys.swift
+++ b/Sources/Kafka/Utilities/KafkaLoggingKeys.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2026 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+enum KafkaLoggingKeys {
+    static let clientId = "kafka.client.id"
+    static let clientType = "kafka.client.type"
+    static let groupId = "kafka.group.id"
+    static let bootstrapServers = "kafka.bootstrap.servers"
+    static let topics = "kafka.topics"
+    static let topic = "kafka.topic"
+    static let rebalanceKind = "kafka.rebalance.kind"
+    static let partitions = "kafka.partitions"
+    static let timeoutMs = "kafka.timeout.ms"
+    static let messageId = "kafka.message.id"
+}

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -249,14 +249,17 @@ import Foundation
         }
 
         let recordedEvents = recorder.recordedEvents
-        #expect(recordedEvents.count == 1)
+        #expect(recordedEvents.count >= 1)
 
         let expectedMessage =
             "[thrd:app]: No `bootstrap.servers` configured: client will not be able to connect to Kafka cluster"
         let expectedLevel = Logger.Level.notice
         let expectedSource = "CONFWARN"
 
-        let receivedEvent = try #require(recordedEvents.first, "Expected log event, but found none")
+        let receivedEvent = try #require(
+            recordedEvents.first(where: { $0.source == expectedSource }),
+            "Expected CONFWARN log event, but found none"
+        )
         #expect(expectedMessage == receivedEvent.message.description)
         #expect(expectedLevel == receivedEvent.level)
         #expect(expectedSource == receivedEvent.source)


### PR DESCRIPTION
## Summary

- Enrich logger with structured metadata (`kafka.client.id`, `kafka.group.id`, `kafka.client.type`) for log filtering
- Add lifecycle and operational logging at appropriate levels (debug/trace/warning/info)
- Extract metadata key strings into `KafkaLoggingKeys` enum with `kafka.*` dot-separated naming
- Fix `producerLog` test to tolerate additional log events

## Motivation

The Swift client bridges librdkafka's internal logs but had no visibility into Swift-layer operations. This adds application-boundary logging that librdkafka cannot provide: lifecycle state, subscription changes, produce failures, and shutdown progress.

## Test plan

- [x] Build passes with `-Xswiftc -warnings-as-errors`
- [x] Unit tests pass