### PR TITLE
Bump docker default Swift version to 6.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG swift_version=6.0
+ARG swift_version=6.1
 ARG ubuntu_version=jammy
 FROM swift:${swift_version}-${ubuntu_version}
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,11 +29,11 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   client:
-    image: swift-kafka-client:${IMAGE_TAG:-local-${SWIFT_VERSION:-6.0}-${UBUNTU_VERSION:-jammy}-${IMAGE_PLATFORM:-amd64}}
+    image: swift-kafka-client:${IMAGE_TAG:-local-${SWIFT_VERSION:-6.1}-${UBUNTU_VERSION:-jammy}-${IMAGE_PLATFORM:-amd64}}
     build:
       args:
         ubuntu_version: "${UBUNTU_VERSION:-jammy}"
-        swift_version: "${SWIFT_VERSION:-6.0}"
+        swift_version: "${SWIFT_VERSION:-6.1}"
       platforms:
         - linux/${IMAGE_PLATFORM:-amd64}
     depends_on: [kafka]


### PR DESCRIPTION
### Motivation

Swift 6.0 is being dropped from the support window. [#219](https://github.com/swift-server/swift-kafka-client/pull/219) bumps the package tools-version to 6.1 and removes the Swift 6.0 CI jobs, but the docker tooling still defaulted to Swift 6.0.

With the package at `swift-tools-version:6.1`, running `make docker-test` / `make docker-build` without an explicit `SWIFT_VERSION` would build on `swift:6.0-jammy`, where SwiftPM refuses a 6.1 tools-version package. The docker defaults should track the minimum supported toolchain.

### Modifications

* Bump the default `swift_version` in `docker/Dockerfile` from `6.0` to `6.1`.
* Bump the `SWIFT_VERSION` fallback in `docker/docker-compose.yaml` (build arg and image tag) from `6.0` to `6.1`.

### Result

The docker defaults track the minimum supported Swift version, so the default `make docker-test` / `make docker-build` path works without needing to set `SWIFT_VERSION` manually.