### PR TITLE
Downgrade swift-log to unblock Swift 6.1 CI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.1.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.14.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics", from: "2.4.1"),
         // The zstd Swift package produces warnings that we cannot resolve:
         // https://github.com/facebook/zstd/issues/3328

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -573,7 +573,7 @@ public final class KafkaConsumer: Sendable, Service {
                 do {
                     try client.consumerClose()
                 } catch {
-                    self.logger.info("Closing KafkaConsumer failed", error: error)
+                    self.logger.info("Closing KafkaConsumer failed", metadata: [KafkaLoggingKeys.error: "\(error)"])
                     self.stateMachine.withLockedValue { $0.closeFailed() }
                 }
                 self.pollAndDrainEvents(client: client)
@@ -609,7 +609,7 @@ public final class KafkaConsumer: Sendable, Service {
                 }
                 self.logger.info(
                     "Kafka client error",
-                    error: kafkaError
+                    metadata: [KafkaLoggingKeys.error: "\(kafkaError)"]
                 )
             }
         }
@@ -664,7 +664,7 @@ public final class KafkaConsumer: Sendable, Service {
                 }
                 self.logger.info(
                     "Kafka client error",
-                    error: kafkaError
+                    metadata: [KafkaLoggingKeys.error: "\(kafkaError)"]
                 )
             }
         }
@@ -957,7 +957,7 @@ public final class KafkaConsumer: Sendable, Service {
         } catch {
             logger.info(
                 "Closing KafkaConsumer failed",
-                error: error
+                metadata: [KafkaLoggingKeys.error: "\(error)"]
             )
         }
     }

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -283,7 +283,7 @@ public final class KafkaProducer: Service, Sendable {
                     case .error(let kafkaError):
                         self.logger.info(
                             "Kafka client error",
-                            error: kafkaError
+                            metadata: [KafkaLoggingKeys.error: "\(kafkaError)"]
                         )
                     }
                 }
@@ -301,7 +301,7 @@ public final class KafkaProducer: Service, Sendable {
                         _ = source?.yield(.error(kafkaError))
                         self.logger.info(
                             "Kafka client error",
-                            error: kafkaError
+                            metadata: [KafkaLoggingKeys.error: "\(kafkaError)"]
                         )
                     }
                 }
@@ -321,9 +321,9 @@ public final class KafkaProducer: Service, Sendable {
                 } catch {
                     self.logger.info(
                         "Flush timed out during shutdown, some messages may not have been delivered",
-                        error: error,
                         metadata: [
-                            KafkaLoggingKeys.timeoutMs: "\(self.config.shutdownFlushTimeoutMs)"
+                            KafkaLoggingKeys.timeoutMs: "\(self.config.shutdownFlushTimeoutMs)",
+                            KafkaLoggingKeys.error: "\(error)",
                         ]
                     )
                     throw error
@@ -352,9 +352,9 @@ public final class KafkaProducer: Service, Sendable {
             case .failure(let error):
                 self.logger.debug(
                     "Message delivery failed",
-                    error: error,
                     metadata: [
-                        KafkaLoggingKeys.messageId: "\(report.id.rawValue)"
+                        KafkaLoggingKeys.messageId: "\(report.id.rawValue)",
+                        KafkaLoggingKeys.error: "\(error)",
                     ]
                 )
             }
@@ -410,8 +410,7 @@ public final class KafkaProducer: Service, Sendable {
             } catch {
                 self.logger.info(
                     "Failed to produce message",
-                    error: error,
-                    metadata: [KafkaLoggingKeys.topic: "\(message.topic)"]
+                    metadata: [KafkaLoggingKeys.topic: "\(message.topic)", KafkaLoggingKeys.error: "\(error)"]
                 )
                 throw error
             }

--- a/Sources/Kafka/Utilities/KafkaLoggingKeys.swift
+++ b/Sources/Kafka/Utilities/KafkaLoggingKeys.swift
@@ -19,6 +19,7 @@ enum KafkaLoggingKeys {
     static let bootstrapServers = "kafka.bootstrap.servers"
     static let topics = "kafka.topics"
     static let topic = "kafka.topic"
+    static let error = "kafka.error"
     static let rebalanceKind = "kafka.rebalance.kind"
     static let partitions = "kafka.partitions"
     static let timeoutMs = "kafka.timeout.ms"


### PR DESCRIPTION
### Motivation

CI is failing on Swift 6.1 (and on `main` itself) because `swift-log` 1.14.0 — pinned in #243 — requires `swift-tools-version:6.2`, while this package still uses `6.1`. Fresh dependency resolution on Swift 6.1 CI can no longer resolve the graph.

### Modifications

- `Package.swift`: change swift-log requirement from `from: "1.14.0"` back to `from: "1.0.0"`, letting SwiftPM pick the highest version compatible with the current tools-version.
- Revert the `logger.info(..., error:)` / `logger.debug(..., error:)` call sites (the `error:` parameter was added in swift-log 1.11.0+) to passing errors via structured metadata under `KafkaLoggingKeys.error`.
- Restore `KafkaLoggingKeys.error` constant.

### Result

Swift 6.1 CI resolves and builds cleanly. Once the package moves to `swift-tools-version:6.2+`, we can re-bump swift-log and switch back to the first-class `error:` parameter.

### Test plan

- [x] `swift build` clean, incl. `-Xswiftc -warnings-as-errors`
- [x] Unit tests: `producerLog`, `consumerLog` pass