### PR TITLE
1.0 Beta release API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DerivedData/
 Package.resolved
 .*.sw?
 .swiftpm
+.idea/

--- a/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/KafkaConsumerBenchmark.swift
+++ b/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/KafkaConsumerBenchmark.swift
@@ -178,7 +178,7 @@ let benchmarks: @Sendable () -> Void = {
                 var totalBytes: UInt64 = 0
 
                 for try await record in consumer.messages {
-                    try consumer.scheduleCommit(record)
+                    Task { try? await consumer.commit(record) }
 
                     ctr += 1
                     totalBytes += UInt64(record.value.readableBytes)

--- a/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/KafkaConsumerBenchmark.swift
+++ b/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/KafkaConsumerBenchmark.swift
@@ -107,7 +107,7 @@ let benchmarks: @Sendable () -> Void = {
 
                 for try await record in consumer.messages {
                     ctr += 1
-                    totalBytes += UInt64(record.value.readableBytes)
+                    totalBytes += UInt64(record.value.count)
 
                     tmpCtr += 1
                     if tmpCtr >= interval {
@@ -181,7 +181,7 @@ let benchmarks: @Sendable () -> Void = {
                     Task { try? await consumer.commit(record) }
 
                     ctr += 1
-                    totalBytes += UInt64(record.value.readableBytes)
+                    totalBytes += UInt64(record.value.count)
 
                     tmpCtr += 1
                     if tmpCtr >= interval {

--- a/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/Utilities.swift
+++ b/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/Utilities.swift
@@ -73,7 +73,7 @@ func prepareTopic(messagesCount: UInt, partitions: Int32 = -1, logger: Logger = 
     producerConfig.bootstrapServers = [bootstrapServer]
     producerConfig.brokerAddressFamily = .v4
 
-    let (producer, acks) = try KafkaProducer.makeProducerWithEvents(config: producerConfig, logger: logger)
+    let (producer, acks) = try KafkaProducer.makeProducer(config: producerConfig)
 
     let serviceGroupConfiguration = ServiceGroupConfiguration(
         services: [producer],

--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ The `sendAndAwait(_:)` method produces a message and asynchronously awaits broke
 var config = KafkaProducerConfig()
 config.bootstrapServers = ["localhost:9092"]
 
-let producer = try KafkaProducer(config: config, logger: logger)
+let logger = Logger(label: "kafka-example")
+
+let (producer, _) = try withLogger(logger) { _ in
+    try KafkaProducer.makeProducer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [producer],
@@ -78,10 +82,11 @@ For high-throughput pipelines that need to maximize send rate, use the fire-and-
 var config = KafkaProducerConfig()
 config.bootstrapServers = ["localhost:9092"]
 
-let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-    config: config,
-    logger: logger
-)
+let logger = Logger(label: "kafka-example")
+
+let (producer, events) = try withLogger(logger) { _ in
+    try KafkaProducer.makeProducer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [producer],
@@ -121,7 +126,11 @@ var config = KafkaConsumerConfig()
 config.bootstrapServers = ["localhost:9092"]
 config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let logger = Logger(label: "kafka-example")
+
+let (consumer, _) = try withLogger(logger) { _ in
+    try KafkaConsumer.makeConsumer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
@@ -150,7 +159,11 @@ config.bootstrapServers = ["localhost:9092"]
 config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
 config.enableAutoOffsetStore = false
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let logger = Logger(label: "kafka-example")
+
+let (consumer, _) = try withLogger(logger) { _ in
+    try KafkaConsumer.makeConsumer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
@@ -181,7 +194,11 @@ config.bootstrapServers = ["localhost:9092"]
 config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
 config.enableAutoCommit = false
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let logger = Logger(label: "kafka-example")
+
+let (consumer, _) = try withLogger(logger) { _ in
+    try KafkaConsumer.makeConsumer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
@@ -204,7 +221,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 To commit all previously stored offsets at once:
 
 ```swift
-try await consumer.commit()
+try await consumer.commitStoredOffsets()
 ```
 
 #### Dynamic subscription management
@@ -280,7 +297,7 @@ config.saslPassword = "password"
 The events sequence surfaces errors from librdkafka with typed error codes:
 
 ```swift
-let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(config: config, logger: logger)
+let (consumer, events) = try KafkaConsumer.makeConsumer(config: config)
 
 for await event in events {
     switch event {

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        let message = KafkaProducer.Message(topic: "topic-name", value: "Hello, World!")
         let report = try await producer.sendAndAwait(message)
         switch report.status {
         case .acknowledged(let ack):
@@ -98,7 +98,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        let message = KafkaProducer.Message(topic: "topic-name", value: "Hello, World!")
         try producer.send(message)
 
         for await event in events {
@@ -128,7 +128,7 @@ config.consumptionStrategy = .group(id: "example-group", topics: ["topic-name"])
 
 let logger = Logger(label: "kafka-example")
 
-let (consumer, _) = try withLogger(logger) { _ in
+let (consumer, messages, _) = try withLogger(logger) { _ in
     try KafkaConsumer.makeConsumer(config: config)
 }
 
@@ -142,7 +142,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        for try await message in consumer.messages {
+        for try await message in messages {
             print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
         }
     }
@@ -161,7 +161,7 @@ config.enableAutoOffsetStore = false
 
 let logger = Logger(label: "kafka-example")
 
-let (consumer, _) = try withLogger(logger) { _ in
+let (consumer, messages, _) = try withLogger(logger) { _ in
     try KafkaConsumer.makeConsumer(config: config)
 }
 
@@ -175,7 +175,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        for try await message in consumer.messages {
+        for try await message in messages {
             // Process message...
             try consumer.storeOffset(message)
             // The background auto-commit timer commits the offset automatically.
@@ -196,7 +196,7 @@ config.enableAutoCommit = false
 
 let logger = Logger(label: "kafka-example")
 
-let (consumer, _) = try withLogger(logger) { _ in
+let (consumer, messages, _) = try withLogger(logger) { _ in
     try KafkaConsumer.makeConsumer(config: config)
 }
 
@@ -210,7 +210,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        for try await message in consumer.messages {
+        for try await message in messages {
             // Process message...
             try await consumer.commit(message)
         }
@@ -233,7 +233,7 @@ Change topics at runtime:
 try consumer.subscribe(topics: ["topic-a", "topic-b"])
 
 // Query current subscription
-let topics = try consumer.subscribedTopics()
+let topics = try consumer.subscribedTopics
 
 // Unsubscribe from all topics
 try consumer.unsubscribe()
@@ -297,7 +297,7 @@ config.saslPassword = "password"
 The events sequence surfaces errors from librdkafka with typed error codes:
 
 ```swift
-let (consumer, events) = try KafkaConsumer.makeConsumer(config: config)
+let (consumer, _, events) = try KafkaConsumer.makeConsumer(config: config)
 
 for await event in events {
     switch event {

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     group.addTask {
         for try await message in messages {
-            print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
+            print("Received: \(message.topic.rawValue)/\(message.partition) at offset \(message.offset)")
         }
     }
 }

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -15,7 +15,7 @@
 import struct Foundation.UUID
 
 /// Configuration values that control a Kafka consumer instance.
-public struct KafkaConsumerConfiguration {
+public struct KafkaConsumerConfiguration: Sendable {
     // MARK: - Kafka-specific Config properties
 
     /// The time between two consecutive polls.
@@ -28,8 +28,8 @@ public struct KafkaConsumerConfiguration {
     /// The Kafka message consumption strategy.
     public struct ConsumptionStrategy: Sendable, Hashable {
         enum _ConsumptionStrategy: Sendable, Hashable {
-            case partition(groupID: String?, topic: String, partition: KafkaPartition, offset: KafkaOffset)
-            case group(groupID: String, topics: [String])
+            case partition(groupID: String?, topic: KafkaTopic, partition: KafkaPartition, offset: KafkaOffset)
+            case group(groupID: String, topics: [KafkaTopic])
         }
 
         let _internal: _ConsumptionStrategy
@@ -49,7 +49,7 @@ public struct KafkaConsumerConfiguration {
         public static func partition(
             _ partition: KafkaPartition,
             groupID: String? = nil,
-            topic: String,
+            topic: KafkaTopic,
             offset: KafkaOffset = .end
         ) -> ConsumptionStrategy {
             .init(consumptionStrategy: .partition(groupID: groupID, topic: topic, partition: partition, offset: offset))
@@ -61,7 +61,7 @@ public struct KafkaConsumerConfiguration {
         /// - Parameters:
         ///     - groupID: The ID of the consumer group to join.
         ///     - topics: An array of topic names to consume from.
-        public static func group(id groupID: String, topics: [String]) -> ConsumptionStrategy {
+        public static func group(id groupID: String, topics: [KafkaTopic]) -> ConsumptionStrategy {
             .init(consumptionStrategy: .group(groupID: groupID, topics: topics))
         }
     }
@@ -374,6 +374,3 @@ extension KafkaConsumerConfiguration {
     }
 }
 
-// MARK: - KafkaConsumerConfiguration + Sendable
-
-extension KafkaConsumerConfiguration: Sendable {}

--- a/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfiguration.swift
@@ -373,4 +373,3 @@ extension KafkaConsumerConfiguration {
         return config
     }
 }
-

--- a/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfiguration.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Configuration values that control a Kafka producer instance.
-public struct KafkaProducerConfiguration {
+public struct KafkaProducerConfiguration: Sendable {
     // MARK: - Kafka-specific Config properties
 
     /// Topic configuration applied to topics that the broker auto-creates.
@@ -272,10 +272,6 @@ extension KafkaProducerConfiguration {
         return resultDict
     }
 }
-
-// MARK: - KafkaProducerConfiguration + Sendable
-
-extension KafkaProducerConfiguration: Sendable {}
 
 // MARK: - KafkaProducerConfiguration + KafkaProducerConfig Conversion
 

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -255,7 +255,6 @@ public struct KafkaTopicConfiguration: Sendable {
     public init() {}
 }
 
-
 // MARK: - KafkaTopicConfiguration + Dictionary
 
 extension KafkaTopicConfiguration {

--- a/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/Kafka/Configuration/KafkaTopicConfiguration.swift
@@ -15,7 +15,7 @@
 /// Configuration applied to new topics that the producer creates.
 ///
 /// The ``KafkaProducer`` applies this configuration when auto-creating topics.
-public struct KafkaTopicConfiguration {
+public struct KafkaTopicConfiguration: Sendable {
     /// The number of acknowledgments the leader broker must receive from in-sync replica (ISR) brokers before responding to the request.
     public struct RequiredAcknowledgments: Sendable, Hashable {
         internal let rawValue: Int
@@ -255,9 +255,6 @@ public struct KafkaTopicConfiguration {
     public init() {}
 }
 
-// MARK: - KafkaTopicConfiguration + Sendable
-
-extension KafkaTopicConfiguration: Sendable {}
 
 // MARK: - KafkaTopicConfiguration + Dictionary
 

--- a/Sources/Kafka/Data/KafkaContiguousBytes.swift
+++ b/Sources/Kafka/Data/KafkaContiguousBytes.swift
@@ -19,7 +19,7 @@
 /// Standard Library currently does not provide such a protocol.
 ///
 /// By conforming your own types to this protocol, you can pass instances of those types
-/// directly to ``KafkaProducerMessage`` as key and value.
+/// directly to ``KafkaProducer/Message`` as key and value.
 public protocol KafkaContiguousBytes {
     /// Calls the closure you provide with the contents of the underlying storage.
     ///

--- a/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
+++ b/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
@@ -189,13 +189,8 @@ extension RDKafkaClient {
     }
 
     /// Creates a topic-management client using the consumer configuration you provide.
-    public static func makeClientForTopics(config: KafkaConsumerConfig, logger: Logger) throws -> RDKafkaClient {
-        try Self.makeClient(type: .consumer, configDictionary: config.config, events: [], logger: logger)
-    }
-
-    /// Creates a topic-management client using the consumer configuration you provide.
-    @available(*, deprecated, message: "Use makeClientForTopics(config:logger:) with KafkaConsumerConfig instead")
-    public static func makeClientForTopics(config: KafkaConsumerConfiguration, logger: Logger) throws -> RDKafkaClient {
-        try Self.makeClient(type: .consumer, configDictionary: config.dictionary, events: [], logger: logger)
+    public static func makeClientForTopics(config: KafkaConsumerConfig) throws -> RDKafkaClient {
+        let logger = Logger.current
+        return try Self.makeClient(type: .consumer, configDictionary: config.config, events: [], logger: logger)
     }
 }

--- a/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
+++ b/Sources/Kafka/ForTesting/RDKafkaClient+Topic.swift
@@ -30,7 +30,7 @@ extension RDKafkaClient {
     /// - Parameter partitions: Partitions in topic (default: -1 - default for broker)
     /// - Returns: Name of newly created topic.
     /// - Throws: A ``KafkaError`` if the topic creation failed.
-    public func _createUniqueTopic(partitions: Int32 = -1) async throws -> String {
+    public func _createUniqueTopic(partitions: Int32 = -1) async throws -> KafkaTopic {
         let uniqueTopicName = UUID().uuidString
 
         let errorChars = UnsafeMutablePointer<CChar>.allocate(capacity: RDKafkaClient.stringSize)
@@ -112,14 +112,14 @@ extension RDKafkaClient {
             )
         }
 
-        return uniqueTopicName
+        return KafkaTopic(rawValue: uniqueTopicName)
     }
 
     /// Delete a topic.
     /// - Parameter topic: Topic to delete.
     /// - Throws: A ``KafkaError`` if the topic deletion failed.
-    public func _deleteTopic(_ topic: String) async throws {
-        let deleteTopic = rd_kafka_DeleteTopic_new(topic)
+    public func _deleteTopic(_ topic: KafkaTopic) async throws {
+        let deleteTopic = rd_kafka_DeleteTopic_new(topic.rawValue)
         defer { rd_kafka_DeleteTopic_destroy(deleteTopic) }
 
         let resultQueue = try self.withKafkaHandlePointer { kafkaHandle in
@@ -181,7 +181,7 @@ extension RDKafkaClient {
         }
 
         let receivedTopicName = String(cString: rd_kafka_topic_result_name(topicResult))
-        guard receivedTopicName == topic else {
+        guard receivedTopicName == topic.rawValue else {
             throw KafkaError.topicDeletion(
                 reason: "Received topic result for topic with different name"
             )

--- a/Sources/Kafka/ForTesting/TestMessages.swift
+++ b/Sources/Kafka/ForTesting/TestMessages.swift
@@ -33,9 +33,9 @@ public func _createTestMessages(
     topic: String,
     headers: [KafkaHeader] = [],
     count: UInt
-) -> [KafkaProducerMessage<String, String>] {
+) -> [KafkaProducer.Message<String, String>] {
     Array(0..<count).map {
-        KafkaProducerMessage(
+        KafkaProducer.Message(
             topic: topic,
             headers: headers,
             key: UUID().uuidString,
@@ -48,11 +48,11 @@ public func _createTestMessages(
 @_spi(Internal)
 public func _sendAndAcknowledgeMessages(
     producer: KafkaProducer,
-    events: KafkaProducerEvents,
-    messages: [KafkaProducerMessage<String, String>],
+    events: KafkaProducer.Events,
+    messages: [KafkaProducer.Message<String, String>],
     skipConsistencyCheck: Bool = false
 ) async throws {
-    var messageIDs = Set<KafkaProducerMessageID>()
+    var messageIDs = Set<KafkaProducer.MessageID>()
     messageIDs.reserveCapacity(messages.count)
 
     for message in messages {
@@ -67,7 +67,7 @@ public func _sendAndAcknowledgeMessages(
         }
     }
 
-    var receivedDeliveryReports = Set<KafkaDeliveryReport>()
+    var receivedDeliveryReports = Set<KafkaProducer.DeliveryReport>()
     receivedDeliveryReports.reserveCapacity(messages.count)
 
     for await event in events {
@@ -89,7 +89,7 @@ public func _sendAndAcknowledgeMessages(
         throw _TestMessagesError.deliveryReportsIdsIncorrect
     }
 
-    let acknowledgedMessages: [KafkaAcknowledgedMessage] = receivedDeliveryReports.compactMap {
+    let acknowledgedMessages: [KafkaProducer.AcknowledgedMessage] = receivedDeliveryReports.compactMap {
         guard case .acknowledged(let receivedMessage) = $0.status else {
             return nil
         }

--- a/Sources/Kafka/ForTesting/TestMessages.swift
+++ b/Sources/Kafka/ForTesting/TestMessages.swift
@@ -30,7 +30,7 @@ public enum _TestMessagesError: Error {
 /// Builds an array of test producer messages with unique keys for the topic you provide.
 @_spi(Internal)
 public func _createTestMessages(
-    topic: String,
+    topic: KafkaTopic,
     headers: [KafkaHeader] = [],
     count: UInt
 ) -> [KafkaProducer.Message<String, String>] {

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -45,7 +45,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     group.addTask {
         for try await message in messages {
-            print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
+            print("Received: \(message.topic.rawValue)/\(message.partition) at offset \(message.offset)")
         }
     }
 }

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -4,7 +4,7 @@ Receive records from Kafka topics as an asynchronous sequence, control offset co
 
 ## Overview
 
-A ``KafkaConsumer`` joins a consumer group and exposes records through a ``KafkaConsumerMessages`` asynchronous sequence. Iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
+A ``KafkaConsumer`` joins a consumer group and exposes records through a ``KafkaConsumer/Messages`` asynchronous sequence. Iterate the sequence with `for try await`, and the consumer integrates naturally with structured concurrency, task cancellation, and graceful shutdown through `ServiceGroup`.
 
 By default, the consumer stores and commits offsets automatically as iteration proceeds. For at-least-once delivery, disable automatic offset storage and store offsets after processing each record. For full control, also turn off the periodic auto-commit and commit explicitly.
 
@@ -25,12 +25,12 @@ For security options, see <doc:SecuringConnections>.
 
 ### Iterate the message sequence
 
-Run the consumer inside a `ServiceGroup` and read records from ``KafkaConsumer/messages``:
+Run the consumer inside a `ServiceGroup` and read records from its ``KafkaConsumer/Messages`` sequence:
 
 ```swift
 let logger = Logger(label: "kafka-example")
 
-let (consumer, _) = try withLogger(logger) { _ in
+let (consumer, messages, _) = try withLogger(logger) { _ in
     try KafkaConsumer.makeConsumer(config: config)
 }
 
@@ -44,14 +44,14 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        for try await message in consumer.messages {
+        for try await message in messages {
             print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
         }
     }
 }
 ```
 
-Each ``KafkaConsumerMessage`` carries the topic, partition, offset, key, value, headers, and timestamp.
+Each ``KafkaConsumer/Message`` carries the topic, partition, offset, key, value, headers, and timestamp.
 
 ### Achieve at-least-once delivery
 
@@ -66,11 +66,11 @@ config.consumptionStrategy = .group(
 )
 config.enableAutoOffsetStore = false
 
-let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+let (consumer, messages, _) = try KafkaConsumer.makeConsumer(config: config)
 
 // ... run inside a ServiceGroup as in the previous example.
 
-for try await message in consumer.messages {
+for try await message in messages {
     // Process the record.
     try consumer.storeOffset(message)
 }
@@ -91,11 +91,11 @@ config.consumptionStrategy = .group(
 )
 config.enableAutoCommit = false
 
-let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+let (consumer, messages, _) = try KafkaConsumer.makeConsumer(config: config)
 
 // ... run inside a ServiceGroup as above.
 
-for try await message in consumer.messages {
+for try await message in messages {
     // Process the record.
     try await consumer.commit(message)
 }
@@ -116,7 +116,7 @@ Topic subscriptions change at runtime — call ``KafkaConsumer/subscribe(topics:
 try consumer.subscribe(topics: ["topic-a", "topic-b"])
 
 // Query the current subscription.
-let topics = try consumer.subscribedTopics()
+let topics = try consumer.subscribedTopics
 
 // Unsubscribe from all topics.
 try consumer.unsubscribe()
@@ -140,14 +140,14 @@ While a partition is paused, the consumer stops fetching records for it but cont
 
 ### Observe rebalances
 
-When the membership of a consumer group changes — a consumer joins, leaves, or fails — Kafka redistributes the group's partitions across the remaining members. This is a *rebalance*. ``KafkaConsumer`` performs the assign and unassign automatically and surfaces a ``KafkaConsumerRebalance`` notification through the ``KafkaConsumerEvents`` sequence, so you can react — for example, by committing offsets for partitions that are moving away.
+When the membership of a consumer group changes — a consumer joins, leaves, or fails — Kafka redistributes the group's partitions across the remaining members. This is a *rebalance*. ``KafkaConsumer`` performs the assign and unassign automatically and surfaces a ``KafkaConsumer/Rebalance`` notification through the ``KafkaConsumer/Events`` sequence, so you can react — for example, by committing offsets for partitions that are moving away.
 
 The following example creates the consumer with ``KafkaConsumer/makeConsumer(config:)`` and iterates the event sequence alongside the messages:
 
 ```swift
 config.partitionAssignmentStrategy = "cooperative-sticky"
 
-let (consumer, events) = try withLogger(logger) { _ in
+let (consumer, messages, events) = try withLogger(logger) { _ in
     try KafkaConsumer.makeConsumer(config: config)
 }
 
@@ -162,7 +162,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Consume records.
     group.addTask {
-        for try await message in consumer.messages {
+        for try await message in messages {
             // Process the record, then store or commit its offset.
         }
     }
@@ -192,7 +192,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 }
 ```
 
-Each ``KafkaConsumerRebalance`` reports its ``KafkaConsumerRebalance/kind`` — ``KafkaConsumerRebalance/Kind/assign``, ``KafkaConsumerRebalance/Kind/revoke``, or ``KafkaConsumerRebalance/Kind/error(_:)`` — and the ``KafkaConsumerRebalance/partitions`` involved. Commit offsets on revoke so another consumer resumes from the right position.
+Each ``KafkaConsumer/Rebalance`` reports its ``KafkaConsumer/Rebalance/kind`` — ``KafkaConsumer/Rebalance/Kind/assign``, ``KafkaConsumer/Rebalance/Kind/revoke``, or ``KafkaConsumer/Rebalance/Kind/error(_:)`` — and the ``KafkaConsumer/Rebalance/partitions`` involved. Commit offsets on revoke so another consumer resumes from the right position.
 
 Choose an assignment strategy with ``KafkaConsumerConfig/partitionAssignmentStrategy``: `cooperative-sticky` for incremental cooperative rebalancing, or `range` and `roundrobin` for eager rebalancing. ``KafkaConsumer`` adapts to the negotiated protocol, so your handling code is identical either way. Cooperative and eager strategies must not be mixed within a group.
 
@@ -202,15 +202,14 @@ Choose an assignment strategy with ``KafkaConsumerConfig/partitionAssignmentStra
 
 ### Reading records
 
-- ``KafkaConsumer/messages``
-- ``KafkaConsumerMessages``
-- ``KafkaConsumerMessage``
+- ``KafkaConsumer/Messages``
+- ``KafkaConsumer/Message``
 
 ### Managing subscriptions
 
 - ``KafkaConsumer/subscribe(topics:)``
 - ``KafkaConsumer/unsubscribe()``
-- ``KafkaConsumer/subscribedTopics()``
+- ``KafkaConsumer/subscribedTopics``
 
 ### Controlling offsets
 
@@ -226,6 +225,6 @@ Choose an assignment strategy with ``KafkaConsumerConfig/partitionAssignmentStra
 ### Observing rebalances and events
 
 - ``KafkaConsumer/makeConsumer(config:)``
-- ``KafkaConsumerRebalance``
-- ``KafkaConsumerEvent``
-- ``KafkaConsumerEvents``
+- ``KafkaConsumer/Rebalance``
+- ``KafkaConsumer/Event``
+- ``KafkaConsumer/Events``

--- a/Sources/Kafka/Kafka.docc/ConsumingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ConsumingMessages.md
@@ -28,7 +28,11 @@ For security options, see <doc:SecuringConnections>.
 Run the consumer inside a `ServiceGroup` and read records from ``KafkaConsumer/messages``:
 
 ```swift
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let logger = Logger(label: "kafka-example")
+
+let (consumer, _) = try withLogger(logger) { _ in
+    try KafkaConsumer.makeConsumer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
@@ -62,7 +66,7 @@ config.consumptionStrategy = .group(
 )
 config.enableAutoOffsetStore = false
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
 // ... run inside a ServiceGroup as in the previous example.
 
@@ -87,7 +91,7 @@ config.consumptionStrategy = .group(
 )
 config.enableAutoCommit = false
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
 // ... run inside a ServiceGroup as above.
 
@@ -97,10 +101,10 @@ for try await message in consumer.messages {
 }
 ```
 
-To commit every previously stored offset in one call, use ``KafkaConsumer/commit()``:
+To commit every previously stored offset in one call, use ``KafkaConsumer/commitStoredOffsets()``:
 
 ```swift
-try await consumer.commit()
+try await consumer.commitStoredOffsets()
 ```
 
 ### Manage subscriptions dynamically
@@ -138,12 +142,14 @@ While a partition is paused, the consumer stops fetching records for it but cont
 
 When the membership of a consumer group changes — a consumer joins, leaves, or fails — Kafka redistributes the group's partitions across the remaining members. This is a *rebalance*. ``KafkaConsumer`` performs the assign and unassign automatically and surfaces a ``KafkaConsumerRebalance`` notification through the ``KafkaConsumerEvents`` sequence, so you can react — for example, by committing offsets for partitions that are moving away.
 
-The following example creates the consumer with ``KafkaConsumer/makeConsumerWithEvents(config:logger:)`` and iterates the event sequence alongside the messages:
+The following example creates the consumer with ``KafkaConsumer/makeConsumer(config:)`` and iterates the event sequence alongside the messages:
 
 ```swift
 config.partitionAssignmentStrategy = "cooperative-sticky"
 
-let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(config: config, logger: logger)
+let (consumer, events) = try withLogger(logger) { _ in
+    try KafkaConsumer.makeConsumer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [consumer],
@@ -210,7 +216,7 @@ Choose an assignment strategy with ``KafkaConsumerConfig/partitionAssignmentStra
 
 - ``KafkaConsumer/storeOffset(_:)``
 - ``KafkaConsumer/commit(_:)``
-- ``KafkaConsumer/commit()``
+- ``KafkaConsumer/commitStoredOffsets()``
 
 ### Pausing partitions
 
@@ -219,7 +225,7 @@ Choose an assignment strategy with ``KafkaConsumerConfig/partitionAssignmentStra
 
 ### Observing rebalances and events
 
-- ``KafkaConsumer/makeConsumerWithEvents(config:logger:)``
+- ``KafkaConsumer/makeConsumer(config:)``
 - ``KafkaConsumerRebalance``
 - ``KafkaConsumerEvent``
 - ``KafkaConsumerEvents``

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -115,7 +115,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     group.addTask {
         for try await message in messages {
-            print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
+            print("Received: \(message.topic.rawValue)/\(message.partition) at offset \(message.offset)")
         }
     }
 }

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -57,7 +57,9 @@ let logger = Logger(label: "kafka-example")
 var config = KafkaProducerConfig()
 config.bootstrapServers = ["localhost:9092"]
 
-let producer = try KafkaProducer(config: config, logger: logger)
+let (producer, _) = try withLogger(logger) { _ in
+    try KafkaProducer.makeProducer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [producer],
@@ -89,6 +91,8 @@ await withThrowingTaskGroup(of: Void.self) { group in
 To consume messages, create a ``KafkaConsumer`` with a group consumption strategy, run it inside a `ServiceGroup`, and iterate ``KafkaConsumer/messages``:
 
 ```swift
+let logger = Logger(label: "kafka-example")
+
 var config = KafkaConsumerConfig()
 config.bootstrapServers = ["localhost:9092"]
 config.consumptionStrategy = .group(
@@ -96,7 +100,9 @@ config.consumptionStrategy = .group(
     topics: ["topic-name"]
 )
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let (consumer, _) = try withLogger(logger) { _ in
+    try KafkaConsumer.makeConsumer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [consumer],

--- a/Sources/Kafka/Kafka.docc/GettingStarted.md
+++ b/Sources/Kafka/Kafka.docc/GettingStarted.md
@@ -71,7 +71,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        let message = KafkaProducerMessage(
+        let message = KafkaProducer.Message(
             topic: "topic-name",
             value: "Hello, World!"
         )
@@ -88,7 +88,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
 ### Read messages from a topic
 
-To consume messages, create a ``KafkaConsumer`` with a group consumption strategy, run it inside a `ServiceGroup`, and iterate ``KafkaConsumer/messages``:
+To consume messages, create a ``KafkaConsumer`` with a group consumption strategy, run it inside a `ServiceGroup`, and iterate its ``KafkaConsumer/Messages`` sequence:
 
 ```swift
 let logger = Logger(label: "kafka-example")
@@ -100,7 +100,7 @@ config.consumptionStrategy = .group(
     topics: ["topic-name"]
 )
 
-let (consumer, _) = try withLogger(logger) { _ in
+let (consumer, messages, _) = try withLogger(logger) { _ in
     try KafkaConsumer.makeConsumer(config: config)
 }
 
@@ -114,7 +114,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        for try await message in consumer.messages {
+        for try await message in messages {
             print("Received: \(message.topic)/\(message.partition) at offset \(message.offset)")
         }
     }

--- a/Sources/Kafka/Kafka.docc/HandlingErrors.md
+++ b/Sources/Kafka/Kafka.docc/HandlingErrors.md
@@ -11,8 +11,8 @@ Both the producer and the consumer report failures as ``KafkaError`` values. A `
 A ``KafkaError`` reaches your code in three ways:
 
 - **Thrown** from throwing calls such as ``KafkaProducer/send(_:)``, ``KafkaProducer/sendAndAwait(_:)``, ``KafkaConsumer/subscribe(topics:)``, and ``KafkaConsumer/commit(_:)``.
-- **On an event sequence**, as ``KafkaConsumerEvent/error(_:)`` or ``KafkaProducerEvent/error(_:)`` — for example, a broker disconnection or an authentication failure.
-- **In a delivery report**, when a ``KafkaDeliveryReport``'s status is `failure` because a message could not be delivered.
+- **On an event sequence**, as ``KafkaConsumer/Event/error(_:)`` or ``KafkaProducer/Event/error(_:)`` — for example, a broker disconnection or an authentication failure.
+- **In a delivery report**, when a ``KafkaProducer/DeliveryReport``'s status is `failure` because a message could not be delivered.
 
 ### Classify an error
 
@@ -57,6 +57,6 @@ func handle(_ error: KafkaError, logger: Logger) {
 
 ### Error events
 
-- ``KafkaConsumerEvent``
-- ``KafkaProducerEvent``
-- ``KafkaDeliveryReport``
+- ``KafkaConsumer/Event``
+- ``KafkaProducer/Event``
+- ``KafkaProducer/DeliveryReport``

--- a/Sources/Kafka/Kafka.docc/HandlingErrors.md
+++ b/Sources/Kafka/Kafka.docc/HandlingErrors.md
@@ -6,7 +6,7 @@ Find where Kafka errors surface and classify them to decide whether to retry, re
 
 Both the producer and the consumer report failures as ``KafkaError`` values. A ``KafkaError`` carries a ``KafkaError/code`` describing the kind of failure and, when the error originates from librdkafka, a ``KafkaError/rdKafkaCode`` with the specific underlying code. The ``KafkaError/isFatal`` and ``KafkaError/isRetriable`` flags tell you how to respond.
 
-## Find where errors surface
+### Find where errors surface
 
 A ``KafkaError`` reaches your code in three ways:
 
@@ -14,7 +14,7 @@ A ``KafkaError`` reaches your code in three ways:
 - **On an event sequence**, as ``KafkaConsumerEvent/error(_:)`` or ``KafkaProducerEvent/error(_:)`` — for example, a broker disconnection or an authentication failure.
 - **In a delivery report**, when a ``KafkaDeliveryReport``'s status is `failure` because a message could not be delivered.
 
-## Classify an error
+### Classify an error
 
 Use ``KafkaError/isFatal`` and ``KafkaError/isRetriable`` to decide how to respond, and inspect ``KafkaError/rdKafkaCode`` for finer-grained handling:
 

--- a/Sources/Kafka/Kafka.docc/Kafka.md
+++ b/Sources/Kafka/Kafka.docc/Kafka.md
@@ -51,6 +51,7 @@ Kafka integrates with [swift-log](https://github.com/apple/swift-log) for struct
 
 ### Identifying topics, partitions, and offsets
 
+- ``KafkaTopic``
 - ``KafkaTopicPartition``
 - ``KafkaTopicPartitionOffset``
 - ``KafkaPartition``

--- a/Sources/Kafka/Kafka.docc/Kafka.md
+++ b/Sources/Kafka/Kafka.docc/Kafka.md
@@ -22,21 +22,21 @@ Kafka integrates with [swift-log](https://github.com/apple/swift-log) for struct
 ### Producing messages
 
 - ``KafkaProducer``
-- ``KafkaProducerMessage``
-- ``KafkaDeliveryReport``
-- ``KafkaAcknowledgedMessage``
-- ``KafkaProducerMessageID``
-- ``KafkaProducerEvents``
-- ``KafkaProducerEvent``
+- ``KafkaProducer/Message``
+- ``KafkaProducer/DeliveryReport``
+- ``KafkaProducer/AcknowledgedMessage``
+- ``KafkaProducer/MessageID``
+- ``KafkaProducer/Events``
+- ``KafkaProducer/Event``
 
 ### Consuming messages
 
 - ``KafkaConsumer``
-- ``KafkaConsumerMessages``
-- ``KafkaConsumerMessage``
-- ``KafkaConsumerEvents``
-- ``KafkaConsumerEvent``
-- ``KafkaConsumerRebalance``
+- ``KafkaConsumer/Messages``
+- ``KafkaConsumer/Message``
+- ``KafkaConsumer/Events``
+- ``KafkaConsumer/Event``
+- ``KafkaConsumer/Rebalance``
 - ``KafkaTimestampType``
 
 ### Configuring clients

--- a/Sources/Kafka/Kafka.docc/KafkaConsumer.md
+++ b/Sources/Kafka/Kafka.docc/KafkaConsumer.md
@@ -4,7 +4,7 @@ An object that consumes messages from a Kafka cluster as part of a service lifec
 
 ## Overview
 
-Create a consumer from a ``KafkaConsumerConfig``, run it inside a `ServiceGroup`, and iterate ``KafkaConsumer/messages`` to receive records. The consumer conforms to `Service`, so the surrounding application controls its lifecycle; the `run()` method drives the underlying poll loop until the calling task is canceled or a graceful shutdown is triggered.
+Create a consumer from a ``KafkaConsumerConfig``, run it inside a `ServiceGroup`, and iterate its ``KafkaConsumer/Messages`` sequence to receive records. The consumer conforms to `Service`, so the surrounding application controls its lifecycle; the `run()` method drives the underlying poll loop until the calling task is canceled or a graceful shutdown is triggered.
 
 By default, the consumer stores and commits offsets automatically as iteration proceeds. For at-least-once delivery, disable automatic offset storage and call ``storeOffset(_:)`` after processing each record. For full control over commit timing, disable auto-commit as well and use ``commit(_:)`` or ``commitStoredOffsets()`` explicitly.
 
@@ -18,9 +18,8 @@ For an end-to-end guide including configuration, rebalance handling, and offset 
 
 ### Consuming messages
 
-- ``messages``
-- ``KafkaConsumerMessages``
-- ``KafkaConsumerMessage``
+- ``KafkaConsumer/Messages``
+- ``KafkaConsumer/Message``
 
 ### Running the service
 
@@ -30,7 +29,7 @@ For an end-to-end guide including configuration, rebalance handling, and offset 
 
 - ``subscribe(topics:)``
 - ``unsubscribe()``
-- ``subscribedTopics()``
+- ``subscribedTopics``
 
 ### Storing and committing offsets
 
@@ -55,6 +54,6 @@ For an end-to-end guide including configuration, rebalance handling, and offset 
 
 ### Observing events
 
-- ``KafkaConsumerEvents``
-- ``KafkaConsumerEvent``
-- ``KafkaConsumerRebalance``
+- ``KafkaConsumer/Events``
+- ``KafkaConsumer/Event``
+- ``KafkaConsumer/Rebalance``

--- a/Sources/Kafka/Kafka.docc/KafkaConsumer.md
+++ b/Sources/Kafka/Kafka.docc/KafkaConsumer.md
@@ -6,7 +6,7 @@ An object that consumes messages from a Kafka cluster as part of a service lifec
 
 Create a consumer from a ``KafkaConsumerConfig``, run it inside a `ServiceGroup`, and iterate ``KafkaConsumer/messages`` to receive records. The consumer conforms to `Service`, so the surrounding application controls its lifecycle; the `run()` method drives the underlying poll loop until the calling task is canceled or a graceful shutdown is triggered.
 
-By default, the consumer stores and commits offsets automatically as iteration proceeds. For at-least-once delivery, disable automatic offset storage and call ``storeOffset(_:)`` after processing each record. For full control over commit timing, disable auto-commit as well and use ``commit(_:)`` or ``commit()`` explicitly.
+By default, the consumer stores and commits offsets automatically as iteration proceeds. For at-least-once delivery, disable automatic offset storage and call ``storeOffset(_:)`` after processing each record. For full control over commit timing, disable auto-commit as well and use ``commit(_:)`` or ``commitStoredOffsets()`` explicitly.
 
 For an end-to-end guide including configuration, rebalance handling, and offset patterns, see <doc:ConsumingMessages>.
 
@@ -14,8 +14,7 @@ For an end-to-end guide including configuration, rebalance handling, and offset 
 
 ### Creating a consumer
 
-- ``init(config:logger:)``
-- ``makeConsumerWithEvents(config:logger:)``
+- ``makeConsumer(config:)``
 
 ### Consuming messages
 
@@ -26,7 +25,6 @@ For an end-to-end guide including configuration, rebalance handling, and offset 
 ### Running the service
 
 - ``run()``
-- ``triggerGracefulShutdown()``
 
 ### Managing subscriptions
 
@@ -38,9 +36,7 @@ For an end-to-end guide including configuration, rebalance handling, and offset 
 
 - ``storeOffset(_:)``
 - ``commit(_:)``
-- ``commit()``
-- ``scheduleCommit(_:)``
-- ``scheduleCommit()``
+- ``commitStoredOffsets()``
 
 ### Querying position
 

--- a/Sources/Kafka/Kafka.docc/KafkaProducer.md
+++ b/Sources/Kafka/Kafka.docc/KafkaProducer.md
@@ -6,7 +6,7 @@ An object that sends messages to a Kafka cluster as part of a service lifecycle.
 
 Create a producer from a ``KafkaProducerConfig``, run it inside a `ServiceGroup`, and call ``send(_:)`` or ``sendAndAwait(_:)`` to publish records. The producer conforms to `Service`, so the surrounding application controls its lifecycle; the `run()` method drives the internal poll loop, dispatches delivery reports, and flushes outstanding messages on graceful shutdown.
 
-Two send styles are available. Use ``sendAndAwait(_:)`` when the caller needs the delivery outcome inline — the method suspends until the broker acknowledges (or rejects) the message and returns a ``KafkaDeliveryReport``. Use ``send(_:)`` paired with ``makeProducerWithEvents(config:logger:)`` for maximum throughput, processing delivery reports asynchronously through the events sequence.
+Two send styles are available. Use ``sendAndAwait(_:)`` when the caller needs the delivery outcome inline — the method suspends until the broker acknowledges (or rejects) the message and returns a ``KafkaDeliveryReport``. Use ``send(_:)`` paired with ``makeProducer(config:)`` for maximum throughput, processing delivery reports asynchronously through the events sequence.
 
 When messages are published to a nonexistent topic, a new topic is created using the default topic configuration (based on ``KafkaProducerConfig`` topic-level properties).
 
@@ -16,8 +16,7 @@ For an end-to-end guide including configuration, delivery patterns, and event ha
 
 ### Creating a producer
 
-- ``init(config:logger:)``
-- ``makeProducerWithEvents(config:logger:)``
+- ``makeProducer(config:)``
 
 ### Sending messages
 
@@ -29,7 +28,6 @@ For an end-to-end guide including configuration, delivery patterns, and event ha
 ### Running the service
 
 - ``run()``
-- ``triggerGracefulShutdown()``
 
 ### Observing outcomes
 

--- a/Sources/Kafka/Kafka.docc/KafkaProducer.md
+++ b/Sources/Kafka/Kafka.docc/KafkaProducer.md
@@ -6,7 +6,7 @@ An object that sends messages to a Kafka cluster as part of a service lifecycle.
 
 Create a producer from a ``KafkaProducerConfig``, run it inside a `ServiceGroup`, and call ``send(_:)`` or ``sendAndAwait(_:)`` to publish records. The producer conforms to `Service`, so the surrounding application controls its lifecycle; the `run()` method drives the internal poll loop, dispatches delivery reports, and flushes outstanding messages on graceful shutdown.
 
-Two send styles are available. Use ``sendAndAwait(_:)`` when the caller needs the delivery outcome inline — the method suspends until the broker acknowledges (or rejects) the message and returns a ``KafkaDeliveryReport``. Use ``send(_:)`` paired with ``makeProducer(config:)`` for maximum throughput, processing delivery reports asynchronously through the events sequence.
+Two send styles are available. Use ``sendAndAwait(_:)`` when the caller needs the delivery outcome inline — the method suspends until the broker acknowledges (or rejects) the message and returns a ``KafkaProducer/DeliveryReport``. Use ``send(_:)`` paired with ``makeProducer(config:)`` for maximum throughput, processing delivery reports asynchronously through the events sequence.
 
 When messages are published to a nonexistent topic, a new topic is created using the default topic configuration (based on ``KafkaProducerConfig`` topic-level properties).
 
@@ -22,8 +22,8 @@ For an end-to-end guide including configuration, delivery patterns, and event ha
 
 - ``send(_:)``
 - ``sendAndAwait(_:)``
-- ``KafkaProducerMessage``
-- ``KafkaProducerMessageID``
+- ``KafkaProducer/Message``
+- ``KafkaProducer/MessageID``
 
 ### Running the service
 
@@ -31,7 +31,7 @@ For an end-to-end guide including configuration, delivery patterns, and event ha
 
 ### Observing outcomes
 
-- ``KafkaProducerEvents``
-- ``KafkaProducerEvent``
-- ``KafkaDeliveryReport``
-- ``KafkaAcknowledgedMessage``
+- ``KafkaProducer/Events``
+- ``KafkaProducer/Event``
+- ``KafkaProducer/DeliveryReport``
+- ``KafkaProducer/AcknowledgedMessage``

--- a/Sources/Kafka/Kafka.docc/Observability.md
+++ b/Sources/Kafka/Kafka.docc/Observability.md
@@ -26,7 +26,7 @@ config.metrics.totalKafkaBrokerRequests = Gauge(label: "kafka_consumer_broker_re
 config.metrics.totalKafkaBrokerMessagesReceived = Gauge(label: "kafka_consumer_messages_received")
 config.metrics.queuedOperation = Gauge(label: "kafka_consumer_queued_operations")
 
-let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 ```
 
 The client emits metrics only when ``KafkaConfiguration/ConsumerMetrics/updateInterval`` is set **and** at least one gauge is assigned; otherwise the client skips statistics collection entirely. The producer exposes the same pattern through ``KafkaProducerConfig/metrics`` with producer-specific gauges such as ``KafkaConfiguration/ProducerMetrics/queuedProducerMessages`` and ``KafkaConfiguration/ProducerMetrics/totalKafkaBrokerMessagesSent``.
@@ -53,7 +53,7 @@ var config = KafkaConsumerConfig()
 config.clientId = "orders-consumer"
 config.consumptionStrategy = .group(id: "orders", topics: ["orders"])
 
-let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 // Every log entry from this consumer now carries kafka.client.id, kafka.client.type,
 // and kafka.group.id.
 ```

--- a/Sources/Kafka/Kafka.docc/Observability.md
+++ b/Sources/Kafka/Kafka.docc/Observability.md
@@ -6,7 +6,7 @@ Emit metrics and structured logs from the producer and consumer.
 
 The Kafka client integrates with [swift-metrics](https://github.com/apple/swift-metrics) for runtime metrics and [swift-log](https://github.com/apple/swift-log) for structured logging. Both are opt-in through the client configuration and the `Logger` you provide.
 
-## Emit metrics
+### Emit metrics
 
 The client periodically samples internal statistics and records them into [swift-metrics](https://github.com/apple/swift-metrics) gauges that you supply. Configure this through the ``KafkaConsumerConfig/metrics`` (or ``KafkaProducerConfig/metrics``) property: set an update interval and assign a `Gauge` to each statistic you want to track.
 
@@ -26,14 +26,14 @@ config.metrics.totalKafkaBrokerRequests = Gauge(label: "kafka_consumer_broker_re
 config.metrics.totalKafkaBrokerMessagesReceived = Gauge(label: "kafka_consumer_messages_received")
 config.metrics.queuedOperation = Gauge(label: "kafka_consumer_queued_operations")
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 ```
 
 The client emits metrics only when ``KafkaConfiguration/ConsumerMetrics/updateInterval`` is set **and** at least one gauge is assigned; otherwise the client skips statistics collection entirely. The producer exposes the same pattern through ``KafkaProducerConfig/metrics`` with producer-specific gauges such as ``KafkaConfiguration/ProducerMetrics/queuedProducerMessages`` and ``KafkaConfiguration/ProducerMetrics/totalKafkaBrokerMessagesSent``.
 
 The gauges you assign are ordinary [swift-metrics](https://github.com/apple/swift-metrics) types, so the values reach whatever metrics backend you bootstrap through `MetricsSystem`.
 
-## Emit structured logs
+### Emit structured logs
 
 Pass a `Logger` when creating a ``KafkaProducer`` or ``KafkaConsumer``. The client logs lifecycle and operational events through it, and enriches every entry with structured metadata so you can filter and correlate logs across many clients:
 
@@ -53,7 +53,7 @@ var config = KafkaConsumerConfig()
 config.clientId = "orders-consumer"
 config.consumptionStrategy = .group(id: "orders", topics: ["orders"])
 
-let consumer = try KafkaConsumer(config: config, logger: logger)
+let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 // Every log entry from this consumer now carries kafka.client.id, kafka.client.type,
 // and kafka.group.id.
 ```

--- a/Sources/Kafka/Kafka.docc/ProducingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ProducingMessages.md
@@ -26,7 +26,11 @@ For configurable security options, see <doc:SecuringConnections>.
 Construct a ``KafkaProducer``, run it inside a `ServiceGroup`, and call ``KafkaProducer/sendAndAwait(_:)`` from a sibling task. The returned ``KafkaDeliveryReport`` carries a ``KafkaDeliveryReport/status`` value of `.acknowledged(KafkaAcknowledgedMessage)` on success, or `.failure(KafkaError)` if the broker rejects the record.
 
 ```swift
-let producer = try KafkaProducer(config: config, logger: logger)
+let logger = Logger(label: "kafka-example")
+
+let (producer, _) = try withLogger(logger) { _ in
+    try KafkaProducer.makeProducer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [producer],
@@ -52,13 +56,14 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
 ### Send records with batched delivery reports
 
-For high-throughput pipelines, create the producer alongside its events sequence with ``KafkaProducer/makeProducerWithEvents(config:logger:)``. Call ``KafkaProducer/send(_:)`` to enqueue records, and consume ``KafkaProducerEvent`` values from the events sequence to learn outcomes:
+For high-throughput pipelines, create the producer alongside its events sequence with ``KafkaProducer/makeProducer(config:)``. Call ``KafkaProducer/send(_:)`` to enqueue records, and consume ``KafkaProducerEvent`` values from the events sequence to learn outcomes:
 
 ```swift
-let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-    config: config,
-    logger: logger
-)
+let logger = Logger(label: "kafka-example")
+
+let (producer, events) = try withLogger(logger) { _ in
+    try KafkaProducer.makeProducer(config: config)
+}
 
 let serviceGroup = ServiceGroup(
     services: [producer],
@@ -103,7 +108,7 @@ Beyond delivery reports, the events sequence emits errors and other broker event
 
 - ``KafkaProducer/send(_:)``
 - ``KafkaProducer/sendAndAwait(_:)``
-- ``KafkaProducer/makeProducerWithEvents(config:logger:)``
+- ``KafkaProducer/makeProducer(config:)``
 
 ### Inspecting outcomes
 

--- a/Sources/Kafka/Kafka.docc/ProducingMessages.md
+++ b/Sources/Kafka/Kafka.docc/ProducingMessages.md
@@ -23,7 +23,7 @@ For configurable security options, see <doc:SecuringConnections>.
 
 ### Send and await acknowledgment
 
-Construct a ``KafkaProducer``, run it inside a `ServiceGroup`, and call ``KafkaProducer/sendAndAwait(_:)`` from a sibling task. The returned ``KafkaDeliveryReport`` carries a ``KafkaDeliveryReport/status`` value of `.acknowledged(KafkaAcknowledgedMessage)` on success, or `.failure(KafkaError)` if the broker rejects the record.
+Construct a ``KafkaProducer``, run it inside a `ServiceGroup`, and call ``KafkaProducer/sendAndAwait(_:)`` from a sibling task. The returned ``KafkaProducer/DeliveryReport`` carries a ``KafkaProducer/DeliveryReport/status`` value of `.acknowledged(KafkaProducer/AcknowledgedMessage)` on success, or `.failure(KafkaError)` if the broker rejects the record.
 
 ```swift
 let logger = Logger(label: "kafka-example")
@@ -42,7 +42,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        let message = KafkaProducer.Message(topic: "topic-name", value: "Hello, World!")
         let report = try await producer.sendAndAwait(message)
         switch report.status {
         case .acknowledged(let ack):
@@ -56,7 +56,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
 ### Send records with batched delivery reports
 
-For high-throughput pipelines, create the producer alongside its events sequence with ``KafkaProducer/makeProducer(config:)``. Call ``KafkaProducer/send(_:)`` to enqueue records, and consume ``KafkaProducerEvent`` values from the events sequence to learn outcomes:
+For high-throughput pipelines, create the producer alongside its events sequence with ``KafkaProducer/makeProducer(config:)``. Call ``KafkaProducer/send(_:)`` to enqueue records, and consume ``KafkaProducer/Event`` values from the events sequence to learn outcomes:
 
 ```swift
 let logger = Logger(label: "kafka-example")
@@ -75,7 +75,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     group.addTask { try await serviceGroup.run() }
 
     group.addTask {
-        let message = KafkaProducerMessage(topic: "topic-name", value: "Hello, World!")
+        let message = KafkaProducer.Message(topic: "topic-name", value: "Hello, World!")
         try producer.send(message)
 
         for await event in events {
@@ -96,11 +96,11 @@ The events sequence delivers reports in batches as `librdkafka` flushes them, wh
 
 ### Identify a record before delivery
 
-The synchronous ``KafkaProducer/send(_:)`` returns a ``KafkaProducerMessageID``. Use this identifier to match a later ``KafkaDeliveryReport`` to the originating record; the same identifier appears on the report.
+The synchronous ``KafkaProducer/send(_:)`` returns a ``KafkaProducer/MessageID``. Use this identifier to match a later ``KafkaProducer/DeliveryReport`` to the originating record; the same identifier appears on the report.
 
 ### Handle producer events
 
-Beyond delivery reports, the events sequence emits errors and other broker events. See ``KafkaProducerEvent`` for the full set of cases. To classify errors, read ``KafkaError/isFatal`` and ``KafkaError/isRetriable``: a fatal error means the producer can't recover, and the application needs to shut it down. A retriable error typically resolves on its own as the broker recovers.
+Beyond delivery reports, the events sequence emits errors and other broker events. See ``KafkaProducer/Event`` for the full set of cases. To classify errors, read ``KafkaError/isFatal`` and ``KafkaError/isRetriable``: a fatal error means the producer can't recover, and the application needs to shut it down. A retriable error typically resolves on its own as the broker recovers.
 
 ## Topics
 
@@ -112,7 +112,7 @@ Beyond delivery reports, the events sequence emits errors and other broker event
 
 ### Inspecting outcomes
 
-- ``KafkaDeliveryReport``
-- ``KafkaAcknowledgedMessage``
-- ``KafkaProducerMessageID``
-- ``KafkaProducerEvent``
+- ``KafkaProducer/DeliveryReport``
+- ``KafkaProducer/AcknowledgedMessage``
+- ``KafkaProducer/MessageID``
+- ``KafkaProducer/Event``

--- a/Sources/Kafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/Kafka/KafkaAcknowledgedMessage.swift
@@ -17,9 +17,9 @@ import NIOCore
 
 extension KafkaProducer {
     /// A message acknowledged by the Kafka cluster.
-    public struct AcknowledgedMessage {
+    public struct AcknowledgedMessage: Hashable, Sendable {
         /// The topic the producer sent the message to.
-        public var topic: String
+        public var topic: KafkaTopic
         /// The partition the producer sent the message to.
         public var partition: KafkaPartition
         /// The key of the message.
@@ -47,7 +47,7 @@ extension KafkaProducer {
                 fatalError("Received topic name that is non-valid UTF-8")
             }
 
-            self.topic = topic
+            self.topic = KafkaTopic(rawValue: topic)
 
             self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))
             self.headers = try RDKafkaClient.getHeaders(for: messagePointer)
@@ -65,11 +65,3 @@ extension KafkaProducer {
         }
     }
 }
-
-// MARK: KafkaProducer.AcknowledgedMessage + Hashable
-
-extension KafkaProducer.AcknowledgedMessage: Hashable {}
-
-// MARK: KafkaProducer.AcknowledgedMessage + Sendable
-
-extension KafkaProducer.AcknowledgedMessage: Sendable {}

--- a/Sources/Kafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/Kafka/KafkaAcknowledgedMessage.swift
@@ -15,59 +15,61 @@
 import Crdkafka
 import NIOCore
 
-/// A message acknowledged by the Kafka cluster.
-public struct KafkaAcknowledgedMessage {
-    /// The topic the producer sent the message to.
-    public var topic: String
-    /// The partition the producer sent the message to.
-    public var partition: KafkaPartition
-    /// The key of the message.
-    public var key: ByteBuffer?
-    /// The body of the message.
-    public var value: ByteBuffer
-    /// The offset of the message in its partition.
-    public var offset: KafkaOffset
-    /// The headers of the message.
-    public var headers: [KafkaHeader]
+extension KafkaProducer {
+    /// A message acknowledged by the Kafka cluster.
+    public struct AcknowledgedMessage {
+        /// The topic the producer sent the message to.
+        public var topic: String
+        /// The partition the producer sent the message to.
+        public var partition: KafkaPartition
+        /// The key of the message.
+        public var key: ByteBuffer?
+        /// The body of the message.
+        public var value: ByteBuffer
+        /// The offset of the message in its partition.
+        public var offset: KafkaOffset
+        /// The headers of the message.
+        public var headers: [KafkaHeader]
 
-    /// Creates a ``KafkaAcknowledgedMessage`` from an `rd_kafka_message_t` pointer.
-    /// - Throws: A ``KafkaError`` for failed acknowledgments or malformed messages.
-    internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
-        let rdKafkaMessage = messagePointer.pointee
+        /// Creates a ``KafkaProducer/AcknowledgedMessage`` from an `rd_kafka_message_t` pointer.
+        /// - Throws: A ``KafkaError`` for failed acknowledgments or malformed messages.
+        internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
+            let rdKafkaMessage = messagePointer.pointee
 
-        let valueBufferPointer = UnsafeRawBufferPointer(start: rdKafkaMessage.payload, count: rdKafkaMessage.len)
-        self.value = ByteBuffer(bytes: valueBufferPointer)
+            let valueBufferPointer = UnsafeRawBufferPointer(start: rdKafkaMessage.payload, count: rdKafkaMessage.len)
+            self.value = ByteBuffer(bytes: valueBufferPointer)
 
-        guard rdKafkaMessage.err == RD_KAFKA_RESP_ERR_NO_ERROR else {
-            throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
+            guard rdKafkaMessage.err == RD_KAFKA_RESP_ERR_NO_ERROR else {
+                throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
+            }
+
+            guard let topic = String(validatingCString: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
+                fatalError("Received topic name that is non-valid UTF-8")
+            }
+
+            self.topic = topic
+
+            self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))
+            self.headers = try RDKafkaClient.getHeaders(for: messagePointer)
+            if let keyPointer = rdKafkaMessage.key {
+                let keyBufferPointer = UnsafeRawBufferPointer(
+                    start: keyPointer,
+                    count: rdKafkaMessage.key_len
+                )
+                self.key = .init(bytes: keyBufferPointer)
+            } else {
+                self.key = nil
+            }
+
+            self.offset = KafkaOffset(rawValue: Int(rdKafkaMessage.offset))
         }
-
-        guard let topic = String(validatingCString: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
-            fatalError("Received topic name that is non-valid UTF-8")
-        }
-
-        self.topic = topic
-
-        self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))
-        self.headers = try RDKafkaClient.getHeaders(for: messagePointer)
-        if let keyPointer = rdKafkaMessage.key {
-            let keyBufferPointer = UnsafeRawBufferPointer(
-                start: keyPointer,
-                count: rdKafkaMessage.key_len
-            )
-            self.key = .init(bytes: keyBufferPointer)
-        } else {
-            self.key = nil
-        }
-
-        self.offset = KafkaOffset(rawValue: Int(rdKafkaMessage.offset))
     }
 }
 
-// MARK: KafkaAcknowledgedMessage + Hashable
+// MARK: KafkaProducer.AcknowledgedMessage + Hashable
 
-extension KafkaAcknowledgedMessage: Hashable {}
+extension KafkaProducer.AcknowledgedMessage: Hashable {}
 
-// MARK: KafkaAcknowledgedMessage + Sendable
+// MARK: KafkaProducer.AcknowledgedMessage + Sendable
 
-extension KafkaAcknowledgedMessage: Sendable {}
+extension KafkaProducer.AcknowledgedMessage: Sendable {}

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -233,19 +233,24 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
-    /// Creates a new consumer.
+    /// Creates a consumer and its paired events sequence.
     ///
-    /// This creates a consumer that does not listen to any events other than consumer messages.
-    /// To also receive events, use ``makeConsumerWithEvents(config:logger:)``.
+    /// Every consumer receives an events sequence for rebalance and error observation.
+    /// Iterate the sequence to react to partition assignment changes and non-fatal
+    /// broker errors, or discard the returned `events` value if you don't need to observe them.
+    ///
+    /// - Important: Iterate the events sequence if you keep a reference to it; otherwise
+    ///   events buffer in memory indefinitely.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
-    ///     - logger: A logger.
+    /// - Returns: A named tuple containing the created ``KafkaConsumer`` and its
+    ///   ``KafkaConsumerEvents`` `AsyncSequence`.
     /// - Throws: A ``KafkaError`` if the initialization failed.
-    public convenience init(
-        config: KafkaConsumerConfig,
-        logger: Logger
-    ) throws {
+    public static func makeConsumer(
+        config: KafkaConsumerConfig
+    ) throws -> (consumer: KafkaConsumer, events: KafkaConsumerEvents) {
+        let logger = Logger.current
         var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance, .error]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
         if !isAutoCommitEnabled {
@@ -255,56 +260,7 @@ public final class KafkaConsumer: Sendable, Service {
             subscribedEvents.append(.statistics)
         }
 
-        let rebalanceContext = RebalanceContext(logger: logger)
-
-        let client = try RDKafkaClient.makeClient(
-            type: .consumer,
-            configDictionary: config.config,
-            events: subscribedEvents,
-            logger: logger,
-            rebalanceContext: rebalanceContext
-        )
-
-        let stateMachine = NIOLockedValueBox(StateMachine())
-
-        try self.init(
-            client: client,
-            stateMachine: stateMachine,
-            config: config,
-            rebalanceContext: rebalanceContext,
-            logger: logger
-        )
-    }
-
-    /// Creates a new consumer paired with an asynchronous event sequence.
-    ///
-    /// The returned tuple pairs a ``KafkaConsumer`` with its ``KafkaConsumerEvents`` sequence.
-    ///
-    /// Use the asynchronous sequence to consume events.
-    ///
-    /// - Important: When the asynchronous sequence is deinitialized, the consumer shuts down and stops accepting new messages.
-    ///   Additionally, consume the asynchronous sequence; otherwise the events buffer in memory indefinitely.
-    ///
-    /// - Parameters:
-    ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
-    ///     - logger: A logger.
-    /// - Returns: A tuple containing the created ``KafkaConsumer`` and the ``KafkaConsumerEvents``
-    /// `AsyncSequence` used for receiving message events.
-    /// - Throws: A ``KafkaError`` if the initialization failed.
-    public static func makeConsumerWithEvents(
-        config: KafkaConsumerConfig,
-        logger: Logger
-    ) throws -> (KafkaConsumer, KafkaConsumerEvents) {
-        var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance, .error]
-        let isAutoCommitEnabled = config.enableAutoCommit ?? true
-        if !isAutoCommitEnabled {
-            subscribedEvents.append(.offsetCommit)
-        }
-        if config.metrics.enabled {
-            subscribedEvents.append(.statistics)
-        }
-
-        let rebalanceContext = RebalanceContext(logger: logger)
+        let rebalanceContext = RebalanceContext()
 
         let client = try RDKafkaClient.makeClient(
             type: .consumer,
@@ -338,35 +294,7 @@ public final class KafkaConsumer: Sendable, Service {
         )
 
         let eventsSequence = KafkaConsumerEvents(wrappedSequence: sourceAndSequence.sequence)
-        return (consumer, eventsSequence)
-    }
-
-    /// Creates a new consumer from a deprecated configuration value.
-    ///
-    /// This initializer is deprecated. Use ``init(config:logger:)`` instead.
-    @available(*, deprecated, message: "Use init(config:logger:) instead")
-    public convenience init(
-        configuration: KafkaConsumerConfiguration,
-        logger: Logger
-    ) throws {
-        try self.init(
-            config: configuration.asKafkaConsumerConfig,
-            logger: logger
-        )
-    }
-
-    /// Creates a new consumer and an event sequence from a deprecated configuration value.
-    ///
-    /// This method is deprecated. Use ``makeConsumerWithEvents(config:logger:)`` instead.
-    @available(*, deprecated, message: "Use makeConsumerWithEvents(config:logger:) instead")
-    public static func makeConsumerWithEvents(
-        configuration: KafkaConsumerConfiguration,
-        logger: Logger
-    ) throws -> (KafkaConsumer, KafkaConsumerEvents) {
-        try Self.makeConsumerWithEvents(
-            config: configuration.asKafkaConsumerConfig,
-            logger: logger
-        )
+        return (consumer: consumer, events: eventsSequence)
     }
 
     // MARK: - Subscription Management
@@ -521,7 +449,8 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// - Important: Call this method to drive the consumer. It runs until either the calling task is canceled or gracefully shut down.
     ///
-    /// Stop the consumer with ``triggerGracefulShutdown()``.
+    /// Stop the consumer by canceling the enclosing task, or by running it inside a
+    /// `ServiceGroup` and triggering that group's graceful shutdown.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()
@@ -731,40 +660,6 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Marks all messages up to the passed message in the topic as read.
     ///
-    /// Schedules a commit and returns immediately.
-    /// The consumer discards any errors encountered after scheduling the commit.
-    ///
-    /// Use this method only for manual offset management.
-    ///
-    /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
-    ///
-    /// - Parameters:
-    ///     - message: Last received message to mark as read.
-    /// - Throws: A ``KafkaError`` if committing failed.
-    public func scheduleCommit(_ message: KafkaConsumerMessage) throws {
-        let action = self.stateMachine.withLockedValue { $0.withClient() }
-        switch action {
-        case .throwClosedError:
-            throw KafkaError.connectionClosed(reason: "Tried to commit message offset on a closed consumer")
-        case .client(let client):
-            guard (self.config.enableAutoCommit ?? true) == false else {
-                throw KafkaError.config(reason: "Committing manually only works if enableAutoCommit is set to false")
-            }
-
-            try client.scheduleCommit(message)
-        }
-    }
-
-    /// Synchronously commits the offset of the message you provide.
-    ///
-    /// This method is deprecated. Use ``commit(_:)`` instead.
-    @available(*, deprecated, renamed: "commit")
-    public func commitSync(_ message: KafkaConsumerMessage) async throws {
-        try await self.commit(message)
-    }
-
-    /// Marks all messages up to the passed message in the topic as read.
-    ///
     /// Awaits until the commit succeeds or an error occurs.
     ///
     /// Use this method only for manual offset management.
@@ -788,33 +683,15 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Schedules an asynchronous commit of all stored offsets.
+    /// Commits every offset currently in the local offset store.
     ///
-    /// Returns immediately. Any errors after scheduling are discarded.
-    ///
-    /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
-    /// - Throws: A ``KafkaError`` if scheduling the commit failed or the consumer is closed.
-    public func scheduleCommit() throws {
-        let action = self.stateMachine.withLockedValue { $0.withClient() }
-        switch action {
-        case .throwClosedError:
-            throw KafkaError.connectionClosed(reason: "Tried to commit offsets on a closed consumer")
-        case .client(let client):
-            guard (self.config.enableAutoCommit ?? true) == false else {
-                throw KafkaError.config(reason: "Committing manually only works if enableAutoCommit is set to false")
-            }
-
-            try client.scheduleCommitAll()
-        }
-    }
-
-    /// Commits all stored offsets to the broker.
-    ///
+    /// The store is populated automatically when ``KafkaConsumerConfig/enableAutoOffsetStore`` is `true`,
+    /// or by explicit calls to ``storeOffset(_:)`` when it is `false`.
     /// Awaits until the commit succeeds or encounters an error.
     ///
     /// - Warning: This method fails if ``KafkaConsumerConfig/enableAutoCommit`` is `true` (default).
     /// - Throws: A ``KafkaError`` if the commit failed or the consumer is closed.
-    public func commit() async throws {
+    public func commitStoredOffsets() async throws {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
         switch action {
         case .throwClosedError:
@@ -929,7 +806,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// Gracefully shuts down a Kafka consumer client.
     ///
     /// - Note: Invoking this method isn't always needed; the ``KafkaConsumer`` already shuts down when consumption of ``KafkaConsumerMessages`` ends.
-    public func triggerGracefulShutdown() {
+    func triggerGracefulShutdown() {
         self.logger.debug("Kafka consumer shutting down")
         let action = self.stateMachine.withLockedValue { $0.finish() }
         switch action {

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -181,35 +181,29 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Creates a consumer, runs it for the duration of the closure, and shuts it down on return.
     ///
-    /// Spawns the consumer's ``run()`` loop in a child task and triggers a graceful shutdown
-    /// when `body` returns or throws — no `ServiceGroup` required. Use this for scoped,
-    /// short-lived consumers (tests, scripts, one-off jobs). For long-running services,
-    /// use ``makeConsumer(config:)`` and manage the lifecycle with a `ServiceGroup`.
+    /// Spawns the consumer's ``run()`` loop internally and cancels it when `body` returns or
+    /// throws.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
     ///     - body: A closure that receives the consumer and its message and events sequences.
     /// - Returns: The value returned by `body`.
     /// - Throws: A ``KafkaError`` if the initialization failed, or any error thrown by `body`.
-    public static func withConsumer<Result>(
+    public static func withConsumer<Result: ~Copyable>(
         config: KafkaConsumerConfig,
         _ body: (KafkaConsumer, Messages, Events) async throws -> Result
     ) async throws -> Result {
         let (consumer, messages, events) = try makeConsumer(config: config)
-        return try await withThrowingTaskGroup(of: Void.self) { group -> Result in
-            group.addTask {
-                try await consumer.run()
-            }
-            do {
-                let value = try await body(consumer, messages, events)
-                consumer.triggerGracefulShutdown()
-                try? await group.waitForAll()
-                return value
-            } catch {
-                consumer.triggerGracefulShutdown()
-                try? await group.waitForAll()
-                throw error
-            }
+        async let running: Void = consumer.run()
+        do {
+            let value = try await body(consumer, messages, events)
+            consumer.triggerGracefulShutdown()
+            _ = try? await running
+            return value
+        } catch {
+            consumer.triggerGracefulShutdown()
+            _ = try? await running
+            throw error
         }
     }
 

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -190,13 +190,16 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// - Parameter topics: An array of topic names to subscribe to.
     /// - Throws: A ``KafkaError`` if the consumer is closed or subscribing failed.
-    public func subscribe(topics: [String]) throws {
+    public func subscribe(topics: [KafkaTopic]) throws {
         guard !topics.isEmpty else {
             try self.unsubscribe()
             return
         }
 
-        self.logger.debug("Subscribing to topics", metadata: [KafkaLoggingKeys.topics: "\(topics)"])
+        self.logger.debug(
+            "Subscribing to topics",
+            metadata: [KafkaLoggingKeys.topics: "\(topics.map(\.rawValue))"]
+        )
 
         let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
         switch action {
@@ -236,12 +239,12 @@ public final class KafkaConsumer: Sendable, Service {
     /// The current topic subscription.
     ///
     /// - Throws: A ``KafkaError`` if the consumer is closed or the query failed.
-    public var subscribedTopics: [String] {
+    public var subscribedTopics: [KafkaTopic] {
         get throws {
             let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
             switch action {
             case .client(let client):
-                return try client.subscription()
+                return try client.subscription().map { KafkaTopic(rawValue: $0) }
             case .throwClosedError:
                 throw KafkaError.connectionClosed(reason: "Consumer is closed")
             }
@@ -289,7 +292,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Internal startup subscription that transitions the state machine from `.initializing` to `.running`.
     /// Called once during `_run()` to set up the initial subscription from `consumptionStrategy`.
-    private func initialSubscribe(topics: [String]) throws {
+    private func initialSubscribe(topics: [KafkaTopic]) throws {
         let action = self.stateMachine.withLockedValue { $0.transitionToRunning() }
         switch action {
         case .setUpConnection(let client):
@@ -313,7 +316,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// Defaults to the end of the Kafka partition queue (waits for the next produced message).
     /// - Throws: A ``KafkaError`` if the consumer could not be assigned to the topic + partition pair.
     private func assign(
-        topic: String,
+        topic: KafkaTopic,
         partition: KafkaPartition,
         offset: KafkaOffset
     ) throws {
@@ -436,7 +439,10 @@ public final class KafkaConsumer: Sendable, Service {
             let rebalance = Rebalance(
                 kind: kind,
                 partitions: event.partitions.map {
-                    KafkaTopicPartition(topic: $0.topic, partition: KafkaPartition(rawValue: $0.partition))
+                    KafkaTopicPartition(
+                        topic: KafkaTopic(rawValue: $0.topic),
+                        partition: KafkaPartition(rawValue: $0.partition)
+                    )
                 }
             )
             if let source = self.eventsSource {
@@ -491,7 +497,10 @@ public final class KafkaConsumer: Sendable, Service {
             let rebalance = Rebalance(
                 kind: kind,
                 partitions: event.partitions.map {
-                    KafkaTopicPartition(topic: $0.topic, partition: KafkaPartition(rawValue: $0.partition))
+                    KafkaTopicPartition(
+                        topic: KafkaTopic(rawValue: $0.topic),
+                        partition: KafkaPartition(rawValue: $0.partition)
+                    )
                 }
             )
             if let source = self.eventsSource {

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -20,7 +20,7 @@ import ServiceLifecycle
 
 // MARK: - KafkaConsumerEventsDelegate
 
-/// `NIOAsyncSequenceProducerDelegate` for ``KafkaConsumerEvents``.
+/// `NIOAsyncSequenceProducerDelegate` for ``KafkaConsumer/Events``.
 internal struct KafkaConsumerEventsDelegate: Sendable {
     let stateMachine: NIOLockedValueBox<KafkaConsumer.StateMachine>
 }
@@ -35,126 +35,12 @@ extension KafkaConsumerEventsDelegate: NIOAsyncSequenceProducerDelegate {
     }
 }
 
-// MARK: - KafkaConsumerEvents
-
-/// An asynchronous sequence of consumer events emitted by Kafka.
-///
-/// The sequence yields ``KafkaConsumerEvent`` values such as rebalance notifications and errors.
-public struct KafkaConsumerEvents: Sendable, AsyncSequence {
-    /// The type of event the sequence yields.
-    public typealias Element = KafkaConsumerEvent
-    typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
-    typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaConsumerEventsDelegate>
-    let wrappedSequence: WrappedSequence
-
-    /// An asynchronous iterator over consumer events emitted by Kafka.
-    ///
-    /// The iterator yields ``KafkaConsumerEvent`` values such as rebalance notifications and errors.
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        var wrappedIterator: WrappedSequence.AsyncIterator
-
-        /// Returns the next consumer event, or `nil` if the sequence has finished.
-        public mutating func next() async -> Element? {
-            await self.wrappedIterator.next()
-        }
-    }
-
-    /// Returns an asynchronous iterator over the consumer event sequence.
-    public func makeAsyncIterator() -> AsyncIterator {
-        AsyncIterator(wrappedIterator: self.wrappedSequence.makeAsyncIterator())
-    }
-}
-
-// MARK: - KafkaConsumerMessages
-
-/// An asynchronous sequence of messages received from the Kafka cluster.
-///
-/// The sequence yields ``KafkaConsumerMessage`` values.
-public struct KafkaConsumerMessages: Sendable, AsyncSequence {
-    typealias LockedMachine = NIOLockedValueBox<KafkaConsumer.StateMachine>
-
-    let stateMachine: LockedMachine
-    let pollInterval: Duration
-
-    /// The type of message the sequence yields.
-    public typealias Element = KafkaConsumerMessage
-
-    /// An asynchronous iterator over messages received from the Kafka cluster.
-    ///
-    /// The iterator yields ``KafkaConsumerMessage`` values.
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        private let stateMachineHolder: MachineHolder
-        let pollInterval: Duration
-        private let queue: DispatchQueueTaskExecutor
-
-        private final class MachineHolder: Sendable {  // only for deinit
-            let stateMachine: LockedMachine
-
-            init(stateMachine: LockedMachine) {
-                self.stateMachine = stateMachine
-            }
-
-            deinit {
-                self.stateMachine.withLockedValue { $0.finishMessageConsumption() }
-            }
-        }
-
-        init(stateMachine: LockedMachine, pollInterval: Duration) {
-            self.stateMachineHolder = .init(stateMachine: stateMachine)
-            self.pollInterval = pollInterval
-            self.queue = DispatchQueueTaskExecutor(
-                DispatchQueue(label: "com.swift-server.swift-kafka.message-consumer")
-            )
-        }
-
-        /// Returns the next consumer message, or `nil` when the consumer has shut down or the task is canceled.
-        ///
-        /// - Throws: A ``KafkaError`` if polling for the next message fails.
-        public func next() async throws -> Element? {
-            while !Task.isCancelled {
-                let action = self.stateMachineHolder.stateMachine.withLockedValue { $0.nextConsumerPollLoopAction() }
-
-                switch action {
-                case .poll(let client):
-                    // Attempt to fetch a message synchronously. Bail
-                    // immediately if no message is waiting for us.
-                    if let message = try client.consumerPoll() {
-                        return message
-                    }
-
-                    // Wait on a separate thread for the next message.
-                    // The call below will block for `pollInterval`.
-                    if let message = try await withTaskExecutorPreference(
-                        queue,
-                        operation: { try client.consumerPoll(for: Int32(self.pollInterval.inMilliseconds)) }
-                    ) {
-                        return message
-                    }
-                case .suspendPollLoop:
-                    try await Task.sleep(for: self.pollInterval)  // not started yet
-                case .terminatePollLoop:
-                    return nil
-                }
-            }
-            return nil
-        }
-    }
-
-    /// Returns an asynchronous iterator over the consumer message sequence.
-    public func makeAsyncIterator() -> AsyncIterator {
-        AsyncIterator(
-            stateMachine: self.stateMachine,
-            pollInterval: self.pollInterval
-        )
-    }
-}
-
 // MARK: - KafkaConsumer
 
 /// Consumes messages from a Kafka cluster.
 public final class KafkaConsumer: Sendable, Service {
     typealias ConsumerEventsProducer = NIOAsyncSequenceProducer<
-        KafkaConsumerEvent,
+        Event,
         NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure,
         KafkaConsumerEventsDelegate
     >
@@ -175,9 +61,6 @@ public final class KafkaConsumer: Sendable, Service {
     /// C callback holds an unretained pointer to it.
     /// - Important: Must be declared AFTER `stateMachine` — see ordering note above.
     private let rebalanceContext: RebalanceContext
-
-    /// An asynchronous sequence of messages from the Kafka cluster.
-    public let messages: KafkaConsumerMessages
 
     // Private initializer, use factory method or convenience init to create KafkaConsumer
     /// Creates a new ``KafkaConsumer``.
@@ -213,11 +96,6 @@ public final class KafkaConsumer: Sendable, Service {
         self.eventsSource = eventsSource
         self.rebalanceContext = rebalanceContext
 
-        self.messages = KafkaConsumerMessages(
-            stateMachine: self.stateMachine,
-            pollInterval: config.pollInterval
-        )
-
         self.stateMachine.withLockedValue {
             $0.initialize(
                 client: client,
@@ -233,7 +111,7 @@ public final class KafkaConsumer: Sendable, Service {
         )
     }
 
-    /// Creates a consumer and its paired events sequence.
+    /// Creates a consumer and its paired message and events sequences.
     ///
     /// Every consumer receives an events sequence for rebalance and error observation.
     /// Iterate the sequence to react to partition assignment changes and non-fatal
@@ -245,11 +123,11 @@ public final class KafkaConsumer: Sendable, Service {
     /// - Parameters:
     ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
     /// - Returns: A named tuple containing the created ``KafkaConsumer`` and its
-    ///   ``KafkaConsumerEvents`` `AsyncSequence`.
+    ///   ``KafkaConsumer/Messages`` and ``KafkaConsumer/Events`` `AsyncSequence`s.
     /// - Throws: A ``KafkaError`` if the initialization failed.
     public static func makeConsumer(
         config: KafkaConsumerConfig
-    ) throws -> (consumer: KafkaConsumer, events: KafkaConsumerEvents) {
+    ) throws -> (consumer: KafkaConsumer, messages: Messages, events: Events) {
         let logger = Logger.current
         var subscribedEvents: [RDKafkaEvent] = [.log, .rebalance, .error]
         let isAutoCommitEnabled = config.enableAutoCommit ?? true
@@ -278,7 +156,7 @@ public final class KafkaConsumer: Sendable, Service {
         // If this order is not met and `RDKafkaClient.makeClient()` fails,
         // it leads to a call to `stateMachine.messageSequenceTerminated()` while it's still in the `.uninitialized` state.
         let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
-            elementType: KafkaConsumerEvent.self,
+            elementType: Event.self,
             backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure(),
             finishOnDeinit: true,
             delegate: KafkaConsumerEventsDelegate(stateMachine: stateMachine)
@@ -293,8 +171,12 @@ public final class KafkaConsumer: Sendable, Service {
             eventsSource: sourceAndSequence.source
         )
 
-        let eventsSequence = KafkaConsumerEvents(wrappedSequence: sourceAndSequence.sequence)
-        return (consumer: consumer, events: eventsSequence)
+        let messagesSequence = Messages(
+            stateMachine: stateMachine,
+            pollInterval: config.pollInterval
+        )
+        let eventsSequence = Events(wrappedSequence: sourceAndSequence.sequence)
+        return (consumer: consumer, messages: messagesSequence, events: eventsSequence)
     }
 
     // MARK: - Subscription Management
@@ -351,24 +233,25 @@ public final class KafkaConsumer: Sendable, Service {
         }
     }
 
-    /// Returns the current topic subscription.
+    /// The current topic subscription.
     ///
-    /// - Returns: An array of topic names or patterns the consumer is currently subscribed to.
     /// - Throws: A ``KafkaError`` if the consumer is closed or the query failed.
-    public func subscribedTopics() throws -> [String] {
-        let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
-        switch action {
-        case .client(let client):
-            return try client.subscription()
-        case .throwClosedError:
-            throw KafkaError.connectionClosed(reason: "Consumer is closed")
+    public var subscribedTopics: [String] {
+        get throws {
+            let action = self.stateMachine.withLockedValue { $0.withClientForSubscription() }
+            switch action {
+            case .client(let client):
+                return try client.subscription()
+            case .throwClosedError:
+                throw KafkaError.connectionClosed(reason: "Consumer is closed")
+            }
         }
     }
 
     /// Pauses consumption for the partitions you provide.
     ///
     /// Paused partitions remain in the consumer group and continue heartbeating
-    /// but don't return messages from ``messages``.
+    /// but don't return messages on the messages sequence.
     ///
     /// - Parameter topicPartitions: The partitions to pause.
     /// - Throws: A ``KafkaError`` if the consumer is closed or pausing failed.
@@ -540,7 +423,7 @@ public final class KafkaConsumer: Sendable, Service {
 
         let rebalanceEvents = self.rebalanceContext.drainEvents()
         for event in rebalanceEvents {
-            let kind: KafkaConsumerRebalance.Kind
+            let kind: Rebalance.Kind
             switch event.kind {
             case .assign:
                 kind = .assign
@@ -550,7 +433,7 @@ public final class KafkaConsumer: Sendable, Service {
                 kind = .error(description)
             }
 
-            let rebalance = KafkaConsumerRebalance(
+            let rebalance = Rebalance(
                 kind: kind,
                 partitions: event.partitions.map {
                     KafkaTopicPartition(topic: $0.topic, partition: KafkaPartition(rawValue: $0.partition))
@@ -595,7 +478,7 @@ public final class KafkaConsumer: Sendable, Service {
 
         let rebalanceEvents = self.rebalanceContext.drainEvents()
         for event in rebalanceEvents {
-            let kind: KafkaConsumerRebalance.Kind
+            let kind: Rebalance.Kind
             switch event.kind {
             case .assign:
                 kind = .assign
@@ -605,7 +488,7 @@ public final class KafkaConsumer: Sendable, Service {
                 kind = .error(description)
             }
 
-            let rebalance = KafkaConsumerRebalance(
+            let rebalance = Rebalance(
                 kind: kind,
                 partitions: event.partitions.map {
                     KafkaTopicPartition(topic: $0.topic, partition: KafkaPartition(rawValue: $0.partition))
@@ -640,7 +523,7 @@ public final class KafkaConsumer: Sendable, Service {
     ///
     /// - Parameter message: The message whose offset to store.
     /// - Throws: A ``KafkaError`` if storing the offset failed or the consumer is closed.
-    public func storeOffset(_ message: KafkaConsumerMessage) throws {
+    public func storeOffset(_ message: Message) throws {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
         switch action {
         case .throwClosedError:
@@ -669,7 +552,7 @@ public final class KafkaConsumer: Sendable, Service {
     /// - Parameters:
     ///     - message: Last received message to mark as read.
     /// - Throws: A ``KafkaError`` if committing failed.
-    public func commit(_ message: KafkaConsumerMessage) async throws {
+    public func commit(_ message: Message) async throws {
         let action = self.stateMachine.withLockedValue { $0.withClient() }
         switch action {
         case .throwClosedError:
@@ -805,7 +688,7 @@ public final class KafkaConsumer: Sendable, Service {
 
     /// Gracefully shuts down a Kafka consumer client.
     ///
-    /// - Note: Invoking this method isn't always needed; the ``KafkaConsumer`` already shuts down when consumption of ``KafkaConsumerMessages`` ends.
+    /// - Note: Invoking this method isn't always needed; the ``KafkaConsumer`` already shuts down when consumption of ``KafkaConsumer/Messages`` ends.
     func triggerGracefulShutdown() {
         self.logger.debug("Kafka consumer shutting down")
         let action = self.stateMachine.withLockedValue { $0.finish() }
@@ -830,6 +713,122 @@ public final class KafkaConsumer: Sendable, Service {
             logger.info(
                 "Closing KafkaConsumer failed",
                 error: error
+            )
+        }
+    }
+}
+
+// MARK: - KafkaConsumer + Events/Messages sequences
+
+extension KafkaConsumer {
+    /// An asynchronous sequence of consumer events emitted by Kafka.
+    ///
+    /// The sequence yields ``KafkaConsumer/Event`` values such as rebalance notifications and errors.
+    public struct Events: Sendable, AsyncSequence {
+        /// The type of event the sequence yields.
+        public typealias Element = Event
+        typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
+        typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaConsumerEventsDelegate>
+        let wrappedSequence: WrappedSequence
+
+        /// An asynchronous iterator over consumer events emitted by Kafka.
+        ///
+        /// The iterator yields ``KafkaConsumer/Event`` values such as rebalance notifications and errors.
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            var wrappedIterator: WrappedSequence.AsyncIterator
+
+            /// Returns the next consumer event, or `nil` if the sequence has finished.
+            public mutating func next() async -> Element? {
+                await self.wrappedIterator.next()
+            }
+        }
+
+        /// Returns an asynchronous iterator over the consumer event sequence.
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(wrappedIterator: self.wrappedSequence.makeAsyncIterator())
+        }
+    }
+
+    /// An asynchronous sequence of messages received from the Kafka cluster.
+    ///
+    /// The sequence yields ``KafkaConsumer/Message`` values.
+    public struct Messages: Sendable, AsyncSequence {
+        typealias LockedMachine = NIOLockedValueBox<KafkaConsumer.StateMachine>
+
+        let stateMachine: LockedMachine
+        let pollInterval: Duration
+
+        /// The type of message the sequence yields.
+        public typealias Element = Message
+
+        /// An asynchronous iterator over messages received from the Kafka cluster.
+        ///
+        /// The iterator yields ``KafkaConsumer/Message`` values.
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            private let stateMachineHolder: MachineHolder
+            let pollInterval: Duration
+            private let queue: DispatchQueueTaskExecutor
+
+            private final class MachineHolder: Sendable {  // only for deinit
+                let stateMachine: LockedMachine
+
+                init(stateMachine: LockedMachine) {
+                    self.stateMachine = stateMachine
+                }
+
+                deinit {
+                    self.stateMachine.withLockedValue { $0.finishMessageConsumption() }
+                }
+            }
+
+            init(stateMachine: LockedMachine, pollInterval: Duration) {
+                self.stateMachineHolder = .init(stateMachine: stateMachine)
+                self.pollInterval = pollInterval
+                self.queue = DispatchQueueTaskExecutor(
+                    DispatchQueue(label: "com.swift-server.swift-kafka.message-consumer")
+                )
+            }
+
+            /// Returns the next consumer message, or `nil` when the consumer has shut down or the task is canceled.
+            ///
+            /// - Throws: A ``KafkaError`` if polling for the next message fails.
+            public func next() async throws -> Element? {
+                while !Task.isCancelled {
+                    let action = self.stateMachineHolder.stateMachine.withLockedValue {
+                        $0.nextConsumerPollLoopAction()
+                    }
+
+                    switch action {
+                    case .poll(let client):
+                        // Attempt to fetch a message synchronously. Bail
+                        // immediately if no message is waiting for us.
+                        if let message = try client.consumerPoll() {
+                            return message
+                        }
+
+                        // Wait on a separate thread for the next message.
+                        // The call below will block for `pollInterval`.
+                        if let message = try await withTaskExecutorPreference(
+                            queue,
+                            operation: { try client.consumerPoll(for: Int32(self.pollInterval.inMilliseconds)) }
+                        ) {
+                            return message
+                        }
+                    case .suspendPollLoop:
+                        try await Task.sleep(for: self.pollInterval)  // not started yet
+                    case .terminatePollLoop:
+                        return nil
+                    }
+                }
+                return nil
+            }
+        }
+
+        /// Returns an asynchronous iterator over the consumer message sequence.
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(
+                stateMachine: self.stateMachine,
+                pollInterval: self.pollInterval
             )
         }
     }
@@ -957,7 +956,7 @@ extension KafkaConsumer {
 
         /// Action to be taken when wanting to poll for a new message.
         enum ConsumerPollLoopAction {
-            /// Poll for a new ``KafkaConsumerMessage``.
+            /// Poll for a new ``KafkaConsumer/Message``.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             case poll(client: RDKafkaClient)
@@ -1102,7 +1101,7 @@ extension KafkaConsumer {
             }
         }
 
-        /// The ``KafkaConsumerMessages`` asynchronous sequence was terminated.
+        /// The ``KafkaConsumer/Messages`` asynchronous sequence was terminated.
         mutating func finishMessageConsumption() {
             switch self.state {
             case .uninitialized:

--- a/Sources/Kafka/KafkaConsumer.swift
+++ b/Sources/Kafka/KafkaConsumer.swift
@@ -179,6 +179,40 @@ public final class KafkaConsumer: Sendable, Service {
         return (consumer: consumer, messages: messagesSequence, events: eventsSequence)
     }
 
+    /// Creates a consumer, runs it for the duration of the closure, and shuts it down on return.
+    ///
+    /// Spawns the consumer's ``run()`` loop in a child task and triggers a graceful shutdown
+    /// when `body` returns or throws — no `ServiceGroup` required. Use this for scoped,
+    /// short-lived consumers (tests, scripts, one-off jobs). For long-running services,
+    /// use ``makeConsumer(config:)`` and manage the lifecycle with a `ServiceGroup`.
+    ///
+    /// - Parameters:
+    ///     - config: The ``KafkaConsumerConfig`` for configuring the ``KafkaConsumer``.
+    ///     - body: A closure that receives the consumer and its message and events sequences.
+    /// - Returns: The value returned by `body`.
+    /// - Throws: A ``KafkaError`` if the initialization failed, or any error thrown by `body`.
+    public static func withConsumer<Result>(
+        config: KafkaConsumerConfig,
+        _ body: (KafkaConsumer, Messages, Events) async throws -> Result
+    ) async throws -> Result {
+        let (consumer, messages, events) = try makeConsumer(config: config)
+        return try await withThrowingTaskGroup(of: Void.self) { group -> Result in
+            group.addTask {
+                try await consumer.run()
+            }
+            do {
+                let value = try await body(consumer, messages, events)
+                consumer.triggerGracefulShutdown()
+                try? await group.waitForAll()
+                return value
+            } catch {
+                consumer.triggerGracefulShutdown()
+                try? await group.waitForAll()
+                throw error
+            }
+        }
+    }
+
     // MARK: - Subscription Management
 
     /// Subscribes to the list of topics you provide.

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -12,21 +12,23 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An event reported by a Kafka consumer, such as a rebalance notification or an error.
-///
-/// Delivered through ``KafkaConsumerEvents``.
-public enum KafkaConsumerEvent: Sendable, Hashable {
-    /// A consumer group rebalance occurred.
+extension KafkaConsumer {
+    /// An event reported by a Kafka consumer, such as a rebalance notification or an error.
     ///
-    /// The library has already performed the necessary assign/unassign
-    /// operations — this notification is informational. Use it to perform
-    /// application-level bookkeeping such as committing offsets on revoke
-    /// or initializing state on assign.
-    case rebalance(KafkaConsumerRebalance)
+    /// Delivered through ``KafkaConsumer/Events``.
+    public enum Event: Sendable, Hashable {
+        /// A consumer group rebalance occurred.
+        ///
+        /// The library has already performed the necessary assign/unassign
+        /// operations — this notification is informational. Use it to perform
+        /// application-level bookkeeping such as committing offsets on revoke
+        /// or initializing state on assign.
+        case rebalance(Rebalance)
 
-    /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
-    case error(KafkaError)
+        /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
+        case error(KafkaError)
 
-    /// - Important: Always provide a `default` case when switching over this `enum`.
-    case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
+        /// - Important: Always provide a `default` case when switching over this `enum`.
+        case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
+    }
 }

--- a/Sources/Kafka/KafkaConsumerEvent.swift
+++ b/Sources/Kafka/KafkaConsumerEvent.swift
@@ -16,6 +16,7 @@ extension KafkaConsumer {
     /// An event reported by a Kafka consumer, such as a rebalance notification or an error.
     ///
     /// Delivered through ``KafkaConsumer/Events``.
+    @nonexhaustive
     public enum Event: Sendable, Hashable {
         /// A consumer group rebalance occurred.
         ///
@@ -27,8 +28,5 @@ extension KafkaConsumer {
 
         /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
         case error(KafkaError)
-
-        /// - Important: Always provide a `default` case when switching over this `enum`.
-        case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
     }
 }

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -51,9 +51,9 @@ public struct KafkaTimestampType: Hashable, Sendable, CustomStringConvertible {
 
 extension KafkaConsumer {
     /// A message received from the Kafka cluster.
-    public struct Message {
+    public struct Message: Hashable, Sendable {
         /// The topic the consumer received the message from.
-        public var topic: String
+        public var topic: KafkaTopic
         /// The partition the consumer received the message from.
         public var partition: KafkaPartition
         /// The headers of the message.
@@ -95,7 +95,7 @@ extension KafkaConsumer {
                 fatalError("Received topic name that is non-valid UTF-8")
             }
 
-            self.topic = topic
+            self.topic = KafkaTopic(rawValue: topic)
 
             self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))
 
@@ -124,10 +124,3 @@ extension KafkaConsumer {
     }
 }
 
-// MARK: - KafkaConsumer.Message + Hashable
-
-extension KafkaConsumer.Message: Hashable {}
-
-// MARK: - KafkaConsumer.Message + Sendable
-
-extension KafkaConsumer.Message: Sendable {}

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -21,7 +21,10 @@ public struct KafkaTimestampType: Hashable, Sendable, CustomStringConvertible {
     public let rawValue: Int32
 
     /// Creates a timestamp type from its raw librdkafka value.
-    public init(rawValue: Int32) {
+    ///
+    /// Internal: the library constructs these from librdkafka. Callers only read
+    /// `rawValue` or compare against the static constants below.
+    init(rawValue: Int32) {
         self.rawValue = rawValue
     }
 
@@ -59,9 +62,9 @@ extension KafkaConsumer {
         /// The headers of the message.
         public var headers: [KafkaHeader]
         /// The key of the message.
-        public var key: ByteBuffer?
+        public var key: [UInt8]?
         /// The body of the message.
-        public var value: ByteBuffer
+        public var value: [UInt8]
         /// The offset of the message in its partition.
         public var offset: KafkaOffset
         /// The timestamp of the message in milliseconds since epoch, or `nil` if not available.
@@ -106,12 +109,12 @@ extension KafkaConsumer {
                     start: keyPointer,
                     count: rdKafkaMessage.key_len
                 )
-                self.key = .init(bytes: keyBufferPointer)
+                self.key = [UInt8](keyBufferPointer)
             } else {
                 self.key = nil
             }
 
-            self.value = ByteBuffer(bytes: valueBufferPointer)
+            self.value = [UInt8](valueBufferPointer)
 
             self.offset = KafkaOffset(rawValue: Int(rdKafkaMessage.offset))
 
@@ -123,4 +126,3 @@ extension KafkaConsumer {
         }
     }
 }
-

--- a/Sources/Kafka/KafkaConsumerMessage.swift
+++ b/Sources/Kafka/KafkaConsumerMessage.swift
@@ -49,83 +49,85 @@ public struct KafkaTimestampType: Hashable, Sendable, CustomStringConvertible {
     }
 }
 
-/// A message received from the Kafka cluster.
-public struct KafkaConsumerMessage {
-    /// The topic the consumer received the message from.
-    public var topic: String
-    /// The partition the consumer received the message from.
-    public var partition: KafkaPartition
-    /// The headers of the message.
-    public var headers: [KafkaHeader]
-    /// The key of the message.
-    public var key: ByteBuffer?
-    /// The body of the message.
-    public var value: ByteBuffer
-    /// The offset of the message in its partition.
-    public var offset: KafkaOffset
-    /// The timestamp of the message in milliseconds since epoch, or `nil` if not available.
-    public var timestamp: Int64?
-    /// The type of timestamp on this message.
-    public var timestampType: KafkaTimestampType
+extension KafkaConsumer {
+    /// A message received from the Kafka cluster.
+    public struct Message {
+        /// The topic the consumer received the message from.
+        public var topic: String
+        /// The partition the consumer received the message from.
+        public var partition: KafkaPartition
+        /// The headers of the message.
+        public var headers: [KafkaHeader]
+        /// The key of the message.
+        public var key: ByteBuffer?
+        /// The body of the message.
+        public var value: ByteBuffer
+        /// The offset of the message in its partition.
+        public var offset: KafkaOffset
+        /// The timestamp of the message in milliseconds since epoch, or `nil` if not available.
+        public var timestamp: Int64?
+        /// The type of timestamp on this message.
+        public var timestampType: KafkaTimestampType
 
-    /// Creates a ``KafkaConsumerMessage`` from an `rd_kafka_message_t` pointer.
-    /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
-    internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
-        let rdKafkaMessage = messagePointer.pointee
+        /// Creates a ``KafkaConsumer/Message`` from an `rd_kafka_message_t` pointer.
+        /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
+        internal init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
+            let rdKafkaMessage = messagePointer.pointee
 
-        guard let valuePointer = rdKafkaMessage.payload else {
-            fatalError("Could not resolve payload of consumer message")
-        }
-
-        let valueBufferPointer = UnsafeRawBufferPointer(start: valuePointer, count: rdKafkaMessage.len)
-
-        guard rdKafkaMessage.err == RD_KAFKA_RESP_ERR_NO_ERROR else {
-            var errorStringBuffer = ByteBuffer(bytes: valueBufferPointer)
-            let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes)
-
-            if let errorString {
-                throw KafkaError.messageConsumption(reason: errorString)
-            } else {
-                throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
+            guard let valuePointer = rdKafkaMessage.payload else {
+                fatalError("Could not resolve payload of consumer message")
             }
+
+            let valueBufferPointer = UnsafeRawBufferPointer(start: valuePointer, count: rdKafkaMessage.len)
+
+            guard rdKafkaMessage.err == RD_KAFKA_RESP_ERR_NO_ERROR else {
+                var errorStringBuffer = ByteBuffer(bytes: valueBufferPointer)
+                let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes)
+
+                if let errorString {
+                    throw KafkaError.messageConsumption(reason: errorString)
+                } else {
+                    throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
+                }
+            }
+
+            guard let topic = String(validatingCString: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
+                fatalError("Received topic name that is non-valid UTF-8")
+            }
+
+            self.topic = topic
+
+            self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))
+
+            self.headers = try RDKafkaClient.getHeaders(for: messagePointer)
+
+            if let keyPointer = rdKafkaMessage.key {
+                let keyBufferPointer = UnsafeRawBufferPointer(
+                    start: keyPointer,
+                    count: rdKafkaMessage.key_len
+                )
+                self.key = .init(bytes: keyBufferPointer)
+            } else {
+                self.key = nil
+            }
+
+            self.value = ByteBuffer(bytes: valueBufferPointer)
+
+            self.offset = KafkaOffset(rawValue: Int(rdKafkaMessage.offset))
+
+            // Extract timestamp and type
+            var tsType = rd_kafka_timestamp_type_t(rawValue: 0)
+            let tsValue = rd_kafka_message_timestamp(messagePointer, &tsType)
+            self.timestampType = KafkaTimestampType(rawValue: Int32(tsType.rawValue))
+            self.timestamp = tsValue != -1 ? tsValue : nil
         }
-
-        guard let topic = String(validatingCString: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {
-            fatalError("Received topic name that is non-valid UTF-8")
-        }
-
-        self.topic = topic
-
-        self.partition = KafkaPartition(rawValue: Int(rdKafkaMessage.partition))
-
-        self.headers = try RDKafkaClient.getHeaders(for: messagePointer)
-
-        if let keyPointer = rdKafkaMessage.key {
-            let keyBufferPointer = UnsafeRawBufferPointer(
-                start: keyPointer,
-                count: rdKafkaMessage.key_len
-            )
-            self.key = .init(bytes: keyBufferPointer)
-        } else {
-            self.key = nil
-        }
-
-        self.value = ByteBuffer(bytes: valueBufferPointer)
-
-        self.offset = KafkaOffset(rawValue: Int(rdKafkaMessage.offset))
-
-        // Extract timestamp and type
-        var tsType = rd_kafka_timestamp_type_t(rawValue: 0)
-        let tsValue = rd_kafka_message_timestamp(messagePointer, &tsType)
-        self.timestampType = KafkaTimestampType(rawValue: Int32(tsType.rawValue))
-        self.timestamp = tsValue != -1 ? tsValue : nil
     }
 }
 
-// MARK: - KafkaConsumerMessage + Hashable
+// MARK: - KafkaConsumer.Message + Hashable
 
-extension KafkaConsumerMessage: Hashable {}
+extension KafkaConsumer.Message: Hashable {}
 
-// MARK: - KafkaConsumerMessage + Sendable
+// MARK: - KafkaConsumer.Message + Sendable
 
-extension KafkaConsumerMessage: Sendable {}
+extension KafkaConsumer.Message: Sendable {}

--- a/Sources/Kafka/KafkaConsumerRebalance.swift
+++ b/Sources/Kafka/KafkaConsumerRebalance.swift
@@ -12,41 +12,43 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Describes a consumer group rebalance event.
-///
-/// When a consumer joins or leaves a consumer group, Kafka redistributes
-/// partitions among the group members. The library handles the assign/unassign
-/// operations automatically — this event is informational only.
-public struct KafkaConsumerRebalance: Sendable, Hashable {
-    /// The kind of rebalance that occurred.
-    public enum Kind: Sendable, Hashable {
-        /// Kafka assigned new partitions to this consumer.
-        case assign
-        /// Kafka revoked partitions from this consumer.
-        case revoke
-        /// An unexpected error occurred during rebalance.
-        ///
-        /// Kafka unassigned all partitions as a recovery measure.
-        /// The associated string describes the error.
-        case error(String)
-    }
-
-    /// Whether this is an assignment, revocation, or error.
-    public let kind: Kind
-
-    /// The partitions involved in this rebalance.
+extension KafkaConsumer {
+    /// Describes a consumer group rebalance event.
     ///
-    /// For ``Kind/assign``: the partitions newly assigned to this consumer.
-    /// For ``Kind/revoke``: the partitions being revoked from this consumer.
-    /// For ``Kind/error(_:)``: empty.
-    public let partitions: [KafkaTopicPartition]
+    /// When a consumer joins or leaves a consumer group, Kafka redistributes
+    /// partitions among the group members. The library handles the assign/unassign
+    /// operations automatically — this event is informational only.
+    public struct Rebalance: Sendable, Hashable {
+        /// The kind of rebalance that occurred.
+        public enum Kind: Sendable, Hashable {
+            /// Kafka assigned new partitions to this consumer.
+            case assign
+            /// Kafka revoked partitions from this consumer.
+            case revoke
+            /// An unexpected error occurred during rebalance.
+            ///
+            /// Kafka unassigned all partitions as a recovery measure.
+            /// The associated string describes the error.
+            case error(String)
+        }
 
-    /// Creates a rebalance event description.
-    /// - Parameters:
-    ///   - kind: Whether this is an assignment, revocation, or error.
-    ///   - partitions: The partitions involved in this rebalance.
-    public init(kind: Kind, partitions: [KafkaTopicPartition]) {
-        self.kind = kind
-        self.partitions = partitions
+        /// Whether this is an assignment, revocation, or error.
+        public let kind: Kind
+
+        /// The partitions involved in this rebalance.
+        ///
+        /// For ``Kind/assign``: the partitions newly assigned to this consumer.
+        /// For ``Kind/revoke``: the partitions being revoked from this consumer.
+        /// For ``Kind/error(_:)``: empty.
+        public let partitions: [KafkaTopicPartition]
+
+        /// Creates a rebalance event description.
+        /// - Parameters:
+        ///   - kind: Whether this is an assignment, revocation, or error.
+        ///   - partitions: The partitions involved in this rebalance.
+        public init(kind: Kind, partitions: [KafkaTopicPartition]) {
+            self.kind = kind
+            self.partitions = partitions
+        }
     }
 }

--- a/Sources/Kafka/KafkaDeliveryReport.swift
+++ b/Sources/Kafka/KafkaDeliveryReport.swift
@@ -14,40 +14,42 @@
 
 import Crdkafka
 
-/// A delivery report for a message the producer sent to the Kafka cluster.
-public struct KafkaDeliveryReport: Sendable, Hashable {
-    /// The outcome of a producer's attempt to deliver a message to the Kafka cluster.
-    public enum Status: Sendable, Hashable {
-        /// The Kafka cluster successfully acknowledged the message.
-        case acknowledged(message: KafkaAcknowledgedMessage)
-        /// The Kafka cluster failed to acknowledge the message and encountered an error.
-        case failure(KafkaError)
-    }
-
-    /// The delivery status of the producer message.
-    public var status: Status
-
-    /// The unique identifier the producer assigned when sending the message to Kafka.
-    ///
-    /// ``KafkaProducer/send(_:)`` returns the same identifier, which correlates
-    /// a sent message with a delivery report.
-    public var id: KafkaProducerMessageID
-
-    internal init?(messagePointer: UnsafePointer<rd_kafka_message_t>?) {
-        guard let messagePointer else {
-            return nil
+extension KafkaProducer {
+    /// A delivery report for a message the producer sent to the Kafka cluster.
+    public struct DeliveryReport: Sendable, Hashable {
+        /// The outcome of a producer's attempt to deliver a message to the Kafka cluster.
+        public enum Status: Sendable, Hashable {
+            /// The Kafka cluster successfully acknowledged the message.
+            case acknowledged(message: AcknowledgedMessage)
+            /// The Kafka cluster failed to acknowledge the message and encountered an error.
+            case failure(KafkaError)
         }
 
-        self.id = KafkaProducerMessageID(rawValue: UInt(bitPattern: messagePointer.pointee._private))
+        /// The delivery status of the producer message.
+        public var status: Status
 
-        do {
-            let message = try KafkaAcknowledgedMessage(messagePointer: messagePointer)
-            self.status = .acknowledged(message: message)
-        } catch {
-            guard let error = error as? KafkaError else {
-                fatalError("Caught error that is not of type \(KafkaError.self)")
+        /// The unique identifier the producer assigned when sending the message to Kafka.
+        ///
+        /// ``KafkaProducer/send(_:)`` returns the same identifier, which correlates
+        /// a sent message with a delivery report.
+        public var id: MessageID
+
+        internal init?(messagePointer: UnsafePointer<rd_kafka_message_t>?) {
+            guard let messagePointer else {
+                return nil
             }
-            self.status = .failure(error)
+
+            self.id = MessageID(rawValue: UInt(bitPattern: messagePointer.pointee._private))
+
+            do {
+                let message = try AcknowledgedMessage(messagePointer: messagePointer)
+                self.status = .acknowledged(message: message)
+            } catch {
+                guard let error = error as? KafkaError else {
+                    fatalError("Caught error that is not of type \(KafkaError.self)")
+                }
+                self.status = .failure(error)
+            }
         }
     }
 }

--- a/Sources/Kafka/KafkaHeader.swift
+++ b/Sources/Kafka/KafkaHeader.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOCore
-
 /// A header attached to a Kafka message.
 ///
 /// Headers are key-value pairs that carry additional metadata alongside a Kafka message.
@@ -22,7 +20,7 @@ public struct KafkaHeader: Sendable, Hashable {
     public var key: String
 
     /// The value associated with the header.
-    public var value: ByteBuffer?
+    public var value: [UInt8]?
 
     /// Creates a new Kafka header with the key and optional value you provide.
     ///
@@ -31,7 +29,7 @@ public struct KafkaHeader: Sendable, Hashable {
     ///   - value: The optional binary value associated with the header.
     public init(
         key: String,
-        value: ByteBuffer? = nil
+        value: [UInt8]? = nil
     ) {
         self.key = key
         self.value = value

--- a/Sources/Kafka/KafkaOffset.swift
+++ b/Sources/Kafka/KafkaOffset.swift
@@ -15,9 +15,12 @@
 import Crdkafka
 
 /// A message offset within a Kafka partition queue.
-public struct KafkaOffset: RawRepresentable {
+public struct KafkaOffset: RawRepresentable, CustomStringConvertible, Hashable, Sendable {
     /// The raw integer value of the offset.
     public var rawValue: Int
+
+    /// A textual representation of the offset.
+    public var description: String { String(self.rawValue) }
 
     /// Creates a Kafka offset from its raw integer value.
     public init(rawValue: Int) {
@@ -41,11 +44,3 @@ public struct KafkaOffset: RawRepresentable {
         KafkaOffset(rawValue: Int(RD_KAFKA_OFFSET_TAIL_BASE) - count)
     }
 }
-
-// MARK: KafkaOffset + Hashable
-
-extension KafkaOffset: Hashable {}
-
-// MARK: KafkaOffset + Sendable
-
-extension KafkaOffset: Sendable {}

--- a/Sources/Kafka/KafkaPartition.swift
+++ b/Sources/Kafka/KafkaPartition.swift
@@ -15,7 +15,7 @@
 import Crdkafka
 
 /// The identifier of a Kafka partition.
-public struct KafkaPartition: RawRepresentable {
+public struct KafkaPartition: RawRepresentable, CustomStringConvertible, Hashable, Sendable {
     /// The raw integer identifier of the partition.
     public var rawValue: Int {
         didSet {
@@ -25,6 +25,9 @@ public struct KafkaPartition: RawRepresentable {
             )
         }
     }
+
+    /// A textual representation of the partition identifier.
+    public var description: String { String(self.rawValue) }
 
     /// Creates a partition identifier from its raw integer value.
     ///
@@ -42,11 +45,3 @@ public struct KafkaPartition: RawRepresentable {
     /// When you set this value, the partition is assigned automatically using the topic's partitioner function.
     public static let unassigned = KafkaPartition(rawValue: Int(RD_KAFKA_PARTITION_UA))
 }
-
-// MARK: KafkaPartition + Hashable
-
-extension KafkaPartition: Hashable {}
-
-// MARK: KafkaPartition + Sendable
-
-extension KafkaPartition: Sendable {}

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -155,6 +155,41 @@ public final class KafkaProducer: Service, Sendable {
         return (producer: producer, events: eventsSequence)
     }
 
+    /// Creates a producer, runs it for the duration of the closure, and shuts it down on return.
+    ///
+    /// Spawns the producer's ``run()`` loop in a child task and triggers a graceful shutdown
+    /// when `body` returns or throws — flushing outstanding messages, with no `ServiceGroup`
+    /// required. Use this for scoped, short-lived producers (tests, scripts, one-off jobs).
+    /// For long-running services, use ``makeProducer(config:)`` and manage the lifecycle
+    /// with a `ServiceGroup`.
+    ///
+    /// - Parameters:
+    ///     - config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
+    ///     - body: A closure that receives the producer and its events sequence.
+    /// - Returns: The value returned by `body`.
+    /// - Throws: A ``KafkaError`` if initializing the producer failed, or any error thrown by `body`.
+    public static func withProducer<Result>(
+        config: KafkaProducerConfig,
+        _ body: (KafkaProducer, Events) async throws -> Result
+    ) async throws -> Result {
+        let (producer, events) = try makeProducer(config: config)
+        return try await withThrowingTaskGroup(of: Void.self) { group -> Result in
+            group.addTask {
+                try await producer.run()
+            }
+            do {
+                let value = try await body(producer, events)
+                producer.triggerGracefulShutdown()
+                try? await group.waitForAll()
+                return value
+            } catch {
+                producer.triggerGracefulShutdown()
+                try? await group.waitForAll()
+                throw error
+            }
+        }
+    }
+
     /// Starts the producer.
     ///
     /// - Important: Call this method to drive the producer. It runs until either the calling task is canceled or gracefully shut down.

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -122,67 +122,25 @@ public final class KafkaProducer: Service, Sendable {
         )
     }
 
-    /// Creates a new producer.
+    /// Creates a producer and its paired events sequence.
     ///
-    /// This creates a producer without listening for events.
-    /// To also receive events, use ``makeProducerWithEvents(config:logger:)``.
+    /// Every producer receives an events sequence for delivery reports from
+    /// ``send(_:)`` and for error observation. Callers who only use
+    /// ``sendAndAwait(_:)`` may discard the returned `events` value.
     ///
-    /// - Parameters:
-    ///     - config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
-    ///     - logger: A logger.
-    /// - Throws: A ``KafkaError`` if initializing the producer failed.
-    public convenience init(
-        config: KafkaProducerConfig,
-        logger: Logger
-    ) throws {
-        let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
-
-        var subscribedEvents: [RDKafkaEvent] = [.log, .deliveryReport, .error]
-
-        if config.metrics.enabled {
-            subscribedEvents.append(.statistics)
-        }
-
-        let client = try RDKafkaClient.makeClient(
-            type: .producer,
-            configDictionary: config.config,
-            events: subscribedEvents,
-            logger: logger
-        )
-
-        stateMachine.withLockedValue {
-            $0.initialize(
-                client: client,
-                source: nil
-            )
-        }
-
-        self.init(
-            stateMachine: stateMachine,
-            config: config,
-            logger: logger
-        )
-    }
-
-    /// Creates a new producer paired with an asynchronous event sequence.
-    ///
-    /// The returned tuple pairs a ``KafkaProducer`` with its ``KafkaProducerEvents`` sequence.
-    ///
-    /// Use the asynchronous sequence to consume events.
-    ///
-    /// - Important: When the asynchronous sequence is deinitialized, the producer shuts down and stops accepting new messages.
-    ///   Additionally, consume the asynchronous sequence; otherwise the events buffer in memory indefinitely.
+    /// - Important: `send(_:)` and ``sendAndAwait(_:)`` keep working regardless of whether
+    ///   `events` is iterated or discarded. If you do iterate it, keep iterating; otherwise
+    ///   events buffer in memory indefinitely.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
-    ///     - logger: A logger.
-    /// - Returns: A tuple containing the created ``KafkaProducer`` and the ``KafkaProducerEvents``
-    /// `AsyncSequence` used for receiving message events.
+    /// - Returns: A named tuple containing the created ``KafkaProducer`` and its
+    ///   ``KafkaProducerEvents`` `AsyncSequence`.
     /// - Throws: A ``KafkaError`` if initializing the producer failed.
-    public static func makeProducerWithEvents(
-        config: KafkaProducerConfig,
-        logger: Logger
-    ) throws -> (KafkaProducer, KafkaProducerEvents) {
+    public static func makeProducer(
+        config: KafkaProducerConfig
+    ) throws -> (producer: KafkaProducer, events: KafkaProducerEvents) {
+        let logger = Logger.current
         let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
         var subscribedEvents: [RDKafkaEvent] = [.log, .deliveryReport, .error]
@@ -224,42 +182,15 @@ public final class KafkaProducer: Service, Sendable {
         }
 
         let eventsSequence = KafkaProducerEvents(wrappedSequence: sourceAndSequence.sequence)
-        return (producer, eventsSequence)
-    }
-
-    /// Creates a new producer from a deprecated configuration value.
-    ///
-    /// This initializer is deprecated. Use ``init(config:logger:)`` instead.
-    @available(*, deprecated, message: "Use init(config:logger:) instead")
-    public convenience init(
-        configuration: KafkaProducerConfiguration,
-        logger: Logger
-    ) throws {
-        try self.init(
-            config: configuration.asKafkaProducerConfig,
-            logger: logger
-        )
-    }
-
-    /// Creates a new producer and an event sequence from a deprecated configuration value.
-    ///
-    /// This method is deprecated. Use ``makeProducerWithEvents(config:logger:)`` instead.
-    @available(*, deprecated, message: "Use makeProducerWithEvents(config:logger:) instead")
-    public static func makeProducerWithEvents(
-        configuration: KafkaProducerConfiguration,
-        logger: Logger
-    ) throws -> (KafkaProducer, KafkaProducerEvents) {
-        try Self.makeProducerWithEvents(
-            config: configuration.asKafkaProducerConfig,
-            logger: logger
-        )
+        return (producer: producer, events: eventsSequence)
     }
 
     /// Starts the producer.
     ///
     /// - Important: Call this method to drive the producer. It runs until either the calling task is canceled or gracefully shut down.
     ///
-    /// Stop the producer with ``triggerGracefulShutdown()``.
+    /// Stop the producer by canceling the enclosing task, or by running it inside a
+    /// `ServiceGroup` and triggering that group's graceful shutdown.
     public func run() async throws {
         try await withGracefulShutdownHandler {
             try await self._run()
@@ -279,7 +210,7 @@ public final class KafkaProducer: Service, Sendable {
                     case .statistics(let statistics):
                         self.config.metrics.update(with: statistics)
                     case .deliveryReport(let reports):
-                        self.resumeContinuations(for: reports)
+                        _ = self.dispatchDeliveryReports(reports)
                     case .error(let kafkaError):
                         self.logger.info(
                             "Kafka client error",
@@ -295,8 +226,10 @@ public final class KafkaProducer: Service, Sendable {
                     case .statistics(let statistics):
                         self.config.metrics.update(with: statistics)
                     case .deliveryReport(let reports):
-                        self.resumeContinuations(for: reports)
-                        _ = source?.yield(.deliveryReports(reports))
+                        let reportsForEvents = self.dispatchDeliveryReports(reports)
+                        if !reportsForEvents.isEmpty {
+                            _ = source?.yield(.deliveryReports(reportsForEvents))
+                        }
                     case .error(let kafkaError):
                         _ = source?.yield(.error(kafkaError))
                         self.logger.info(
@@ -338,13 +271,18 @@ public final class KafkaProducer: Service, Sendable {
         }
     }
 
-    /// Match delivery reports against pending `sendAndAwait` continuations.
+    /// Route each delivery report to exactly one channel.
     ///
-    /// For each report, if a continuation is registered for that message ID, resume it.
-    /// Returns all reports; the producer yields them to the events sequence regardless
-    /// of whether it resumed a continuation. This ensures the events sequence is a complete
-    /// log of all delivery reports, even for messages sent via `sendAndAwait`.
-    private func resumeContinuations(for reports: [KafkaDeliveryReport]) {
+    /// - Reports whose message ID has a pending `sendAndAwait(_:)` continuation are resolved
+    ///   on that continuation only. The report is not re-emitted on the events sequence.
+    /// - Reports whose message ID has no pending continuation came from `send(_:)`;
+    ///   these are returned so the caller can emit them on the events sequence.
+    ///
+    /// Each delivery lands on exactly one destination. Callers using both `sendAndAwait(_:)`
+    /// and iterating `KafkaProducerEvents` never see the same report twice.
+    private func dispatchDeliveryReports(_ reports: [KafkaDeliveryReport]) -> [KafkaDeliveryReport] {
+        var reportsForEvents: [KafkaDeliveryReport] = []
+        reportsForEvents.reserveCapacity(reports.count)
         for report in reports {
             switch report.status {
             case .acknowledged:
@@ -370,8 +308,11 @@ public final class KafkaProducer: Service, Sendable {
                 case .failure(let error):
                     continuation.resume(throwing: error)
                 }
+            } else {
+                reportsForEvents.append(report)
             }
         }
+        return reportsForEvents
     }
 
     /// Shuts the producer down gracefully.
@@ -379,7 +320,7 @@ public final class KafkaProducer: Service, Sendable {
     /// Flushes any buffered messages and waits until the producer receives a callback for each one. After flushing, this method shuts down the connection to Kafka and cleans up any remaining state.
     ///
     /// Pairs with ``run()``.
-    public func triggerGracefulShutdown() {
+    func triggerGracefulShutdown() {
         self.logger.debug("Kafka producer shutting down")
         self.stateMachine.withLockedValue { $0.finish() }
     }
@@ -542,10 +483,16 @@ extension KafkaProducer {
                 topicHandles: RDKafkaTopicHandles
             )
             /// The producer is still running but the events asynchronous sequence terminated.
-            /// The producer drops all incoming events.
+            /// The producer drops all incoming events but continues to accept and send messages.
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
-            case eventConsumptionFinished(client: RDKafkaClient)
+            /// - Parameter messageIDCounter: Used to incrementally assign unique IDs to messages.
+            /// - Parameter topicHandles: Class containing all topic names with their respective `rd_kafka_topic_t` pointer.
+            case eventConsumptionFinished(
+                client: RDKafkaClient,
+                messageIDCounter: UInt,
+                topicHandles: RDKafkaTopicHandles
+            )
             /// ``KafkaProducer/triggerGracefulShutdown()`` was invoked so we are flushing
             /// any messages that wait to be sent and serve any remaining queued callbacks.
             ///
@@ -612,7 +559,7 @@ extension KafkaProducer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .started(let client, _, let source, _):
                 return .pollAndYield(client: client, source: source)
-            case .eventConsumptionFinished(let client):
+            case .eventConsumptionFinished(let client, _, _):
                 return .pollWithoutYield(client: client)
             case .finishing(let client, let source):
                 return .flushFinishSourceAndTerminatePollLoop(client: client, source: source)
@@ -653,9 +600,20 @@ extension KafkaProducer {
                     newMessageID: newMessageID,
                     topicHandles: topicHandles
                 )
-            case .eventConsumptionFinished:
-                throw KafkaError.connectionClosed(
-                    reason: "Sequence consuming events was abruptly terminated, producer closed"
+            case .eventConsumptionFinished(let client, let messageIDCounter, let topicHandles):
+                // Events observation ended, but sending is independent of observation —
+                // matches every other Kafka client (Rust, Python, Go, Java), none of which
+                // tie the ability to send to whether delivery outcomes are being observed.
+                let newMessageID = messageIDCounter + 1
+                self.state = .eventConsumptionFinished(
+                    client: client,
+                    messageIDCounter: newMessageID,
+                    topicHandles: topicHandles
+                )
+                return .send(
+                    client: client,
+                    newMessageID: newMessageID,
+                    topicHandles: topicHandles
                 )
             case .finishing:
                 throw KafkaError.connectionClosed(reason: "Producer in the process of finishing")
@@ -680,8 +638,12 @@ extension KafkaProducer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .eventConsumptionFinished:
                 fatalError("messageSequenceTerminated() must not be invoked more than once")
-            case .started(let client, _, let source, _):
-                self.state = .eventConsumptionFinished(client: client)
+            case .started(let client, let messageIDCounter, let source, let topicHandles):
+                self.state = .eventConsumptionFinished(
+                    client: client,
+                    messageIDCounter: messageIDCounter,
+                    topicHandles: topicHandles
+                )
                 return .finishSource(source: source)
             case .finishing(let client, let source):
                 // Setting source to nil to prevent incoming events from buffering in `source`
@@ -702,7 +664,7 @@ extension KafkaProducer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .started(let client, _, let source, _):
                 self.state = .finishing(client: client, source: source)
-            case .eventConsumptionFinished(let client):
+            case .eventConsumptionFinished(let client, _, _):
                 self.state = .finishing(client: client, source: nil)
             case .finishing, .finished:
                 break
@@ -733,9 +695,9 @@ extension KafkaProducer {
             for messageID: UInt
         ) -> RegisterContinuationResult {
             guard let existing = self.pendingContinuations[messageID] else {
-                fatalError(
-                    "registerContinuation called without prior initializeContinuation for messageID \(messageID)"
-                )
+                // If the slot is missing, it was likely removed by failPendingContinuations()
+                // during producer shutdown. Treat this as a cancellation/closure.
+                return .alreadyCancelled
             }
             switch existing {
             case .cancelled:

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -41,36 +41,6 @@ extension KafkaProducerCloseOnTerminate: NIOAsyncSequenceProducerDelegate {
     }
 }
 
-// MARK: - KafkaProducerEvents
-
-/// An asynchronous sequence of producer events emitted by Kafka.
-///
-/// The sequence yields ``KafkaProducerEvent`` values such as delivery reports and errors.
-public struct KafkaProducerEvents: Sendable, AsyncSequence {
-    /// The type of event the sequence yields.
-    public typealias Element = KafkaProducerEvent
-    typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
-    typealias WrappedSequence = NIOAsyncSequenceProducer<Element, BackPressureStrategy, KafkaProducerCloseOnTerminate>
-    let wrappedSequence: WrappedSequence
-
-    /// An asynchronous iterator over producer events emitted by Kafka.
-    ///
-    /// The iterator yields ``KafkaProducerEvent`` values such as delivery reports and errors.
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        var wrappedIterator: WrappedSequence.AsyncIterator
-
-        /// Returns the next producer event, or `nil` if the sequence has finished.
-        public mutating func next() async -> Element? {
-            await self.wrappedIterator.next()
-        }
-    }
-
-    /// Returns an asynchronous iterator over the producer event sequence.
-    public func makeAsyncIterator() -> AsyncIterator {
-        AsyncIterator(wrappedIterator: self.wrappedSequence.makeAsyncIterator())
-    }
-}
-
 // MARK: - KafkaProducer
 
 /// Sends messages to the Kafka cluster.
@@ -79,7 +49,7 @@ public struct KafkaProducerEvents: Sendable, AsyncSequence {
 ///   (based on topic-level configuration properties set on `KafkaProducerConfig`).
 public final class KafkaProducer: Service, Sendable {
     typealias Producer = NIOAsyncSequenceProducer<
-        KafkaProducerEvent,
+        Event,
         NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure,
         KafkaProducerCloseOnTerminate
     >
@@ -135,11 +105,11 @@ public final class KafkaProducer: Service, Sendable {
     /// - Parameters:
     ///     - config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
     /// - Returns: A named tuple containing the created ``KafkaProducer`` and its
-    ///   ``KafkaProducerEvents`` `AsyncSequence`.
+    ///   ``KafkaProducer/Events`` `AsyncSequence`.
     /// - Throws: A ``KafkaError`` if initializing the producer failed.
     public static func makeProducer(
         config: KafkaProducerConfig
-    ) throws -> (producer: KafkaProducer, events: KafkaProducerEvents) {
+    ) throws -> (producer: KafkaProducer, events: Events) {
         let logger = Logger.current
         let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
@@ -168,7 +138,7 @@ public final class KafkaProducer: Service, Sendable {
         // If this order is not met and `RDKafkaClient.makeClient()` fails,
         // it leads to a call to `stateMachine.stopConsuming()` while it's still in the `.uninitialized` state.
         let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
-            elementType: KafkaProducerEvent.self,
+            elementType: Event.self,
             backPressureStrategy: NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure(),
             finishOnDeinit: true,
             delegate: KafkaProducerCloseOnTerminate(stateMachine: stateMachine)
@@ -181,7 +151,7 @@ public final class KafkaProducer: Service, Sendable {
             )
         }
 
-        let eventsSequence = KafkaProducerEvents(wrappedSequence: sourceAndSequence.sequence)
+        let eventsSequence = Events(wrappedSequence: sourceAndSequence.sequence)
         return (producer: producer, events: eventsSequence)
     }
 
@@ -279,9 +249,9 @@ public final class KafkaProducer: Service, Sendable {
     ///   these are returned so the caller can emit them on the events sequence.
     ///
     /// Each delivery lands on exactly one destination. Callers using both `sendAndAwait(_:)`
-    /// and iterating `KafkaProducerEvents` never see the same report twice.
-    private func dispatchDeliveryReports(_ reports: [KafkaDeliveryReport]) -> [KafkaDeliveryReport] {
-        var reportsForEvents: [KafkaDeliveryReport] = []
+    /// and iterating `KafkaProducer.Events` never see the same report twice.
+    private func dispatchDeliveryReports(_ reports: [DeliveryReport]) -> [DeliveryReport] {
+        var reportsForEvents: [DeliveryReport] = []
         reportsForEvents.reserveCapacity(reports.count)
         for report in reports {
             switch report.status {
@@ -297,7 +267,7 @@ public final class KafkaProducer: Service, Sendable {
                 )
             }
 
-            let continuation: CheckedContinuation<KafkaDeliveryReport, Error>? =
+            let continuation: CheckedContinuation<DeliveryReport, Error>? =
                 self.stateMachine.withLockedValue {
                     $0.removeContinuation(for: report.id.rawValue)
                 }
@@ -333,12 +303,12 @@ public final class KafkaProducer: Service, Sendable {
     ///
     /// For acknowledged delivery, use ``sendAndAwait(_:)``.
     ///
-    /// - Parameter message: The ``KafkaProducerMessage`` to send.
-    /// - Returns: Unique ``KafkaProducerMessageID`` matching the ``KafkaDeliveryReport/id`` property
-    /// of the corresponding ``KafkaDeliveryReport``.
+    /// - Parameter message: The ``KafkaProducer/Message`` to send.
+    /// - Returns: Unique ``KafkaProducer/MessageID`` matching the ``KafkaProducer/DeliveryReport/id`` property
+    /// of the corresponding ``KafkaProducer/DeliveryReport``.
     /// - Throws: A ``KafkaError`` if sending the message failed.
     @discardableResult
-    public func send<Key, Value>(_ message: KafkaProducerMessage<Key, Value>) throws -> KafkaProducerMessageID {
+    public func send<Key, Value>(_ message: Message<Key, Value>) throws -> MessageID {
         let action = try self.stateMachine.withLockedValue { try $0.send() }
         switch action {
         case .send(let client, let newMessageID, let topicHandles):
@@ -356,22 +326,22 @@ public final class KafkaProducer: Service, Sendable {
                 )
                 throw error
             }
-            return KafkaProducerMessageID(rawValue: newMessageID)
+            return MessageID(rawValue: newMessageID)
         }
     }
 
     /// Sends a message to the Kafka cluster and awaits the delivery report.
     ///
     /// Unlike ``send(_:)``, this method suspends until the broker acknowledges (or rejects)
-    /// the message. The returned ``KafkaDeliveryReport`` contains the acknowledgment status,
+    /// the message. The returned ``KafkaProducer/DeliveryReport`` contains the acknowledgment status,
     /// partition, offset, and other metadata.
     ///
-    /// - Parameter message: The ``KafkaProducerMessage`` to send.
-    /// - Returns: A ``KafkaDeliveryReport`` with the delivery status.
+    /// - Parameter message: The ``KafkaProducer/Message`` to send.
+    /// - Returns: A ``KafkaProducer/DeliveryReport`` with the delivery status.
     /// - Throws: A ``KafkaError`` if the message could not be enqueued or was rejected by the broker.
     public func sendAndAwait<Key, Value>(
-        _ message: KafkaProducerMessage<Key, Value>
-    ) async throws -> KafkaDeliveryReport {
+        _ message: Message<Key, Value>
+    ) async throws -> DeliveryReport {
         // Get the message ID and produce BEFORE entering the continuation,
         // so we have the ID available for the cancellation handler.
         let action = try self.stateMachine.withLockedValue { try $0.send() }
@@ -394,7 +364,7 @@ public final class KafkaProducer: Service, Sendable {
 
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation {
-                (continuation: CheckedContinuation<KafkaDeliveryReport, Error>) in
+                (continuation: CheckedContinuation<DeliveryReport, Error>) in
                 // Transition from .initialized to .pending BEFORE producing.
                 // The delivery report could arrive before produce() returns.
                 let result = self.stateMachine.withLockedValue {
@@ -434,6 +404,40 @@ public final class KafkaProducer: Service, Sendable {
     }
 }
 
+// MARK: - KafkaProducer + Events sequence
+
+extension KafkaProducer {
+    /// An asynchronous sequence of producer events emitted by Kafka.
+    ///
+    /// The sequence yields ``KafkaProducer/Event`` values such as delivery reports and errors.
+    public struct Events: Sendable, AsyncSequence {
+        /// The type of event the sequence yields.
+        public typealias Element = Event
+        typealias BackPressureStrategy = NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure
+        typealias WrappedSequence = NIOAsyncSequenceProducer<
+            Element, BackPressureStrategy, KafkaProducerCloseOnTerminate
+        >
+        let wrappedSequence: WrappedSequence
+
+        /// An asynchronous iterator over producer events emitted by Kafka.
+        ///
+        /// The iterator yields ``KafkaProducer/Event`` values such as delivery reports and errors.
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            var wrappedIterator: WrappedSequence.AsyncIterator
+
+            /// Returns the next producer event, or `nil` if the sequence has finished.
+            public mutating func next() async -> Element? {
+                await self.wrappedIterator.next()
+            }
+        }
+
+        /// Returns an asynchronous iterator over the producer event sequence.
+        public func makeAsyncIterator() -> AsyncIterator {
+            AsyncIterator(wrappedIterator: self.wrappedSequence.makeAsyncIterator())
+        }
+    }
+}
+
 // MARK: - KafkaProducer + StateMachine
 
 extension KafkaProducer {
@@ -451,7 +455,7 @@ extension KafkaProducer {
         /// - `.cancelled`: `onCancel` fired before registration — reject on register
         enum ContinuationState {
             case initialized
-            case pending(CheckedContinuation<KafkaDeliveryReport, Error>)
+            case pending(CheckedContinuation<DeliveryReport, Error>)
             case cancelled
         }
 
@@ -691,7 +695,7 @@ extension KafkaProducer {
         /// Transitions the slot from `.initialized` to `.pending(continuation)`.
         /// Returns `.alreadyCancelled` if `onCancel` already set the slot to `.cancelled`.
         mutating func registerContinuation(
-            _ continuation: CheckedContinuation<KafkaDeliveryReport, Error>,
+            _ continuation: CheckedContinuation<DeliveryReport, Error>,
             for messageID: UInt
         ) -> RegisterContinuationResult {
             guard let existing = self.pendingContinuations[messageID] else {
@@ -720,7 +724,7 @@ extension KafkaProducer {
         /// as `.cancelled` so `registerContinuation` can reject it later.
         mutating func cancelContinuation(
             for messageID: UInt
-        ) -> CheckedContinuation<KafkaDeliveryReport, Error>? {
+        ) -> CheckedContinuation<DeliveryReport, Error>? {
             guard let existing = self.pendingContinuations.removeValue(forKey: messageID) else {
                 // Missing: the event loop already removed it via removeContinuation.
                 return nil
@@ -748,7 +752,7 @@ extension KafkaProducer {
         @discardableResult
         mutating func removeContinuation(
             for messageID: UInt
-        ) -> CheckedContinuation<KafkaDeliveryReport, Error>? {
+        ) -> CheckedContinuation<DeliveryReport, Error>? {
             guard let existing = self.pendingContinuations.removeValue(forKey: messageID) else {
                 return nil
             }

--- a/Sources/Kafka/KafkaProducer.swift
+++ b/Sources/Kafka/KafkaProducer.swift
@@ -157,36 +157,29 @@ public final class KafkaProducer: Service, Sendable {
 
     /// Creates a producer, runs it for the duration of the closure, and shuts it down on return.
     ///
-    /// Spawns the producer's ``run()`` loop in a child task and triggers a graceful shutdown
-    /// when `body` returns or throws — flushing outstanding messages, with no `ServiceGroup`
-    /// required. Use this for scoped, short-lived producers (tests, scripts, one-off jobs).
-    /// For long-running services, use ``makeProducer(config:)`` and manage the lifecycle
-    /// with a `ServiceGroup`.
+    /// Spawns the producer's ``run()`` loop internally and cancels it when `body` returns or
+    /// throws.
     ///
     /// - Parameters:
     ///     - config: The ``KafkaProducerConfig`` for configuring the ``KafkaProducer``.
     ///     - body: A closure that receives the producer and its events sequence.
     /// - Returns: The value returned by `body`.
     /// - Throws: A ``KafkaError`` if initializing the producer failed, or any error thrown by `body`.
-    public static func withProducer<Result>(
+    public static func withProducer<Result: ~Copyable>(
         config: KafkaProducerConfig,
         _ body: (KafkaProducer, Events) async throws -> Result
     ) async throws -> Result {
         let (producer, events) = try makeProducer(config: config)
-        return try await withThrowingTaskGroup(of: Void.self) { group -> Result in
-            group.addTask {
-                try await producer.run()
-            }
-            do {
-                let value = try await body(producer, events)
-                producer.triggerGracefulShutdown()
-                try? await group.waitForAll()
-                return value
-            } catch {
-                producer.triggerGracefulShutdown()
-                try? await group.waitForAll()
-                throw error
-            }
+        async let running: Void = producer.run()
+        do {
+            let value = try await body(producer, events)
+            producer.triggerGracefulShutdown()
+            _ = try? await running
+            return value
+        } catch {
+            producer.triggerGracefulShutdown()
+            _ = try? await running
+            throw error
         }
     }
 

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -12,25 +12,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An event reported by a Kafka producer, such as a delivery report or an error.
-///
-/// Delivered through ``KafkaProducerEvents``.
-public enum KafkaProducerEvent: Sendable, Hashable {
-    /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
-    case deliveryReports([KafkaDeliveryReport])
-    /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
-    case error(KafkaError)
-    /// - Important: Always provide a `default` case when switching over this `enum`.
-    case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
+extension KafkaProducer {
+    /// An event reported by a Kafka producer, such as a delivery report or an error.
+    ///
+    /// Delivered through ``KafkaProducer/Events``.
+    public enum Event: Sendable, Hashable {
+        /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
+        case deliveryReports([DeliveryReport])
+        /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
+        case error(KafkaError)
+        /// - Important: Always provide a `default` case when switching over this `enum`.
+        case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
 
-    internal init(_ event: RDKafkaClient.ProducerPollEvent) {
-        switch event {
-        case .deliveryReport(let results):
-            self = .deliveryReports(results)
-        case .error(let kafkaError):
-            self = .error(kafkaError)
-        case .statistics:
-            fatalError("Cannot cast \(event) to KafkaProducerEvent")
+        internal init(_ event: RDKafkaClient.ProducerPollEvent) {
+            switch event {
+            case .deliveryReport(let results):
+                self = .deliveryReports(results)
+            case .error(let kafkaError):
+                self = .error(kafkaError)
+            case .statistics:
+                fatalError("Cannot cast \(event) to KafkaProducer.Event")
+            }
         }
     }
 }

--- a/Sources/Kafka/KafkaProducerEvent.swift
+++ b/Sources/Kafka/KafkaProducerEvent.swift
@@ -16,13 +16,12 @@ extension KafkaProducer {
     /// An event reported by a Kafka producer, such as a delivery report or an error.
     ///
     /// Delivered through ``KafkaProducer/Events``.
+    @nonexhaustive
     public enum Event: Sendable, Hashable {
         /// A collection of delivery reports received from the Kafka cluster indicating the status of produced messages.
         case deliveryReports([DeliveryReport])
         /// An error reported by the Kafka client (for example, broker disconnection or authentication failure).
         case error(KafkaError)
-        /// - Important: Always provide a `default` case when switching over this `enum`.
-        case DO_NOT_SWITCH_OVER_THIS_EXHAUSITVELY
 
         internal init(_ event: RDKafkaClient.ProducerPollEvent) {
             switch event {

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -15,56 +15,58 @@
 import Crdkafka
 import NIOCore
 
-/// A message a producer sends to the Kafka cluster.
-public struct KafkaProducerMessage<Key: KafkaContiguousBytes, Value: KafkaContiguousBytes> {
-    /// The topic the producer sends the message to.
-    public var topic: String
+extension KafkaProducer {
+    /// A message a producer sends to the Kafka cluster.
+    public struct Message<Key: KafkaContiguousBytes, Value: KafkaContiguousBytes> {
+        /// The topic the producer sends the message to.
+        public var topic: String
 
-    /// The partition the producer sends the message to.
-    ///
-    /// Defaults to ``KafkaPartition/unassigned``.
-    /// When unassigned, the topic's partitioner function selects a partition automatically.
-    public var partition: KafkaPartition
+        /// The partition the producer sends the message to.
+        ///
+        /// Defaults to ``KafkaPartition/unassigned``.
+        /// When unassigned, the topic's partitioner function selects a partition automatically.
+        public var partition: KafkaPartition
 
-    /// The headers of the message.
-    public var headers: [KafkaHeader]
+        /// The headers of the message.
+        public var headers: [KafkaHeader]
 
-    /// The optional key associated with the message.
-    ///
-    /// If the ``KafkaPartition`` is ``KafkaPartition/unassigned``, the producer uses
-    /// ``KafkaProducerMessage/key`` to ensure that two ``KafkaProducerMessage``s with
-    /// the same key route to the same ``KafkaPartition``.
-    public var key: Key?
+        /// The optional key associated with the message.
+        ///
+        /// If the ``KafkaPartition`` is ``KafkaPartition/unassigned``, the producer uses
+        /// ``KafkaProducer/Message/key`` to ensure that two ``KafkaProducer/Message``s with
+        /// the same key route to the same ``KafkaPartition``.
+        public var key: Key?
 
-    /// The value of the message to send.
-    public var value: Value
+        /// The value of the message to send.
+        public var value: Value
 
-    /// Creates a producer message with key and value content.
-    ///
-    /// Both `key` and `value` must conform to ``KafkaContiguousBytes``.
-    ///
-    /// - Parameters:
-    ///     - topic: The topic the producer sends the message to. The ``KafkaProducer`` creates the topic if it doesn't exist.
-    ///     - partition: The topic partition the producer sends the message to. If you don't set this explicitly, the producer assigns the partition automatically.
-    ///     - headers: The headers of the message.
-    ///     - key: Guarantees that messages with the same key go to the same partition, preserving their order.
-    ///     - value: The message's value.
-    public init(
-        topic: String,
-        partition: KafkaPartition = .unassigned,
-        headers: [KafkaHeader] = [],
-        key: Key?,
-        value: Value
-    ) {
-        self.topic = topic
-        self.partition = partition
-        self.headers = headers
-        self.key = key
-        self.value = value
+        /// Creates a producer message with key and value content.
+        ///
+        /// Both `key` and `value` must conform to ``KafkaContiguousBytes``.
+        ///
+        /// - Parameters:
+        ///     - topic: The topic the producer sends the message to. The ``KafkaProducer`` creates the topic if it doesn't exist.
+        ///     - partition: The topic partition the producer sends the message to. If you don't set this explicitly, the producer assigns the partition automatically.
+        ///     - headers: The headers of the message.
+        ///     - key: Guarantees that messages with the same key go to the same partition, preserving their order.
+        ///     - value: The message's value.
+        public init(
+            topic: String,
+            partition: KafkaPartition = .unassigned,
+            headers: [KafkaHeader] = [],
+            key: Key?,
+            value: Value
+        ) {
+            self.topic = topic
+            self.partition = partition
+            self.headers = headers
+            self.key = key
+            self.value = value
+        }
     }
 }
 
-extension KafkaProducerMessage where Key == Never {
+extension KafkaProducer.Message where Key == Never {
     /// Creates a producer message with value content and no key.
     ///
     /// The `value` must conform to ``KafkaContiguousBytes``.
@@ -88,8 +90,8 @@ extension KafkaProducerMessage where Key == Never {
     }
 }
 
-extension KafkaProducerMessage: Hashable where Key: Hashable, Value: Hashable {}
+extension KafkaProducer.Message: Hashable where Key: Hashable, Value: Hashable {}
 
-extension KafkaProducerMessage: Equatable where Key: Equatable, Value: Equatable {}
+extension KafkaProducer.Message: Equatable where Key: Equatable, Value: Equatable {}
 
-extension KafkaProducerMessage: Sendable where Key: Sendable, Value: Sendable {}
+extension KafkaProducer.Message: Sendable where Key: Sendable, Value: Sendable {}

--- a/Sources/Kafka/KafkaProducerMessage.swift
+++ b/Sources/Kafka/KafkaProducerMessage.swift
@@ -19,7 +19,7 @@ extension KafkaProducer {
     /// A message a producer sends to the Kafka cluster.
     public struct Message<Key: KafkaContiguousBytes, Value: KafkaContiguousBytes> {
         /// The topic the producer sends the message to.
-        public var topic: String
+        public var topic: KafkaTopic
 
         /// The partition the producer sends the message to.
         ///
@@ -51,7 +51,7 @@ extension KafkaProducer {
         ///     - key: Guarantees that messages with the same key go to the same partition, preserving their order.
         ///     - value: The message's value.
         public init(
-            topic: String,
+            topic: KafkaTopic,
             partition: KafkaPartition = .unassigned,
             headers: [KafkaHeader] = [],
             key: Key?,
@@ -77,7 +77,7 @@ extension KafkaProducer.Message where Key == Never {
     ///     - headers: The headers of the message.
     ///     - value: The message body.
     public init(
-        topic: String,
+        topic: KafkaTopic,
         partition: KafkaPartition = .unassigned,
         headers: [KafkaHeader] = [],
         value: Value

--- a/Sources/Kafka/KafkaProducerMessageID.swift
+++ b/Sources/Kafka/KafkaProducerMessageID.swift
@@ -17,7 +17,7 @@ extension KafkaProducer {
     ///
     /// Use a ``KafkaProducer/MessageID`` to correlate an incoming ``KafkaProducer/DeliveryReport`` with the
     /// corresponding ``KafkaProducer/send(_:)`` call that produced it.
-    public struct MessageID {
+    public struct MessageID: Hashable, Sendable {
         internal var rawValue: UInt
 
         internal init(rawValue: UInt) {
@@ -35,10 +35,6 @@ extension KafkaProducer.MessageID: CustomStringConvertible {
     }
 }
 
-// MARK: - KafkaProducer.MessageID + Hashable
-
-extension KafkaProducer.MessageID: Hashable {}
-
 // MARK: - KafkaProducer.MessageID + Comparable
 
 extension KafkaProducer.MessageID: Comparable {
@@ -47,7 +43,3 @@ extension KafkaProducer.MessageID: Comparable {
         lhs.rawValue < rhs.rawValue
     }
 }
-
-// MARK: - KafkaProducer.MessageID + Sendable
-
-extension KafkaProducer.MessageID: Sendable {}

--- a/Sources/Kafka/KafkaProducerMessageID.swift
+++ b/Sources/Kafka/KafkaProducerMessageID.swift
@@ -12,40 +12,42 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An identifier for a message produced by a Kafka producer.
-///
-/// Use a ``KafkaProducerMessageID`` to correlate an incoming ``KafkaDeliveryReport`` with the
-/// corresponding ``KafkaProducer/send(_:)`` call that produced it.
-public struct KafkaProducerMessageID {
-    internal var rawValue: UInt
+extension KafkaProducer {
+    /// An identifier for a message produced by a Kafka producer.
+    ///
+    /// Use a ``KafkaProducer/MessageID`` to correlate an incoming ``KafkaProducer/DeliveryReport`` with the
+    /// corresponding ``KafkaProducer/send(_:)`` call that produced it.
+    public struct MessageID {
+        internal var rawValue: UInt
 
-    internal init(rawValue: UInt) {
-        self.rawValue = rawValue
+        internal init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
     }
 }
 
-// MARK: - KafkaProducerMessageID + CustomStringConvertible
+// MARK: - KafkaProducer.MessageID + CustomStringConvertible
 
-extension KafkaProducerMessageID: CustomStringConvertible {
+extension KafkaProducer.MessageID: CustomStringConvertible {
     /// A textual representation of the producer message identifier.
     public var description: String {
         String(self.rawValue)
     }
 }
 
-// MARK: - KafkaProducerMessageID + Hashable
+// MARK: - KafkaProducer.MessageID + Hashable
 
-extension KafkaProducerMessageID: Hashable {}
+extension KafkaProducer.MessageID: Hashable {}
 
-// MARK: - KafkaProducerMessageID + Comparable
+// MARK: - KafkaProducer.MessageID + Comparable
 
-extension KafkaProducerMessageID: Comparable {
+extension KafkaProducer.MessageID: Comparable {
     /// Returns a Boolean value that indicates whether the first identifier is ordered before the second.
-    public static func < (lhs: KafkaProducerMessageID, rhs: KafkaProducerMessageID) -> Bool {
+    public static func < (lhs: KafkaProducer.MessageID, rhs: KafkaProducer.MessageID) -> Bool {
         lhs.rawValue < rhs.rawValue
     }
 }
 
-// MARK: - KafkaProducerMessageID + Sendable
+// MARK: - KafkaProducer.MessageID + Sendable
 
-extension KafkaProducerMessageID: Sendable {}
+extension KafkaProducer.MessageID: Sendable {}

--- a/Sources/Kafka/KafkaTopic.swift
+++ b/Sources/Kafka/KafkaTopic.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2025 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// The name of a Kafka topic.
+public struct KafkaTopic: RawRepresentable, ExpressibleByStringLiteral, CustomStringConvertible, Hashable, Sendable {
+    /// The raw string name of the topic.
+    public var rawValue: String
+
+    /// A textual representation of the topic name.
+    public var description: String { self.rawValue }
+
+    /// Creates a topic name from its raw string value.
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    /// Creates a topic name from a string literal.
+    public init(stringLiteral value: String) {
+        self.rawValue = value
+    }
+}

--- a/Sources/Kafka/KafkaTopicPartition.swift
+++ b/Sources/Kafka/KafkaTopicPartition.swift
@@ -15,7 +15,7 @@
 /// A topic and partition pair identifying a specific Kafka partition.
 public struct KafkaTopicPartition: Sendable, Hashable {
     /// The name of the Kafka topic.
-    public var topic: String
+    public var topic: KafkaTopic
 
     /// The partition within the topic.
     public var partition: KafkaPartition
@@ -25,7 +25,7 @@ public struct KafkaTopicPartition: Sendable, Hashable {
     /// - Parameters:
     ///   - topic: The name of the Kafka topic.
     ///   - partition: The partition within the topic.
-    public init(topic: String, partition: KafkaPartition) {
+    public init(topic: KafkaTopic, partition: KafkaPartition) {
         self.topic = topic
         self.partition = partition
     }

--- a/Sources/Kafka/KafkaTopicPartitionOffset.swift
+++ b/Sources/Kafka/KafkaTopicPartitionOffset.swift
@@ -29,7 +29,7 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
     /// The name of the Kafka topic.
     ///
     /// A convenience accessor for the underlying ``KafkaTopicPartition/topic``.
-    public var topic: String { self.topicPartition.topic }
+    public var topic: KafkaTopic { self.topicPartition.topic }
 
     /// The partition within the topic.
     ///
@@ -42,7 +42,7 @@ public struct KafkaTopicPartitionOffset: Sendable, Hashable {
     ///   - topic: The name of the Kafka topic.
     ///   - partition: The partition within the topic.
     ///   - offset: The offset for this topic-partition.
-    public init(topic: String, partition: KafkaPartition, offset: KafkaOffset?) {
+    public init(topic: KafkaTopic, partition: KafkaPartition, offset: KafkaOffset?) {
         self.topicPartition = KafkaTopicPartition(topic: topic, partition: partition)
         self.offset = offset
     }

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -731,52 +731,6 @@ public final class RDKafkaClient: Sendable {
         }
     }
 
-    /// Schedules a non-blocking, fire-and-forget commit of the message's offset to Kafka.
-    ///
-    /// The client discards any errors encountered after scheduling the commit.
-    ///
-    /// - Parameter message: Last received message to mark as read.
-    /// - Throws: A ``KafkaError`` if scheduling the commit failed.
-    func scheduleCommit(_ message: KafkaConsumerMessage) throws {
-        // The offset committed is always the offset of the next requested message.
-        // Thus, we increase the offset of the current message by one before committing it.
-        // See: https://github.com/edenhill/librdkafka/issues/2745#issuecomment-598067945
-        let changesList = RDKafkaTopicPartitionList()
-        changesList.setOffset(
-            topic: message.topic,
-            partition: message.partition,
-            offset: Int64(message.offset.rawValue + 1)
-        )
-
-        let error = changesList.withListPointer { listPointer in
-            rd_kafka_commit(
-                self.kafkaHandle.pointer,
-                listPointer,
-                1  // async = true
-            )
-        }
-
-        if error != RD_KAFKA_RESP_ERR_NO_ERROR {
-            throw KafkaError.rdKafkaError(wrapping: error)
-        }
-    }
-
-    /// Schedule an async commit of all stored offsets.
-    /// Returns immediately. Any errors after scheduling are discarded.
-    ///
-    /// Equivalent to `rd_kafka_commit(rk, NULL, async=1)`.
-    func scheduleCommitAll() throws {
-        let error = rd_kafka_commit(
-            self.kafkaHandle.pointer,
-            nil,
-            1  // async = true
-        )
-
-        if error != RD_KAFKA_RESP_ERR_NO_ERROR {
-            throw KafkaError.rdKafkaError(wrapping: error)
-        }
-    }
-
     /// Non-blocking **awaitable** commit of all stored offsets.
     ///
     /// Equivalent to `rd_kafka_commit_queue(rk, NULL, ...)`.

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -117,11 +117,11 @@ public final class RDKafkaClient: Sendable {
 
     /// Produce a message to the Kafka cluster.
     ///
-    /// - Parameter message: The ``KafkaProducerMessage`` to send to the KafkaCluster.
+    /// - Parameter message: The ``KafkaProducer/Message`` to send to the KafkaCluster.
     /// - Parameter newMessageID: ID assigned to the `message`.
     /// - Parameter topicHandles: Topic handles that this client uses to produce new messages.
     func produce<Key, Value>(
-        message: KafkaProducerMessage<Key, Value>,
+        message: KafkaProducer.Message<Key, Value>,
         newMessageID: UInt,
         topicHandles: RDKafkaTopicHandles
     ) throws {
@@ -224,12 +224,12 @@ public final class RDKafkaClient: Sendable {
         )
     }
 
-    /// Scoped accessor that enables safe access to a ``KafkaProducerMessage``'s key and value raw buffers.
+    /// Scoped accessor that enables safe access to a ``KafkaProducer/Message``'s key and value raw buffers.
     /// - Warning: Do not escape the pointer from the closure for later use.
     /// - Parameter body: The closure that uses the pointer.
     @discardableResult
     private static func withMessageKeyAndValueBuffer<T, Key, Value>(
-        for message: KafkaProducerMessage<Key, Value>,
+        for message: KafkaProducer.Message<Key, Value>,
         _ body: (UnsafeRawBufferPointer?, UnsafeRawBufferPointer) throws -> T  // (keyBuffer, valueBuffer)
     ) rethrows -> T {
         try message.value.withUnsafeBytes { valueBuffer in
@@ -299,7 +299,7 @@ public final class RDKafkaClient: Sendable {
     /// Typed event returned by ``producerEventPoll(maxEvents:)``.
     /// Contains only events relevant to a Kafka producer.
     enum ProducerPollEvent {
-        case deliveryReport(results: [KafkaDeliveryReport])
+        case deliveryReport(results: [KafkaProducer.DeliveryReport])
         case statistics(RDKafkaStatistics)
         case error(KafkaError)
     }
@@ -423,13 +423,13 @@ public final class RDKafkaClient: Sendable {
     ///
     /// - Parameter event: Pointer to underlying `rd_kafka_event_t`.
     /// - Returns: Delivery report results parsed from the event.
-    private func handleDeliveryReportEvent(_ event: OpaquePointer?) -> [KafkaDeliveryReport] {
+    private func handleDeliveryReportEvent(_ event: OpaquePointer?) -> [KafkaProducer.DeliveryReport] {
         let deliveryReportCount = rd_kafka_event_message_count(event)
-        var deliveryReportResults = [KafkaDeliveryReport]()
+        var deliveryReportResults = [KafkaProducer.DeliveryReport]()
         deliveryReportResults.reserveCapacity(deliveryReportCount)
 
         while let messagePointer = rd_kafka_event_message_next(event) {
-            guard let messageStatus = KafkaDeliveryReport(messagePointer: messagePointer) else {
+            guard let messageStatus = KafkaProducer.DeliveryReport(messagePointer: messagePointer) else {
                 continue
             }
             deliveryReportResults.append(messageStatus)
@@ -549,9 +549,9 @@ public final class RDKafkaClient: Sendable {
     ///
     /// - Important: This method should only be invoked from ``KafkaConsumer``.
     ///
-    /// - Returns: A ``KafkaConsumerMessage`` or `nil` if there are no new messages.
+    /// - Returns: A ``KafkaConsumer/Message`` or `nil` if there are no new messages.
     /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
-    func consumerPoll(for pollTimeoutMs: Int32 = 0) throws -> KafkaConsumerMessage? {
+    func consumerPoll(for pollTimeoutMs: Int32 = 0) throws -> KafkaConsumer.Message? {
         guard let messagePointer = rd_kafka_consumer_poll(self.kafkaHandle.pointer, pollTimeoutMs) else {
             // No error, there might be no more messages
             return nil
@@ -567,7 +567,7 @@ public final class RDKafkaClient: Sendable {
             return nil
         }
 
-        let message = try KafkaConsumerMessage(messagePointer: messagePointer)
+        let message = try KafkaConsumer.Message(messagePointer: messagePointer)
         return message
     }
 
@@ -708,7 +708,7 @@ public final class RDKafkaClient: Sendable {
     ///
     /// - Parameter message: The message whose offset to store.
     /// - Throws: A ``KafkaError`` if storing the offset failed.
-    func storeOffset(_ message: KafkaConsumerMessage) throws {
+    func storeOffset(_ message: KafkaConsumer.Message) throws {
         // rd_kafka_offsets_store expects the offset of the *next* message to consume,
         // which is the current message's offset + 1.
         // See: https://github.com/edenhill/librdkafka/issues/2745#issuecomment-598067945
@@ -765,7 +765,7 @@ public final class RDKafkaClient: Sendable {
     ///
     /// - Parameter message: Last received message that shall be marked as read.
     /// - Throws: A ``KafkaError`` if the commit failed.
-    func commit(_ message: KafkaConsumerMessage) async throws {
+    func commit(_ message: KafkaConsumer.Message) async throws {
         let promise = CommitPromise()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
@@ -1073,7 +1073,7 @@ public final class RDKafkaClient: Sendable {
             }
 
             guard let headerKeyPointer else {
-                fatalError("Found null pointer when reading KafkaConsumerMessage header key")
+                fatalError("Found null pointer when reading consumer message header key")
             }
             let headerKey = String(cString: headerKeyPointer)
 

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -275,7 +275,7 @@ public final class RDKafkaClient: Sendable {
         // can ultimately access all kafkaHeader underlying key/value bytes safely.
         return try kafkaHeader.key.withCString { keyCString in
             if let headerValue = kafkaHeader.value {
-                return try headerValue.withUnsafeReadableBytes { valueBuffer in
+                return try headerValue.withUnsafeBytes { valueBuffer in
                     let cHeader: (UnsafePointer<CChar>, UnsafeRawBufferPointer?) = (keyCString, valueBuffer)
                     cHeaders.append(cHeader)
                     return try self._withKafkaCHeadersRecursive(
@@ -1081,13 +1081,13 @@ public final class RDKafkaClient: Sendable {
             }
             let headerKey = String(cString: headerKeyPointer)
 
-            var headerValue: ByteBuffer?
+            var headerValue: [UInt8]?
             if let headerValuePointer, headerValueSize > 0 {
                 let headerValueBufferPointer = UnsafeRawBufferPointer(
                     start: headerValuePointer,
                     count: headerValueSize
                 )
-                headerValue = ByteBuffer(bytes: headerValueBufferPointer)
+                headerValue = [UInt8](headerValueBufferPointer)
             }
 
             let newHeader = KafkaHeader(key: headerKey, value: headerValue)

--- a/Sources/Kafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaClient.swift
@@ -932,7 +932,9 @@ public final class RDKafkaClient: Sendable {
                 element.offset == Int64(RD_KAFKA_OFFSET_INVALID)
                 ? nil
                 : KafkaOffset(rawValue: Int(element.offset))
-            results.append(KafkaTopicPartitionOffset(topic: topic, partition: partition, offset: offset))
+            results.append(
+                KafkaTopicPartitionOffset(topic: KafkaTopic(rawValue: topic), partition: partition, offset: offset)
+            )
         }
 
         return results
@@ -975,7 +977,9 @@ public final class RDKafkaClient: Sendable {
         let tpl = RDKafkaTopicPartitionList(size: Int32(topicPartitionOffsets.count))
         for tpo in topicPartitionOffsets {
             guard let offset = tpo.offset else {
-                throw KafkaError.config(reason: "Seek requires a non-nil offset for \(tpo.topic):\(tpo.partition)")
+                throw KafkaError.config(
+                    reason: "Seek requires a non-nil offset for \(tpo.topic):\(tpo.partition)"
+                )
             }
             tpl.setOffset(
                 topic: tpo.topic,

--- a/Sources/Kafka/RDKafka/RDKafkaTopicHandles.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaTopicHandles.swift
@@ -38,14 +38,14 @@ internal final class RDKafkaTopicHandles: Sendable {
 
     /// Scoped accessor that enables safe access to the pointer of the topic's handle.
     /// - Warning: Do not escape the pointer from the closure for later use.
-    /// - Parameter topic: The name of the topic that is addressed.
+    /// - Parameter topic: The topic that is addressed.
     /// - Parameter body: The closure that uses the topic handle pointer.
     @discardableResult
     func withTopicHandlePointer<T>(
-        topic: String,
+        topic: KafkaTopic,
         _ body: (OpaquePointer) throws -> T
     ) throws -> T {
-        let topicHandle = try self.createTopicHandleIfNeeded(topic: topic)
+        let topicHandle = try self.createTopicHandleIfNeeded(topic: topic.rawValue)
         return try body(topicHandle)
     }
 

--- a/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
+++ b/Sources/Kafka/RDKafka/RDKafkaTopicPartitionList.swift
@@ -35,7 +35,7 @@ final class RDKafkaTopicPartitionList: @unchecked Sendable {
     }
 
     /// Add topic+partition pair to list.
-    func add(topic: String, partition: KafkaPartition) {
+    func add(topic: KafkaTopic, partition: KafkaPartition) {
         precondition(
             0...Int(Int32.max) ~= partition.rawValue || partition == .unassigned,
             "Partition ID outside of valid range \(0...Int32.max)"
@@ -43,13 +43,13 @@ final class RDKafkaTopicPartitionList: @unchecked Sendable {
 
         rd_kafka_topic_partition_list_add(
             self._internal,
-            topic,
+            topic.rawValue,
             Int32(partition.rawValue)
         )
     }
 
     /// Manually set read offset for a given topic+partition pair.
-    func setOffset(topic: String, partition: KafkaPartition, offset: Int64) {
+    func setOffset(topic: KafkaTopic, partition: KafkaPartition, offset: Int64) {
         precondition(
             0...Int(Int32.max) ~= partition.rawValue || partition == .unassigned,
             "Partition ID outside of valid range \(0...Int32.max)"
@@ -58,7 +58,7 @@ final class RDKafkaTopicPartitionList: @unchecked Sendable {
         guard
             let partitionPointer = rd_kafka_topic_partition_list_add(
                 self._internal,
-                topic,
+                topic.rawValue,
                 Int32(partition.rawValue)
             )
         else {

--- a/Sources/Kafka/RDKafka/RebalanceContext.swift
+++ b/Sources/Kafka/RDKafka/RebalanceContext.swift
@@ -59,7 +59,8 @@ final class RebalanceContext: @unchecked Sendable {
     /// Logger for rebalance operations. Used from the C callback thread.
     private let logger: Logger
 
-    init(logger: Logger) {
+    init() {
+        let logger = Logger.current
         self.pendingEvents = NIOLockedValueBox([])
         self.logger = logger
     }

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -2198,6 +2198,54 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
         }
     }
 
+    // MARK: - Scoped withConsumer / withProducer
+
+    @Test func withConsumerConsumesMessagesThenShutsDown() async throws {
+        try await withTestTopic { testTopic in
+            let testMessages = try await self.produceMessages(topic: testTopic, count: 10)
+
+            var consumerConfig = KafkaConsumerConfig()
+            consumerConfig.consumptionStrategy = .group(id: UUID().uuidString, topics: [testTopic])
+            consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
+            consumerConfig.autoOffsetReset = .beginning
+            consumerConfig.brokerAddressFamily = .v4
+
+            // withConsumer runs the consumer for the duration of the closure and
+            // gracefully shuts it down when the closure returns.
+            let consumed = try await KafkaConsumer.withConsumer(config: consumerConfig) { _, messages, _ in
+                var received = [KafkaConsumer.Message]()
+                for try await message in messages {
+                    received.append(message)
+                    if received.count >= testMessages.count {
+                        break
+                    }
+                }
+                return received
+            }
+
+            #expect(consumed.count == testMessages.count)
+            for (index, message) in consumed.enumerated() {
+                #expect(testMessages[index].topic == message.topic)
+                #expect(ByteBuffer(string: testMessages[index].value) == message.value)
+            }
+        }
+    }
+
+    @Test func withProducerSendsMessageThenShutsDown() async throws {
+        try await withTestTopic { testTopic in
+            let report = try await KafkaProducer.withProducer(config: self.producerConfig) { producer, _ in
+                let message = KafkaProducer.Message(topic: testTopic, value: "hello withProducer")
+                return try await producer.sendAndAwait(message)
+            }
+
+            guard case .acknowledged(let acknowledged) = report.status else {
+                Issue.record("Expected message to be acknowledged, got \(report.status)")
+                return
+            }
+            #expect(acknowledged.topic == testTopic)
+        }
+    }
+
     // MARK: - Helpers
 
     func produceMessages(topic: KafkaTopic, count: UInt) async throws -> [KafkaProducer.Message<String, String>] {

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -99,8 +99,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
 
                     for (index, consumedMessage) in consumedMessages.enumerated() {
                         #expect(testMessages[index].topic == consumedMessage.topic)
-                        #expect(ByteBuffer(string: testMessages[index].key!) == consumedMessage.key)
-                        #expect(ByteBuffer(string: testMessages[index].value) == consumedMessage.value)
+                        #expect(Array(testMessages[index].key!.utf8) == consumedMessage.key)
+                        #expect(Array(testMessages[index].value.utf8) == consumedMessage.value)
                     }
                 }
 
@@ -157,8 +157,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
 
                     for (index, consumedMessage) in consumedMessages.enumerated() {
                         #expect(testMessages[index].topic == consumedMessage.topic)
-                        #expect(ByteBuffer(string: testMessages[index].key!) == consumedMessage.key)
-                        #expect(ByteBuffer(string: testMessages[index].value) == consumedMessage.value)
+                        #expect(Array(testMessages[index].key!.utf8) == consumedMessage.key)
+                        #expect(Array(testMessages[index].value.utf8) == consumedMessage.value)
                     }
                 }
 
@@ -275,7 +275,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
             let testMessages = Self.createTestMessages(
                 topic: testTopic,
                 headers: [
-                    KafkaHeader(key: "some.header", value: ByteBuffer(string: "some-header-value")),
+                    KafkaHeader(key: "some.header", value: Array("some-header-value".utf8)),
                     KafkaHeader(key: "some.null.header", value: nil),
                 ],
                 count: 10
@@ -371,8 +371,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
 
                 let consumedMessage = try await consumerIterator.next()
                 #expect(testMessages.first!.topic == consumedMessage!.topic)
-                #expect(ByteBuffer(string: testMessages.first!.key!) == consumedMessage!.key)
-                #expect(ByteBuffer(string: testMessages.first!.value) == consumedMessage!.value)
+                #expect(Array(testMessages.first!.key!.utf8) == consumedMessage!.key)
+                #expect(Array(testMessages.first!.value.utf8) == consumedMessage!.value)
 
                 // Trigger a graceful shutdown
                 await serviceGroup.triggerGracefulShutdown()
@@ -440,8 +440,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
 
                     for (index, consumedMessage) in consumedMessages.enumerated() {
                         #expect(testMessages[index].topic == consumedMessage.topic)
-                        #expect(ByteBuffer(string: testMessages[index].key!) == consumedMessage.key)
-                        #expect(ByteBuffer(string: testMessages[index].value) == consumedMessage.value)
+                        #expect(Array(testMessages[index].key!.utf8) == consumedMessage.key)
+                        #expect(Array(testMessages[index].value.utf8) == consumedMessage.value)
                     }
                 }
 
@@ -500,11 +500,11 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
                     for (index, consumedMessage) in consumedMessages.enumerated() {
                         #expect(testMessages[firstConsumerOffset + index].topic == consumedMessage.topic)
                         #expect(
-                            ByteBuffer(string: testMessages[firstConsumerOffset + index].key!)
+                            Array(testMessages[firstConsumerOffset + index].key!.utf8)
                                 == consumedMessage.key
                         )
                         #expect(
-                            ByteBuffer(string: testMessages[firstConsumerOffset + index].value)
+                            Array(testMessages[firstConsumerOffset + index].value.utf8)
                                 == consumedMessage.value
                         )
                     }
@@ -807,11 +807,11 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
                     for (index, consumedMessage) in consumedMessages.enumerated() {
                         #expect(testMessages[firstConsumerCount + index].topic == consumedMessage.topic)
                         #expect(
-                            ByteBuffer(string: testMessages[firstConsumerCount + index].key!)
+                            Array(testMessages[firstConsumerCount + index].key!.utf8)
                                 == consumedMessage.key
                         )
                         #expect(
-                            ByteBuffer(string: testMessages[firstConsumerCount + index].value)
+                            Array(testMessages[firstConsumerCount + index].value.utf8)
                                 == consumedMessage.value
                         )
                     }
@@ -2226,7 +2226,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) asyn
             #expect(consumed.count == testMessages.count)
             for (index, message) in consumed.enumerated() {
                 #expect(testMessages[index].topic == message.topic)
-                #expect(ByteBuffer(string: testMessages[index].value) == message.value)
+                #expect(Array(testMessages[index].value.utf8) == message.value)
             }
         }
     }

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -32,7 +32,7 @@ import Foundation
 private let kafkaHost: String = ProcessInfo.processInfo.environment["KAFKA_HOST"] ?? "localhost"
 private let kafkaPort: Int = .init(ProcessInfo.processInfo.environment["KAFKA_PORT"] ?? "9092")!
 
-func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async throws -> Void) async throws {
+func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: KafkaTopic) async throws -> Void) async throws {
     var basicConfig = KafkaConsumerConfig()
     basicConfig.groupId = UUID().uuidString
     basicConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
@@ -2200,7 +2200,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     // MARK: - Helpers
 
-    func produceMessages(topic: String, count: UInt) async throws -> [KafkaProducer.Message<String, String>] {
+    func produceMessages(topic: KafkaTopic, count: UInt) async throws -> [KafkaProducer.Message<String, String>] {
         let testMessages = Self.createTestMessages(topic: topic, count: count)
         try await self.produceMessages(messages: testMessages)
         return testMessages
@@ -2241,7 +2241,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
     }
 
     private static func createTestMessages(
-        topic: String,
+        topic: KafkaTopic,
         headers: [KafkaHeader] = [],
         count: UInt
     ) -> [KafkaProducer.Message<String, String>] {
@@ -2270,7 +2270,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2303,7 +2303,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2333,7 +2333,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2367,7 +2367,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+            let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
                 services: [consumer],
@@ -2453,7 +2453,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     // Subscribe dynamically to both topics
                     try consumer.subscribe(topics: [testTopic1, testTopic2])
 
-                    var receivedTopics: Set<String> = []
+                    var receivedTopics: Set<KafkaTopic> = []
                     for try await message in consumerMsgs {
                         receivedTopics.insert(message.topic)
                         if receivedTopics.count >= 2 {

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -68,7 +68,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -86,8 +86,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Consumer Task
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumerMsgs {
                         consumedMessages.append(message)
 
                         if consumedMessages.count >= testMessages.count {
@@ -126,7 +126,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -144,8 +144,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Consumer Task
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumerMsgs {
                         consumedMessages.append(message)
 
                         if consumedMessages.count >= testMessages.count {
@@ -181,7 +181,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -199,8 +199,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Consumer Task
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumerMsgs {
                         consumedMessages.append(message)
                         try await consumer.commit(message)
 
@@ -231,7 +231,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -249,8 +249,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Consumer Task
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumerMsgs {
                         consumedMessages.append(message)
                         try await consumer.commit(message)
 
@@ -292,7 +292,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -310,8 +310,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Consumer Task
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await messageResult in consumer.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await messageResult in consumerMsgs {
                         guard case let message = messageResult else {
                             continue
                         }
@@ -350,7 +350,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
             consumerConfig.autoOffsetReset = .beginning  // Read topic from beginning
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -367,7 +367,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 }
 
                 // Verify that we receive the first message
-                let consumerIterator = consumer.messages.makeAsyncIterator()
+                let consumerIterator = consumerMsgs.makeAsyncIterator()
 
                 let consumedMessage = try await consumerIterator.next()
                 #expect(testMessages.first!.topic == consumedMessage!.topic)
@@ -408,7 +408,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.autoOffsetReset = .beginning  // Read topic from beginning
             consumer1Config.brokerAddressFamily = .v4
 
-            let (consumer1, _) = try KafkaConsumer.makeConsumer(
+            let (consumer1, consumer1Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer1Config
             )
 
@@ -426,8 +426,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // First Consumer Task
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer1.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumer1Msgs {
                         consumedMessages.append(message)
 
                         // Only read first half of messages
@@ -470,7 +470,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.autoOffsetReset = .latest
             consumer2Config.brokerAddressFamily = .v4
 
-            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+            let (consumer2, consumer2Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer2Config
             )
 
@@ -485,8 +485,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Second Consumer Task
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer2.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumer2Msgs {
                         consumedMessages.append(message)
 
                         // Read second half of messages
@@ -536,7 +536,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.pollInterval = .milliseconds(1)
             consumer1Config.enableAutoCommit = false
 
-            let (consumer1, _) = try KafkaConsumer.makeConsumer(
+            let (consumer1, consumer1Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer1Config
             )
 
@@ -551,7 +551,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.pollInterval = .milliseconds(1)
             consumer2Config.enableAutoCommit = false
 
-            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+            let (consumer2, consumer2Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer2Config
             )
 
@@ -589,7 +589,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // First Consumer Task
                 group.addTask {
                     // 6 partitions
-                    for try await record in consumer1.messages {
+                    for try await record in consumer1Msgs {
                         c1messages.wrappingIncrement(ordering: .relaxed)
 
                         try await consumer1.commit(record)  // commit time to time
@@ -603,7 +603,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // Second Consumer Task
                 group.addTask {
                     // 6 partitions
-                    for try await record in consumer2.messages {
+                    for try await record in consumer2Msgs {
                         c2messages.wrappingIncrement(ordering: .relaxed)
 
                         try await consumer2.commit(record)  // commit time to time
@@ -680,7 +680,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try await withThrowingTaskGroup(of: Void.self) { sendGroup in
                     for i in 0..<messageCount {
                         sendGroup.addTask {
-                            let message = KafkaProducerMessage(
+                            let message = KafkaProducer.Message(
                                 topic: testTopic,
                                 key: "key-\(i)",
                                 value: "value-\(i)"
@@ -729,7 +729,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             // At-least-once config: auto-commit ON, auto-offset-store OFF
             consumer1Config.enableAutoOffsetStore = false
 
-            let (consumer1, _) = try KafkaConsumer.makeConsumer(
+            let (consumer1, consumer1Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer1Config
             )
 
@@ -745,8 +745,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 }
 
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer1.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumer1Msgs {
                         // Store offset only after "processing" — at-least-once pattern
                         try consumer1.storeOffset(message)
                         consumedMessages.append(message)
@@ -776,7 +776,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.autoOffsetReset = .latest
             consumer2Config.brokerAddressFamily = .v4
 
-            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+            let (consumer2, consumer2Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer2Config
             )
 
@@ -792,8 +792,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 }
 
                 group.addTask {
-                    var consumedMessages = [KafkaConsumerMessage]()
-                    for try await message in consumer2.messages {
+                    var consumedMessages = [KafkaConsumer.Message]()
+                    for try await message in consumer2Msgs {
                         consumedMessages.append(message)
 
                         if consumedMessages.count >= (testMessages.count - firstConsumerCount) {
@@ -837,7 +837,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -854,7 +854,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 group.addTask {
                     // Consume one real message, then try storeOffset — should throw config error
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         #expect(throws: KafkaError.self) {
                             try consumer.storeOffset(message)
                         }
@@ -886,7 +886,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -903,7 +903,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 group.addTask {
                     var consumedCount = 0
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         consumedCount += 1
                         if consumedCount >= testMessages.count {
                             // Commit and verify BEFORE breaking — breaking drops the
@@ -951,7 +951,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -968,7 +968,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 group.addTask {
                     var consumedCount = 0
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         consumedCount += 1
 
                         // After consuming, position should be message.offset + 1
@@ -1011,7 +1011,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -1027,10 +1027,10 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 }
 
                 group.addTask {
-                    let iterator = consumer.messages.makeAsyncIterator()
+                    let iterator = consumerMsgs.makeAsyncIterator()
 
                     // Consume all 5 messages
-                    var firstPassMessages = [KafkaConsumerMessage]()
+                    var firstPassMessages = [KafkaConsumer.Message]()
                     for _ in 0..<testMessages.count {
                         let optionalMessage = try await iterator.next()
                         let message = try #require(optionalMessage)
@@ -1047,7 +1047,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     try await consumer.seek(topicPartitionOffsets: [seekTarget])
 
                     // Consume again — should replay the same messages
-                    var replayedMessages = [KafkaConsumerMessage]()
+                    var replayedMessages = [KafkaConsumer.Message]()
                     for _ in 0..<testMessages.count {
                         let optionalMessage = try await iterator.next()
                         let message = try #require(optionalMessage)
@@ -1091,7 +1091,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             // Lower auto-commit interval so stored offsets flush quickly in this test
             consumerConfig.autoCommitIntervalMs = 500
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -1108,7 +1108,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 group.addTask {
                     var consumedCount = 0
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         try consumer.storeOffset(message)
                         consumedCount += 1
                         if consumedCount >= testMessages.count {
@@ -1165,7 +1165,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.enableAutoCommit = false
             consumerConfig.enableAutoOffsetStore = false
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -1182,7 +1182,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 group.addTask {
                     var consumedCount = 0
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         try consumer.storeOffset(message)
                         consumedCount += 1
                         if consumedCount >= testMessages.count {
@@ -1235,7 +1235,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.enableAutoCommit = false
             consumerConfig.enableAutoOffsetStore = false
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -1252,7 +1252,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 group.addTask {
                     var consumedCount = 0
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         try consumer.storeOffset(message)
                         consumedCount += 1
                         if consumedCount >= testMessages.count {
@@ -1307,7 +1307,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.brokerAddressFamily = .v4
             consumer1Config.pollInterval = .milliseconds(1)
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+            let (consumer1, consumer1Msgs, events1) = try KafkaConsumer.makeConsumer(
                 config: consumer1Config
             )
 
@@ -1322,7 +1322,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.brokerAddressFamily = .v4
             consumer2Config.pollInterval = .milliseconds(1)
 
-            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+            let (consumer2, consumer2Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer2Config
             )
 
@@ -1347,7 +1347,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 group.addTask { try await serviceGroup1.run() }
 
                 group.addTask {
-                    for try await _ in consumer1.messages {}
+                    for try await _ in consumer1Msgs {}
                 }
 
                 group.addTask {
@@ -1374,7 +1374,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // Start consumer 2 — triggers a second rebalance
                 group.addTask { try await serviceGroup2.run() }
                 group.addTask {
-                    for try await _ in consumer2.messages {}
+                    for try await _ in consumer2Msgs {}
                 }
 
                 // Poll until consumer 1 receives the rebalance triggered by consumer 2 joining (bounded: 30s)
@@ -1410,7 +1410,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.pollInterval = .milliseconds(1)
             consumer1Config.enableAutoCommit = false
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+            let (consumer1, consumer1Msgs, events1) = try KafkaConsumer.makeConsumer(
                 config: consumer1Config
             )
 
@@ -1425,7 +1425,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.pollInterval = .milliseconds(1)
             consumer2Config.enableAutoCommit = false
 
-            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+            let (consumer2, consumer2Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer2Config
             )
 
@@ -1452,7 +1452,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 group.addTask { try await serviceGroup1.run() }
 
                 group.addTask {
-                    for try await record in consumer1.messages {
+                    for try await record in consumer1Msgs {
                         c1Messages.wrappingIncrement(ordering: .relaxed)
                         try await consumer1.commit(record)
                         if c2Messages.load(ordering: .relaxed) == 0 {
@@ -1485,7 +1485,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // Start consumer 2 — triggers rebalance while messages are flowing
                 group.addTask { try await serviceGroup2.run() }
                 group.addTask {
-                    for try await record in consumer2.messages {
+                    for try await record in consumer2Msgs {
                         c2Messages.wrappingIncrement(ordering: .relaxed)
                         try await consumer2.commit(record)
                     }
@@ -1548,7 +1548,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             // Auto-commit ON (default) + auto-offset-store OFF = at-least-once
             consumer1Config.autoCommitIntervalMs = 500
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+            let (consumer1, consumer1Msgs, events1) = try KafkaConsumer.makeConsumer(
                 config: consumer1Config
             )
 
@@ -1565,7 +1565,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.enableAutoOffsetStore = false
             consumer2Config.autoCommitIntervalMs = 500
 
-            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+            let (consumer2, consumer2Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer2Config
             )
 
@@ -1594,7 +1594,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Consumer 1 — consume + storeOffset (at-least-once)
                 group.addTask {
-                    for try await message in consumer1.messages {
+                    for try await message in consumer1Msgs {
                         try consumer1.storeOffset(message)
                         c1Messages.wrappingIncrement(ordering: .relaxed)
                         // Slow down so consumer 2 can join mid-consumption
@@ -1626,7 +1626,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // Start consumer 2 — triggers rebalance
                 group.addTask { try await serviceGroup2.run() }
                 group.addTask {
-                    for try await message in consumer2.messages {
+                    for try await message in consumer2Msgs {
                         try consumer2.storeOffset(message)
                         c2Messages.wrappingIncrement(ordering: .relaxed)
                     }
@@ -1704,7 +1704,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.pollInterval = .milliseconds(1)
             consumer1Config.partitionAssignmentStrategy = "cooperative-sticky"
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+            let (consumer1, consumer1Msgs, events1) = try KafkaConsumer.makeConsumer(
                 config: consumer1Config
             )
 
@@ -1719,7 +1719,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.pollInterval = .milliseconds(1)
             consumer2Config.partitionAssignmentStrategy = "cooperative-sticky"
 
-            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+            let (consumer2, consumer2Msgs, _) = try KafkaConsumer.makeConsumer(
                 config: consumer2Config
             )
 
@@ -1744,7 +1744,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask { try await serviceGroup1.run() }
                 group.addTask {
-                    for try await _ in consumer1.messages {}
+                    for try await _ in consumer1Msgs {}
                 }
 
                 group.addTask {
@@ -1778,7 +1778,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // Start consumer 2 — triggers cooperative rebalance
                 group.addTask { try await serviceGroup2.run() }
                 group.addTask {
-                    for try await _ in consumer2.messages {}
+                    for try await _ in consumer2Msgs {}
                 }
 
                 // Poll until consumer 1 receives a revoke (bounded: 30s)
@@ -1812,7 +1812,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             config.brokerAddressFamily = .v4
             config.pollInterval = .milliseconds(10)
 
-            let (consumer, events) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, events) = try KafkaConsumer.makeConsumer(
                 config: config
             )
 
@@ -1831,7 +1831,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 group.addTask { try await serviceGroup.run() }
 
                 group.addTask {
-                    for try await _ in consumer.messages {}
+                    for try await _ in consumerMsgs {}
                 }
 
                 group.addTask {
@@ -1882,7 +1882,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.brokerAddressFamily = .v4
 
             // Important: we leave `consumptionStrategy` nil to test the dynamic subscribe path.
-            let (consumer, events) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, events) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -1912,7 +1912,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try consumer.subscribe(topics: [testTopic])
 
                 // 4. Verify subscription contains our topic
-                let currentSubscription = try consumer.subscribedTopics()
+                let currentSubscription = try consumer.subscribedTopics
                 #expect(
                     currentSubscription.contains(testTopic),
                     "Expected subscription to contain \(testTopic), got \(currentSubscription)"
@@ -1921,7 +1921,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // 5. Consume the test messages in a background task to keep consumer alive
                 let consumedCount = ManagedAtomic<Int>(0)
                 group.addTask {
-                    for try await _ in consumer.messages {
+                    for try await _ in consumerMsgs {
                         consumedCount.wrappingIncrement(ordering: .relaxed)
                     }
                 }
@@ -1938,7 +1938,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try consumer.unsubscribe()
 
                 // 7. Verify subscription is now empty
-                let emptySubscription = try consumer.subscribedTopics()
+                let emptySubscription = try consumer.subscribedTopics
                 #expect(
                     emptySubscription.isEmpty,
                     "Expected empty subscription after unsubscribe, got \(emptySubscription)"
@@ -1946,11 +1946,11 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // 8. Dynamically subscribe again
                 try consumer.subscribe(topics: [testTopic])
-                #expect(try consumer.subscribedTopics().contains(testTopic))
+                #expect(try consumer.subscribedTopics.contains(testTopic))
 
                 // 9. Verify passing empty array to subscribe is equivalent to unsubscribe
                 try consumer.subscribe(topics: [])
-                let emptySub = try consumer.subscribedTopics()
+                let emptySub = try consumer.subscribedTopics
                 #expect(
                     emptySub.isEmpty,
                     "Expected empty subscription after subscribe(topics: []), got \(emptySub)"
@@ -1985,7 +1985,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     for await _ in events {}
                 }
 
-                let message = KafkaProducerMessage(
+                let message = KafkaProducer.Message(
                     topic: testTopic,
                     key: "test-key",
                     value: "test-value"
@@ -2031,7 +2031,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Send 5 messages via sendAndAwait and verify each gets acknowledged
                 for i in 0..<5 {
-                    let message = KafkaProducerMessage(
+                    let message = KafkaProducer.Message(
                         topic: testTopic,
                         key: "key-\(i)",
                         value: "value-\(i)"
@@ -2065,7 +2065,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     try await serviceGroup.run()
                 }
 
-                let message = KafkaProducerMessage(
+                let message = KafkaProducer.Message(
                     topic: testTopic,
                     key: "key",
                     value: "value"
@@ -2099,10 +2099,10 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
                 // Send 10 messages concurrently via sendAndAwait in a TaskGroup
                 let messageCount = 10
-                try await withThrowingTaskGroup(of: KafkaDeliveryReport.self) { sendGroup in
+                try await withThrowingTaskGroup(of: KafkaProducer.DeliveryReport.self) { sendGroup in
                     for i in 0..<messageCount {
                         sendGroup.addTask {
-                            let message = KafkaProducerMessage(
+                            let message = KafkaProducer.Message(
                                 topic: testTopic,
                                 key: "key-\(i)",
                                 value: "concurrent-\(i)"
@@ -2160,7 +2160,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 }
 
                 // send() — fire-and-forget, delivery report goes to events sequence
-                let sendMessage = KafkaProducerMessage(
+                let sendMessage = KafkaProducer.Message(
                     topic: testTopic,
                     key: "send-key",
                     value: "send-value"
@@ -2168,7 +2168,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try producer.send(sendMessage)
 
                 // sendAndAwait() — delivery report goes to continuation, NOT events sequence
-                let awaitMessage = KafkaProducerMessage(
+                let awaitMessage = KafkaProducer.Message(
                     topic: testTopic,
                     key: "await-key",
                     value: "await-value"
@@ -2200,14 +2200,14 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     // MARK: - Helpers
 
-    func produceMessages(topic: String, count: UInt) async throws -> [KafkaProducerMessage<String, String>] {
+    func produceMessages(topic: String, count: UInt) async throws -> [KafkaProducer.Message<String, String>] {
         let testMessages = Self.createTestMessages(topic: topic, count: count)
         try await self.produceMessages(messages: testMessages)
         return testMessages
     }
 
     func produceMessages(
-        messages: [KafkaProducerMessage<String, String>]
+        messages: [KafkaProducer.Message<String, String>]
     ) async throws {
         let (producer, events) = try KafkaProducer.makeProducer(
             config: self.producerConfig
@@ -2244,14 +2244,14 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         topic: String,
         headers: [KafkaHeader] = [],
         count: UInt
-    ) -> [KafkaProducerMessage<String, String>] {
+    ) -> [KafkaProducer.Message<String, String>] {
         _createTestMessages(topic: topic, headers: headers, count: count)
     }
 
     private static func sendAndAcknowledgeMessages(
         producer: KafkaProducer,
-        events: KafkaProducerEvents,
-        messages: [KafkaProducerMessage<String, String>],
+        events: KafkaProducer.Events,
+        messages: [KafkaProducer.Message<String, String>],
         skipConsistencyCheck: Bool = false
     ) async throws {
         try await _sendAndAcknowledgeMessages(
@@ -2270,7 +2270,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2284,12 +2284,12 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
             // Subscribe to topic-a
             try consumer.subscribe(topics: ["topic-a"])
-            let sub1 = try consumer.subscribedTopics()
+            let sub1 = try consumer.subscribedTopics
             #expect(sub1 == ["topic-a"])
 
             // Re-subscribe to topic-b — should replace, not append
             try consumer.subscribe(topics: ["topic-b"])
-            let sub2 = try consumer.subscribedTopics()
+            let sub2 = try consumer.subscribedTopics
             #expect(sub2 == ["topic-b"])
             #expect(!sub2.contains("topic-a"))
 
@@ -2303,7 +2303,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2316,11 +2316,11 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
 
             try consumer.subscribe(topics: ["topic-a", "topic-b"])
-            let subBefore = try consumer.subscribedTopics()
+            let subBefore = try consumer.subscribedTopics
             #expect(subBefore.count == 2)
 
             try consumer.unsubscribe()
-            let subAfter = try consumer.subscribedTopics()
+            let subAfter = try consumer.subscribedTopics
             #expect(subAfter.isEmpty)
 
             await serviceGroup.triggerGracefulShutdown()
@@ -2333,7 +2333,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2350,7 +2350,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             try consumer.unsubscribe()
             try consumer.subscribe(topics: ["topic-b"])
 
-            let sub = try consumer.subscribedTopics()
+            let sub = try consumer.subscribedTopics
             #expect(sub == ["topic-b"])
 
             await serviceGroup.triggerGracefulShutdown()
@@ -2367,7 +2367,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
                 services: [consumer],
@@ -2384,12 +2384,12 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 try await Task.sleep(for: .seconds(2), tolerance: .zero)
 
                 // Verify initial subscription
-                let initialSub = try consumer.subscribedTopics()
+                let initialSub = try consumer.subscribedTopics
                 #expect(initialSub.contains(testTopic))
 
                 // Re-subscribe to a different topic while running
                 try consumer.subscribe(topics: ["other-topic"])
-                let newSub = try consumer.subscribedTopics()
+                let newSub = try consumer.subscribedTopics
                 #expect(newSub == ["other-topic"])
                 #expect(!newSub.contains(testTopic))
 
@@ -2421,8 +2421,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                         for await _ in events {}
                     }
 
-                    let msg1 = KafkaProducerMessage(topic: testTopic1, value: "msg1")
-                    let msg2 = KafkaProducerMessage(topic: testTopic2, value: "msg2")
+                    let msg1 = KafkaProducer.Message(topic: testTopic1, value: "msg1")
+                    let msg2 = KafkaProducer.Message(topic: testTopic2, value: "msg2")
                     try producer.send(msg1)
                     try producer.send(msg2)
 
@@ -2437,7 +2437,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 consumerConfig.autoOffsetReset = .beginning
                 consumerConfig.brokerAddressFamily = .v4
 
-                let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+                let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
                 let consumerServiceGroupConfig = ServiceGroupConfiguration(
                     services: [consumer],
@@ -2454,7 +2454,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     try consumer.subscribe(topics: [testTopic1, testTopic2])
 
                     var receivedTopics: Set<String> = []
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         receivedTopics.insert(message.topic)
                         if receivedTopics.count >= 2 {
                             break
@@ -2482,7 +2482,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
+            let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
                 services: [consumer],
@@ -2495,7 +2495,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     try await serviceGroup.run()
                 }
 
-                for try await message in consumer.messages {
+                for try await message in consumerMsgs {
                     // Timestamp should be set (broker assigns it)
                     #expect(message.timestamp != nil)
                     #expect(
@@ -2527,7 +2527,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, events) = try KafkaConsumer.makeConsumer(
+            let (consumer, consumerMsgs, events) = try KafkaConsumer.makeConsumer(
                 config: consumerConfig
             )
 
@@ -2550,7 +2550,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 let consumedCount = ManagedAtomic<Int>(0)
                 let firstPartition = ManagedAtomic<Int32>(-1)
                 group.addTask {
-                    for try await message in consumer.messages {
+                    for try await message in consumerMsgs {
                         if firstPartition.load(ordering: .relaxed) == -1 {
                             firstPartition.store(
                                 Int32(message.partition.rawValue),

--- a/Tests/IntegrationTests/KafkaTests.swift
+++ b/Tests/IntegrationTests/KafkaTests.swift
@@ -39,8 +39,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
     basicConfig.brokerAddressFamily = .v4
 
     let client = try RDKafkaClient.makeClientForTopics(
-        config: basicConfig,
-        logger: .kafkaTest
+        config: basicConfig
     )
     let testTopic = try await client._createUniqueTopic(partitions: partitions)
 
@@ -69,9 +68,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -128,9 +126,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -184,9 +181,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -206,7 +202,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     var consumedMessages = [KafkaConsumerMessage]()
                     for try await message in consumer.messages {
                         consumedMessages.append(message)
-                        try consumer.scheduleCommit(message)
+                        try await consumer.commit(message)
 
                         if consumedMessages.count >= testMessages.count {
                             break
@@ -235,9 +231,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -297,9 +292,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning  // Always read topics from beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -356,9 +350,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
             consumerConfig.autoOffsetReset = .beginning  // Read topic from beginning
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -415,9 +408,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.autoOffsetReset = .beginning  // Read topic from beginning
             consumer1Config.brokerAddressFamily = .v4
 
-            let consumer1 = try KafkaConsumer(
-                config: consumer1Config,
-                logger: .kafkaTest
+            let (consumer1, _) = try KafkaConsumer.makeConsumer(
+                config: consumer1Config
             )
 
             let serviceGroupConfiguration1 = ServiceGroupConfiguration(
@@ -478,9 +470,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.autoOffsetReset = .latest
             consumer2Config.brokerAddressFamily = .v4
 
-            let consumer2 = try KafkaConsumer(
-                config: consumer2Config,
-                logger: .kafkaTest
+            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+                config: consumer2Config
             )
 
             let serviceGroupConfiguration2 = ServiceGroupConfiguration(services: [consumer2], logger: .kafkaTest)
@@ -545,9 +536,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.pollInterval = .milliseconds(1)
             consumer1Config.enableAutoCommit = false
 
-            let consumer1 = try KafkaConsumer(
-                config: consumer1Config,
-                logger: .kafkaTest
+            let (consumer1, _) = try KafkaConsumer.makeConsumer(
+                config: consumer1Config
             )
 
             var consumer2Config = KafkaConsumerConfig()
@@ -561,9 +551,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.pollInterval = .milliseconds(1)
             consumer2Config.enableAutoCommit = false
 
-            let consumer2 = try KafkaConsumer(
-                config: consumer2Config,
-                logger: .kafkaTest
+            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+                config: consumer2Config
             )
 
             let serviceGroupConfiguration1 = ServiceGroupConfiguration(
@@ -603,7 +592,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     for try await record in consumer1.messages {
                         c1messages.wrappingIncrement(ordering: .relaxed)
 
-                        try consumer1.scheduleCommit(record)  // commit time to time
+                        try await consumer1.commit(record)  // commit time to time
                         if c2messages.load(ordering: .relaxed) == 0 {
                             // Don't read all messages before 2nd consumer
                             try await Task.sleep(for: .milliseconds(100))
@@ -617,7 +606,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                     for try await record in consumer2.messages {
                         c2messages.wrappingIncrement(ordering: .relaxed)
 
-                        try consumer2.scheduleCommit(record)  // commit time to time
+                        try await consumer2.commit(record)  // commit time to time
                     }
                 }
 
@@ -651,9 +640,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     @Test func concurrentSendsDoNotLoseMessages() async throws {
         try await withTestTopic(partitions: 4) { testTopic in
-            let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-                config: self.producerConfig,
-                logger: .kafkaTest
+            let (producer, events) = try KafkaProducer.makeProducer(
+                config: self.producerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -741,9 +729,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             // At-least-once config: auto-commit ON, auto-offset-store OFF
             consumer1Config.enableAutoOffsetStore = false
 
-            let consumer1 = try KafkaConsumer(
-                config: consumer1Config,
-                logger: .kafkaTest
+            let (consumer1, _) = try KafkaConsumer.makeConsumer(
+                config: consumer1Config
             )
 
             let serviceGroupConfig1 = ServiceGroupConfiguration(
@@ -789,9 +776,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.autoOffsetReset = .latest
             consumer2Config.brokerAddressFamily = .v4
 
-            let consumer2 = try KafkaConsumer(
-                config: consumer2Config,
-                logger: .kafkaTest
+            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+                config: consumer2Config
             )
 
             let serviceGroupConfig2 = ServiceGroupConfiguration(
@@ -851,9 +837,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -901,9 +886,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -967,9 +951,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -1028,9 +1011,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -1109,9 +1091,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             // Lower auto-commit interval so stored offsets flush quickly in this test
             consumerConfig.autoCommitIntervalMs = 500
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -1184,9 +1165,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.enableAutoCommit = false
             consumerConfig.enableAutoOffsetStore = false
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -1208,7 +1188,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                         if consumedCount >= testMessages.count {
                             // Commit and verify BEFORE breaking — breaking drops the
                             // iterator which triggers consumer shutdown.
-                            try await consumer.commit()
+                            try await consumer.commitStoredOffsets()
 
                             let tp = KafkaTopicPartition(
                                 topic: message.topic,
@@ -1238,7 +1218,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         }
     }
 
-    @Test func scheduleCommitAllCommitsStoredOffsets() async throws {
+    @Test func commitStoredOffsetsFlushesStoredOffsets() async throws {
         try await withTestTopic { testTopic in
             let testMessages = try await self.produceMessages(topic: testTopic, count: 5)
 
@@ -1255,9 +1235,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.enableAutoCommit = false
             consumerConfig.enableAutoOffsetStore = false
 
-            let consumer = try KafkaConsumer(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, _) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -1279,7 +1258,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                         if consumedCount >= testMessages.count {
                             // Schedule commit and verify BEFORE breaking — breaking
                             // drops the iterator which triggers consumer shutdown.
-                            try consumer.scheduleCommit()
+                            try await consumer.commitStoredOffsets()
 
                             // Wait for the async commit to complete on the broker
                             try await Task.sleep(for: .seconds(2))
@@ -1328,9 +1307,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.brokerAddressFamily = .v4
             consumer1Config.pollInterval = .milliseconds(1)
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
-                config: consumer1Config,
-                logger: .kafkaTest
+            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+                config: consumer1Config
             )
 
             // Consumer 2 — plain consumer, joins later to trigger rebalance
@@ -1344,9 +1322,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.brokerAddressFamily = .v4
             consumer2Config.pollInterval = .milliseconds(1)
 
-            let consumer2 = try KafkaConsumer(
-                config: consumer2Config,
-                logger: .kafkaTest
+            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+                config: consumer2Config
             )
 
             let serviceGroup1 = ServiceGroup(
@@ -1433,9 +1410,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.pollInterval = .milliseconds(1)
             consumer1Config.enableAutoCommit = false
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
-                config: consumer1Config,
-                logger: .kafkaTest
+            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+                config: consumer1Config
             )
 
             var consumer2Config = KafkaConsumerConfig()
@@ -1449,9 +1425,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.pollInterval = .milliseconds(1)
             consumer2Config.enableAutoCommit = false
 
-            let consumer2 = try KafkaConsumer(
-                config: consumer2Config,
-                logger: .kafkaTest
+            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+                config: consumer2Config
             )
 
             let serviceGroup1 = ServiceGroup(
@@ -1479,7 +1454,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 group.addTask {
                     for try await record in consumer1.messages {
                         c1Messages.wrappingIncrement(ordering: .relaxed)
-                        try consumer1.scheduleCommit(record)
+                        try await consumer1.commit(record)
                         if c2Messages.load(ordering: .relaxed) == 0 {
                             try await Task.sleep(for: .milliseconds(50))
                         }
@@ -1512,7 +1487,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 group.addTask {
                     for try await record in consumer2.messages {
                         c2Messages.wrappingIncrement(ordering: .relaxed)
-                        try consumer2.scheduleCommit(record)
+                        try await consumer2.commit(record)
                     }
                 }
 
@@ -1573,9 +1548,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             // Auto-commit ON (default) + auto-offset-store OFF = at-least-once
             consumer1Config.autoCommitIntervalMs = 500
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
-                config: consumer1Config,
-                logger: .kafkaTest
+            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+                config: consumer1Config
             )
 
             // Consumer 2 — same at-least-once config, joins later
@@ -1591,9 +1565,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.enableAutoOffsetStore = false
             consumer2Config.autoCommitIntervalMs = 500
 
-            let consumer2 = try KafkaConsumer(
-                config: consumer2Config,
-                logger: .kafkaTest
+            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+                config: consumer2Config
             )
 
             let serviceGroup1 = ServiceGroup(
@@ -1731,9 +1704,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer1Config.pollInterval = .milliseconds(1)
             consumer1Config.partitionAssignmentStrategy = "cooperative-sticky"
 
-            let (consumer1, events1) = try KafkaConsumer.makeConsumerWithEvents(
-                config: consumer1Config,
-                logger: .kafkaTest
+            let (consumer1, events1) = try KafkaConsumer.makeConsumer(
+                config: consumer1Config
             )
 
             var consumer2Config = KafkaConsumerConfig()
@@ -1747,9 +1719,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumer2Config.pollInterval = .milliseconds(1)
             consumer2Config.partitionAssignmentStrategy = "cooperative-sticky"
 
-            let consumer2 = try KafkaConsumer(
-                config: consumer2Config,
-                logger: .kafkaTest
+            let (consumer2, _) = try KafkaConsumer.makeConsumer(
+                config: consumer2Config
             )
 
             let serviceGroup1 = ServiceGroup(
@@ -1841,9 +1812,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             config.brokerAddressFamily = .v4
             config.pollInterval = .milliseconds(10)
 
-            let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
-                config: config,
-                logger: .kafkaTest
+            let (consumer, events) = try KafkaConsumer.makeConsumer(
+                config: config
             )
 
             let serviceGroup = ServiceGroup(
@@ -1912,9 +1882,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.brokerAddressFamily = .v4
 
             // Important: we leave `consumptionStrategy` nil to test the dynamic subscribe path.
-            let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, events) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroup = ServiceGroup(
@@ -1996,9 +1965,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     @Test func sendAndAwaitReturnsDeliveryReport() async throws {
         try await withTestTopic { testTopic in
-            let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-                config: self.producerConfig,
-                logger: .kafkaTest
+            let (producer, events) = try KafkaProducer.makeProducer(
+                config: self.producerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -2042,9 +2010,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     @Test func sendAndAwaitMultipleMessages() async throws {
         try await withTestTopic { testTopic in
-            let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-                config: self.producerConfig,
-                logger: .kafkaTest
+            let (producer, events) = try KafkaProducer.makeProducer(
+                config: self.producerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -2083,9 +2050,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
     @Test func sendAndAwaitWorksWithoutEventsSequence() async throws {
         try await withTestTopic { testTopic in
             // Producer created WITHOUT events — sendAndAwait should still work
-            let producer = try KafkaProducer(
-                config: self.producerConfig,
-                logger: .kafkaTest
+            let (producer, _) = try KafkaProducer.makeProducer(
+                config: self.producerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -2117,9 +2083,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     @Test func sendAndAwaitConcurrentSends() async throws {
         try await withTestTopic(partitions: 4) { testTopic in
-            let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-                config: self.producerConfig,
-                logger: .kafkaTest
+            let (producer, events) = try KafkaProducer.makeProducer(
+                config: self.producerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -2166,9 +2131,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
 
     @Test func sendAndSendAndAwaitMixedOnSameProducer() async throws {
         try await withTestTopic { testTopic in
-            let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-                config: self.producerConfig,
-                logger: .kafkaTest
+            let (producer, events) = try KafkaProducer.makeProducer(
+                config: self.producerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -2219,12 +2183,14 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 // Give time for send() delivery report to arrive via events sequence
                 try await Task.sleep(for: .milliseconds(500))
 
-                // Verify ALL delivery reports arrived through events sequence —
-                // both send() and sendAndAwait() reports should appear
+                // Verify each delivery lands on exactly one channel — send() reports
+                // arrive on the events sequence, sendAndAwait() reports resolve on the
+                // continuation only. The events counter must equal the number of send()
+                // calls (1), not both.
                 let eventsCount = eventReportCount.load(ordering: .relaxed)
                 #expect(
-                    eventsCount >= 2,
-                    "Both send() and sendAndAwait() reports should arrive via events, got \(eventsCount)"
+                    eventsCount == 1,
+                    "Only send() reports flow through events; sendAndAwait must not duplicate. Got \(eventsCount)"
                 )
 
                 await serviceGroup.triggerGracefulShutdown()
@@ -2243,9 +2209,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
     func produceMessages(
         messages: [KafkaProducerMessage<String, String>]
     ) async throws {
-        let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-            config: self.producerConfig,
-            logger: .kafkaTest
+        let (producer, events) = try KafkaProducer.makeProducer(
+            config: self.producerConfig
         )
         let serviceGroupConfiguration = ServiceGroupConfiguration(
             services: [producer],
@@ -2305,7 +2270,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2338,7 +2303,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2368,7 +2333,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
         consumerConfig.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -2402,7 +2367,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.bootstrapServers = ["\(kafkaHost):\(kafkaPort)"]
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+            let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
                 services: [consumer],
@@ -2437,9 +2402,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
         try await withTestTopic { testTopic1 in
             try await withTestTopic { testTopic2 in
                 // Produce a message to each topic
-                let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-                    config: self.producerConfig,
-                    logger: .kafkaTest
+                let (producer, events) = try KafkaProducer.makeProducer(
+                    config: self.producerConfig
                 )
 
                 let serviceGroupConfiguration = ServiceGroupConfiguration(
@@ -2473,7 +2437,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
                 consumerConfig.autoOffsetReset = .beginning
                 consumerConfig.brokerAddressFamily = .v4
 
-                let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+                let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
                 let consumerServiceGroupConfig = ServiceGroupConfiguration(
                     services: [consumer],
@@ -2518,7 +2482,7 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let consumer = try KafkaConsumer(config: consumerConfig, logger: .kafkaTest)
+            let (consumer, _) = try KafkaConsumer.makeConsumer(config: consumerConfig)
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(
                 services: [consumer],
@@ -2563,9 +2527,8 @@ func withTestTopic(partitions: Int32 = 1, _ body: (_ testTopic: String) async th
             consumerConfig.autoOffsetReset = .beginning
             consumerConfig.brokerAddressFamily = .v4
 
-            let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
-                config: consumerConfig,
-                logger: .kafkaTest
+            let (consumer, events) = try KafkaConsumer.makeConsumer(
+                config: consumerConfig
             )
 
             let serviceGroupConfiguration = ServiceGroupConfiguration(

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -69,7 +69,9 @@ import Foundation
         )
         config.debug = [.all]
 
-        let consumer = try KafkaConsumer(config: config, logger: mockLogger)
+        let (consumer, _) = try withLogger(mockLogger) { _ in
+            try KafkaConsumer.makeConsumer(config: config)
+        }
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -112,8 +114,8 @@ import Foundation
             topics: ["this-topic-does-not-exist"]
         )
 
-        _ = try KafkaConsumer(config: config, logger: .kafkaTest)  // deinit called before run
-        _ = try KafkaConsumer.makeConsumerWithEvents(config: config, logger: .kafkaTest)
+        _ = try KafkaConsumer.makeConsumer(config: config)  // deinit called before run
+        _ = try KafkaConsumer.makeConsumer(config: config)
     }
 
     @Test func consumerMessagesReadCancelledBeforeRun() async throws {
@@ -124,7 +126,7 @@ import Foundation
             topics: ["this-topic-does-not-exist"]
         )
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let svcGroupConfig = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: svcGroupConfig)
@@ -164,7 +166,7 @@ import Foundation
 
     @Test func positionFailsOnClosedConsumerViaStateMachine() async throws {
         let config = makeConfig(enableAutoOffsetStore: false)
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -191,7 +193,7 @@ import Foundation
 
     @Test func subscribedTopicsFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -212,7 +214,7 @@ import Foundation
 
     @Test func subscribeFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -233,7 +235,7 @@ import Foundation
 
     @Test func unsubscribeFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -254,7 +256,7 @@ import Foundation
 
     @Test func subscribeWithEmptyTopicsCallsUnsubscribe() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -279,7 +281,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // subscribe() in .initializing state should not crash
         try consumer.subscribe(topics: ["test-topic"])
@@ -290,7 +292,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // No subscription set — should return empty
         let topics = try consumer.subscribedTopics()
@@ -303,7 +305,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -325,7 +327,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // Subscribe before run
         try consumer.subscribe(topics: ["test-topic"])
@@ -349,7 +351,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // Unsubscribe when never subscribed — should not crash
         try consumer.unsubscribe()
@@ -360,7 +362,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // librdkafka rejects duplicate topics with "Invalid argument"
         #expect(throws: KafkaError.self) {
@@ -373,7 +375,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // Regex pattern subscription — librdkafka supports ^-prefixed patterns
         try consumer.subscribe(topics: ["^test-.*"])
@@ -383,7 +385,7 @@ import Foundation
 
     @Test func pauseFailsOnUnknownPartition() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -406,7 +408,7 @@ import Foundation
 
     @Test func resumeFailsOnUnknownPartition() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -429,7 +431,7 @@ import Foundation
 
     @Test func pauseFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -452,7 +454,7 @@ import Foundation
 
     @Test func resumeFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -496,7 +498,7 @@ import Foundation
 
     @Test func committedFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -521,7 +523,7 @@ import Foundation
 
     @Test func positionFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -547,7 +549,7 @@ import Foundation
 
     @Test func isAssignmentLostFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -569,7 +571,7 @@ import Foundation
 
     @Test func isAssignmentLostReturnsFalseWhenRunning() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -603,7 +605,7 @@ import Foundation
 
     @Test func seekFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -627,38 +629,11 @@ import Foundation
         }
     }
 
-    // MARK: - scheduleCommit Config Guard Tests
-    //
-    // scheduleCommit(_:) requires a KafkaConsumerMessage which cannot be constructed
-    // without a broker. The config guard (enableAutoCommit must be false) is tested
-    // indirectly: if enableAutoCommit is true (default), calling scheduleCommit would
-    // throw a config error. The closed-consumer path is the same as other withClient()
-    // methods, already tested above.
-
     // MARK: - Commit All Tests
-
-    @Test func scheduleCommitAllFailsWithAutoCommitEnabled() async throws {
-        let config = makeConfig(enableAutoCommit: true)
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
-
-        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
-        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
-
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await serviceGroup.run() }
-            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
-
-            #expect(throws: KafkaError.self) {
-                try consumer.scheduleCommit()
-            }
-
-            await serviceGroup.triggerGracefulShutdown()
-        }
-    }
 
     @Test func commitAllFailsWithAutoCommitEnabled() async throws {
         let config = makeConfig(enableAutoCommit: true)
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -668,35 +643,16 @@ import Foundation
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
 
             await #expect(throws: KafkaError.self) {
-                try await consumer.commit()
+                try await consumer.commitStoredOffsets()
             }
 
             await serviceGroup.triggerGracefulShutdown()
         }
     }
 
-    @Test func scheduleCommitAllFailsOnClosedConsumer() async throws {
-        let config = makeConfig(enableAutoCommit: false)
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
-
-        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
-        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
-
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await serviceGroup.run() }
-            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
-            await serviceGroup.triggerGracefulShutdown()
-            try await group.waitForAll()
-        }
-
-        #expect(throws: KafkaError.self) {
-            try consumer.scheduleCommit()
-        }
-    }
-
     @Test func commitAllFailsOnClosedConsumer() async throws {
         let config = makeConfig(enableAutoCommit: false)
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -709,17 +665,16 @@ import Foundation
         }
 
         await #expect(throws: KafkaError.self) {
-            try await consumer.commit()
+            try await consumer.commitStoredOffsets()
         }
     }
 
-    // MARK: - makeConsumerWithEvents Tests
+    // MARK: - makeConsumer Tests
 
-    @Test func makeConsumerWithEventsConstructDeinit() async throws {
+    @Test func makeConsumerConstructDeinit() async throws {
         let config = makeConfig()
-        let (consumer, events) = try KafkaConsumer.makeConsumerWithEvents(
-            config: config,
-            logger: .kafkaTest
+        let (consumer, events) = try KafkaConsumer.makeConsumer(
+            config: config
         )
         _ = consumer
         _ = events
@@ -1007,13 +962,13 @@ import Foundation
     // MARK: - RebalanceContext Tests
 
     @Test func rebalanceContextDrainEventsEmpty() {
-        let context = RebalanceContext(logger: .kafkaTest)
+        let context = RebalanceContext()
         let events = context.drainEvents()
         #expect(events.isEmpty)
     }
 
     @Test func rebalanceContextInjectAndDrain() {
-        let context = RebalanceContext(logger: .kafkaTest)
+        let context = RebalanceContext()
 
         context._testInjectEvent(
             RebalanceContext.ConsumerRebalanceEvent(
@@ -1046,7 +1001,7 @@ import Foundation
     }
 
     @Test func rebalanceContextDrainClearsBuffer() {
-        let context = RebalanceContext(logger: .kafkaTest)
+        let context = RebalanceContext()
 
         context._testInjectEvent(
             RebalanceContext.ConsumerRebalanceEvent(kind: .assign, partitions: [("t", 0)])
@@ -1060,7 +1015,7 @@ import Foundation
     }
 
     @Test func rebalanceContextErrorEventInjection() {
-        let context = RebalanceContext(logger: .kafkaTest)
+        let context = RebalanceContext()
 
         context._testInjectEvent(
             RebalanceContext.ConsumerRebalanceEvent(kind: .error("coordinator not available"), partitions: [])
@@ -1079,7 +1034,7 @@ import Foundation
     @Test func rebalanceContextConcurrentInjectAndDrain() async {
         // This tests the core race condition: the C callback thread appends events
         // while the Swift event loop drains them concurrently.
-        let context = RebalanceContext(logger: .kafkaTest)
+        let context = RebalanceContext()
 
         // Use an actor to safely count drained events across tasks
         actor Counter {
@@ -1125,7 +1080,7 @@ import Foundation
 
     @Test func rebalanceContextConcurrentMultipleInjectersAndDrain() async {
         // Multiple "C callback threads" appending simultaneously while event loop drains
-        let context = RebalanceContext(logger: .kafkaTest)
+        let context = RebalanceContext()
         let injectersCount = 5
         let eventsPerInjecter = 50
 
@@ -1172,7 +1127,7 @@ import Foundation
 
     @Test func rebalanceContextFIFOOrderingPreservedUnderConcurrency() async {
         // Verify events from a single injecter maintain FIFO order
-        let context = RebalanceContext(logger: .kafkaTest)
+        let context = RebalanceContext()
         var allDrained: [RebalanceContext.ConsumerRebalanceEvent] = []
 
         // Inject 100 events with sequential partition IDs
@@ -1232,7 +1187,7 @@ import Foundation
 
     @Test func iteratorDropDoesNotCrashServiceGroup() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -1261,7 +1216,7 @@ import Foundation
 
     @Test func iteratorDropThenGracefulShutdownSucceeds() async throws {
         let config = makeConfig()
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -1384,7 +1339,7 @@ import Foundation
         config.groupId = "test-group"
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // This used to cause a fatalError when consumer was in the .initializing state
         consumer.triggerGracefulShutdown()
@@ -1395,26 +1350,8 @@ import Foundation
         config.groupId = "test-group"
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
         try consumer.subscribe(topics: ["test-topic"])
         consumer.triggerGracefulShutdown()
-    }
-
-    @Test func scheduleCommitAllSucceeds() async throws {
-        let config = self.makeConfig(enableAutoCommit: false)
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
-
-        let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
-        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
-
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await serviceGroup.run() }
-            try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
-
-            try consumer.scheduleCommit()
-            try await Task.sleep(for: .milliseconds(1000), tolerance: .zero)
-
-            await serviceGroup.triggerGracefulShutdown()
-        }
     }
 }

--- a/Tests/KafkaTests/KafkaConsumerTests.swift
+++ b/Tests/KafkaTests/KafkaConsumerTests.swift
@@ -69,7 +69,7 @@ import Foundation
         )
         config.debug = [.all]
 
-        let (consumer, _) = try withLogger(mockLogger) { _ in
+        let (consumer, _, _) = try withLogger(mockLogger) { _ in
             try KafkaConsumer.makeConsumer(config: config)
         }
 
@@ -126,14 +126,14 @@ import Foundation
             topics: ["this-topic-does-not-exist"]
         )
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let svcGroupConfig = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: svcGroupConfig)
 
         // explicitly run and cancel message consuming task before serviceGroup.run()
         let consumingTask = Task {
-            for try await record in consumer.messages {
+            for try await record in consumerMsgs {
                 Issue.record("Unexpected record \(record))")
             }
         }
@@ -158,15 +158,15 @@ import Foundation
 
     // MARK: - Closed Consumer State Machine Tests
     //
-    // storeOffset(_:) cannot be unit-tested directly because KafkaConsumerMessage
+    // storeOffset(_:) cannot be unit-tested directly because KafkaConsumer.Message
     // can only be constructed from a real rd_kafka_message_t pointer (requires a broker).
     // All new consumer methods (storeOffset, committed, position, seek, isAssignmentLost)
     // share the same state machine guard (withClient()), so we verify the closed-consumer
-    // path through the methods that don't require a KafkaConsumerMessage.
+    // path through the methods that don't require a KafkaConsumer.Message.
 
     @Test func positionFailsOnClosedConsumerViaStateMachine() async throws {
         let config = makeConfig(enableAutoOffsetStore: false)
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -193,7 +193,7 @@ import Foundation
 
     @Test func subscribedTopicsFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -208,13 +208,13 @@ import Foundation
         }
 
         #expect(throws: KafkaError.self) {
-            try consumer.subscribedTopics()
+            try consumer.subscribedTopics
         }
     }
 
     @Test func subscribeFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -235,7 +235,7 @@ import Foundation
 
     @Test func unsubscribeFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -256,7 +256,7 @@ import Foundation
 
     @Test func subscribeWithEmptyTopicsCallsUnsubscribe() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -281,7 +281,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // subscribe() in .initializing state should not crash
         try consumer.subscribe(topics: ["test-topic"])
@@ -292,10 +292,10 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // No subscription set — should return empty
-        let topics = try consumer.subscribedTopics()
+        let topics = try consumer.subscribedTopics
         #expect(topics.isEmpty)
     }
 
@@ -305,7 +305,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -327,7 +327,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // Subscribe before run
         try consumer.subscribe(topics: ["test-topic"])
@@ -351,7 +351,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // Unsubscribe when never subscribed — should not crash
         try consumer.unsubscribe()
@@ -362,7 +362,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // librdkafka rejects duplicate topics with "Invalid argument"
         #expect(throws: KafkaError.self) {
@@ -375,7 +375,7 @@ import Foundation
         config.groupId = UUID().uuidString
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // Regex pattern subscription — librdkafka supports ^-prefixed patterns
         try consumer.subscribe(topics: ["^test-.*"])
@@ -385,7 +385,7 @@ import Foundation
 
     @Test func pauseFailsOnUnknownPartition() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -408,7 +408,7 @@ import Foundation
 
     @Test func resumeFailsOnUnknownPartition() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -431,7 +431,7 @@ import Foundation
 
     @Test func pauseFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -454,7 +454,7 @@ import Foundation
 
     @Test func resumeFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -498,7 +498,7 @@ import Foundation
 
     @Test func committedFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -523,7 +523,7 @@ import Foundation
 
     @Test func positionFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -549,7 +549,7 @@ import Foundation
 
     @Test func isAssignmentLostFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -571,7 +571,7 @@ import Foundation
 
     @Test func isAssignmentLostReturnsFalseWhenRunning() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -605,7 +605,7 @@ import Foundation
 
     @Test func seekFailsOnClosedConsumer() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -633,7 +633,7 @@ import Foundation
 
     @Test func commitAllFailsWithAutoCommitEnabled() async throws {
         let config = makeConfig(enableAutoCommit: true)
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -652,7 +652,7 @@ import Foundation
 
     @Test func commitAllFailsOnClosedConsumer() async throws {
         let config = makeConfig(enableAutoCommit: false)
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -673,7 +673,7 @@ import Foundation
 
     @Test func makeConsumerConstructDeinit() async throws {
         let config = makeConfig()
-        let (consumer, events) = try KafkaConsumer.makeConsumer(
+        let (consumer, _, events) = try KafkaConsumer.makeConsumer(
             config: config
         )
         _ = consumer
@@ -814,14 +814,14 @@ import Foundation
         #expect(set.count == 2)
     }
 
-    // MARK: - KafkaConsumerRebalance Tests
+    // MARK: - KafkaConsumer.Rebalance Tests
 
     @Test func rebalanceAssignConstruction() {
         let partitions = [
             KafkaTopicPartition(topic: "topic-a", partition: KafkaPartition(rawValue: 0)),
             KafkaTopicPartition(topic: "topic-a", partition: KafkaPartition(rawValue: 1)),
         ]
-        let rebalance = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
+        let rebalance = KafkaConsumer.Rebalance(kind: .assign, partitions: partitions)
         #expect(rebalance.kind == .assign)
         #expect(rebalance.partitions.count == 2)
         #expect(rebalance.partitions[0].topic == "topic-a")
@@ -830,7 +830,7 @@ import Foundation
     }
 
     @Test func rebalanceRevokeConstruction() {
-        let rebalance = KafkaConsumerRebalance(kind: .revoke, partitions: [])
+        let rebalance = KafkaConsumer.Rebalance(kind: .revoke, partitions: [])
         #expect(rebalance.kind == .revoke)
         #expect(rebalance.partitions.isEmpty)
     }
@@ -839,10 +839,10 @@ import Foundation
         let partitions = [
             KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))
         ]
-        let r1 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
-        let r2 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
-        let r3 = KafkaConsumerRebalance(kind: .revoke, partitions: partitions)
-        let r4 = KafkaConsumerRebalance(kind: .assign, partitions: [])
+        let r1 = KafkaConsumer.Rebalance(kind: .assign, partitions: partitions)
+        let r2 = KafkaConsumer.Rebalance(kind: .assign, partitions: partitions)
+        let r3 = KafkaConsumer.Rebalance(kind: .revoke, partitions: partitions)
+        let r4 = KafkaConsumer.Rebalance(kind: .assign, partitions: [])
 
         #expect(r1 == r2)
         #expect(r1 != r3)
@@ -853,11 +853,11 @@ import Foundation
         let partitions = [
             KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))
         ]
-        let r1 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
-        let r2 = KafkaConsumerRebalance(kind: .assign, partitions: partitions)
-        let r3 = KafkaConsumerRebalance(kind: .revoke, partitions: partitions)
+        let r1 = KafkaConsumer.Rebalance(kind: .assign, partitions: partitions)
+        let r2 = KafkaConsumer.Rebalance(kind: .assign, partitions: partitions)
+        let r3 = KafkaConsumer.Rebalance(kind: .revoke, partitions: partitions)
 
-        var set: Set<KafkaConsumerRebalance> = []
+        var set: Set<KafkaConsumer.Rebalance> = []
         set.insert(r1)
         set.insert(r2)
         set.insert(r3)
@@ -865,19 +865,19 @@ import Foundation
     }
 
     @Test func rebalanceKindEquality() {
-        #expect(KafkaConsumerRebalance.Kind.assign == KafkaConsumerRebalance.Kind.assign)
-        #expect(KafkaConsumerRebalance.Kind.revoke == KafkaConsumerRebalance.Kind.revoke)
-        #expect(KafkaConsumerRebalance.Kind.assign != KafkaConsumerRebalance.Kind.revoke)
+        #expect(KafkaConsumer.Rebalance.Kind.assign == KafkaConsumer.Rebalance.Kind.assign)
+        #expect(KafkaConsumer.Rebalance.Kind.revoke == KafkaConsumer.Rebalance.Kind.revoke)
+        #expect(KafkaConsumer.Rebalance.Kind.assign != KafkaConsumer.Rebalance.Kind.revoke)
     }
 
-    // MARK: - KafkaConsumerEvent Rebalance Tests
+    // MARK: - KafkaConsumer.Event Rebalance Tests
 
     @Test func consumerEventRebalancePatternMatch() {
-        let rebalance = KafkaConsumerRebalance(
+        let rebalance = KafkaConsumer.Rebalance(
             kind: .assign,
             partitions: [KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0))]
         )
-        let event = KafkaConsumerEvent.rebalance(rebalance)
+        let event = KafkaConsumer.Event.rebalance(rebalance)
 
         switch event {
         case .rebalance(let r):
@@ -889,14 +889,14 @@ import Foundation
     }
 
     @Test func consumerEventFromConsumerPollEvent() {
-        let rebalance = KafkaConsumerRebalance(
+        let rebalance = KafkaConsumer.Rebalance(
             kind: .revoke,
             partitions: [
                 KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 0)),
                 KafkaTopicPartition(topic: "t", partition: KafkaPartition(rawValue: 1)),
             ]
         )
-        let event = KafkaConsumerEvent.rebalance(rebalance)
+        let event = KafkaConsumer.Event.rebalance(rebalance)
 
         switch event {
         case .rebalance(let r):
@@ -907,10 +907,10 @@ import Foundation
         }
     }
 
-    // MARK: - KafkaConsumerRebalance.Kind.error Tests
+    // MARK: - KafkaConsumer.Rebalance.Kind.error Tests
 
     @Test func rebalanceErrorConstruction() {
-        let rebalance = KafkaConsumerRebalance(kind: .error("broker unavailable"), partitions: [])
+        let rebalance = KafkaConsumer.Rebalance(kind: .error("broker unavailable"), partitions: [])
         #expect(rebalance.partitions.isEmpty)
         if case .error(let description) = rebalance.kind {
             #expect(description == "broker unavailable")
@@ -920,10 +920,10 @@ import Foundation
     }
 
     @Test func rebalanceErrorEquality() {
-        let r1 = KafkaConsumerRebalance(kind: .error("err1"), partitions: [])
-        let r2 = KafkaConsumerRebalance(kind: .error("err1"), partitions: [])
-        let r3 = KafkaConsumerRebalance(kind: .error("err2"), partitions: [])
-        let r4 = KafkaConsumerRebalance(kind: .assign, partitions: [])
+        let r1 = KafkaConsumer.Rebalance(kind: .error("err1"), partitions: [])
+        let r2 = KafkaConsumer.Rebalance(kind: .error("err1"), partitions: [])
+        let r3 = KafkaConsumer.Rebalance(kind: .error("err2"), partitions: [])
+        let r4 = KafkaConsumer.Rebalance(kind: .assign, partitions: [])
 
         #expect(r1 == r2)
         #expect(r1 != r3)
@@ -931,11 +931,11 @@ import Foundation
     }
 
     @Test func rebalanceErrorHashable() {
-        let r1 = KafkaConsumerRebalance(kind: .error("err"), partitions: [])
-        let r2 = KafkaConsumerRebalance(kind: .error("err"), partitions: [])
-        let r3 = KafkaConsumerRebalance(kind: .assign, partitions: [])
+        let r1 = KafkaConsumer.Rebalance(kind: .error("err"), partitions: [])
+        let r2 = KafkaConsumer.Rebalance(kind: .error("err"), partitions: [])
+        let r3 = KafkaConsumer.Rebalance(kind: .assign, partitions: [])
 
-        var set: Set<KafkaConsumerRebalance> = []
+        var set: Set<KafkaConsumer.Rebalance> = []
         set.insert(r1)
         set.insert(r2)
         set.insert(r3)
@@ -943,8 +943,8 @@ import Foundation
     }
 
     @Test func rebalanceErrorEventPatternMatch() {
-        let rebalance = KafkaConsumerRebalance(kind: .error("group coordinator not available"), partitions: [])
-        let event = KafkaConsumerEvent.rebalance(rebalance)
+        let rebalance = KafkaConsumer.Rebalance(kind: .error("group coordinator not available"), partitions: [])
+        let event = KafkaConsumer.Event.rebalance(rebalance)
 
         switch event {
         case .rebalance(let r):
@@ -1158,11 +1158,11 @@ import Foundation
         }
     }
 
-    // MARK: - KafkaConsumerEvent.error Tests
+    // MARK: - KafkaConsumer.Event.error Tests
 
     @Test func consumerEventErrorPatternMatch() {
         let error = KafkaError.config(reason: "All brokers are down")
-        let event = KafkaConsumerEvent.error(error)
+        let event = KafkaConsumer.Event.error(error)
 
         switch event {
         case .error(let e):
@@ -1176,8 +1176,8 @@ import Foundation
         let error1 = KafkaError.config(reason: "All brokers are down")
         let error2 = KafkaError.config(reason: "Authentication failed")
 
-        let event1 = KafkaConsumerEvent.error(error1)
-        let event2 = KafkaConsumerEvent.error(error2)
+        let event1 = KafkaConsumer.Event.error(error1)
+        let event2 = KafkaConsumer.Event.error(error2)
 
         // Same error code (.config), so they are equal per current Equatable (known limitation)
         #expect(event1 == event2)
@@ -1187,7 +1187,7 @@ import Foundation
 
     @Test func iteratorDropDoesNotCrashServiceGroup() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -1199,7 +1199,7 @@ import Foundation
 
             // Start consuming messages in a separate task, then drop the iterator
             group.addTask {
-                for try await _ in consumer.messages {
+                for try await _ in consumerMsgs {
                     break  // immediately drop the iterator
                 }
             }
@@ -1216,7 +1216,7 @@ import Foundation
 
     @Test func iteratorDropThenGracefulShutdownSucceeds() async throws {
         let config = makeConfig()
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -1229,7 +1229,7 @@ import Foundation
             try await Task.sleep(for: .milliseconds(500), tolerance: .zero)
 
             // Drop the iterator by creating and immediately discarding it
-            var iterator: KafkaConsumerMessages.AsyncIterator? = consumer.messages.makeAsyncIterator()
+            var iterator: KafkaConsumer.Messages.AsyncIterator? = consumerMsgs.makeAsyncIterator()
             _ = iterator
             iterator = nil
 
@@ -1339,7 +1339,7 @@ import Foundation
         config.groupId = "test-group"
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         // This used to cause a fatalError when consumer was in the .initializing state
         consumer.triggerGracefulShutdown()
@@ -1350,7 +1350,7 @@ import Foundation
         config.groupId = "test-group"
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
         try consumer.subscribe(topics: ["test-topic"])
         consumer.triggerGracefulShutdown()
     }

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -52,7 +52,7 @@ final class KafkaMetricsTests {
         config.useMockBroker()
         config.brokerAddressFamily = .v4
 
-        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, _, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let svcGroupConfig = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: svcGroupConfig)

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -52,7 +52,7 @@ final class KafkaMetricsTests {
         config.useMockBroker()
         config.brokerAddressFamily = .v4
 
-        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
+        let (consumer, consumerMsgs, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let svcGroupConfig = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: svcGroupConfig)

--- a/Tests/KafkaTests/KafkaMetricsTests.swift
+++ b/Tests/KafkaTests/KafkaMetricsTests.swift
@@ -52,7 +52,7 @@ final class KafkaMetricsTests {
         config.useMockBroker()
         config.brokerAddressFamily = .v4
 
-        let consumer = try KafkaConsumer(config: config, logger: .kafkaTest)
+        let (consumer, _) = try KafkaConsumer.makeConsumer(config: config)
 
         let svcGroupConfig = ServiceGroupConfiguration(services: [consumer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: svcGroupConfig)
@@ -80,9 +80,8 @@ final class KafkaMetricsTests {
         config.metrics.updateInterval = .milliseconds(100)
         config.metrics.queuedOperation = .init(label: "operations")
 
-        let producer = try KafkaProducer(
-            config: config,
-            logger: .kafkaTest
+        let (producer, _) = try KafkaProducer.makeProducer(
+            config: config
         )
 
         let svcGroupConfig = ServiceGroupConfiguration(services: [producer], logger: .kafkaTest)

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -50,7 +50,7 @@ import Foundation
 
             let expectedTopic = "test-topic"
             let headers = [KafkaHeader(key: "some", value: ByteBuffer.init(string: "test"))]
-            let message = KafkaProducerMessage(
+            let message = KafkaProducer.Message(
                 topic: expectedTopic,
                 headers: headers,
                 key: "key",
@@ -59,7 +59,7 @@ import Foundation
 
             let messageID = try producer.send(message)
 
-            var receivedDeliveryReports = Set<KafkaDeliveryReport>()
+            var receivedDeliveryReports = Set<KafkaProducer.DeliveryReport>()
 
             for await event in events {
                 switch event {
@@ -109,14 +109,14 @@ import Foundation
             }
 
             let expectedTopic = "test-topic"
-            let message = KafkaProducerMessage(
+            let message = KafkaProducer.Message(
                 topic: expectedTopic,
                 value: ByteBuffer()
             )
 
             let messageID = try producer.send(message)
 
-            var receivedDeliveryReports = Set<KafkaDeliveryReport>()
+            var receivedDeliveryReports = Set<KafkaProducer.DeliveryReport>()
 
             for await event in events {
                 switch event {
@@ -163,23 +163,23 @@ import Foundation
                 try await serviceGroup.run()
             }
 
-            let message1 = KafkaProducerMessage(
+            let message1 = KafkaProducer.Message(
                 topic: "test-topic1",
                 key: "key1",
                 value: "Hello, Munich!"
             )
-            let message2 = KafkaProducerMessage(
+            let message2 = KafkaProducer.Message(
                 topic: "test-topic2",
                 key: "key2",
                 value: "Hello, London!"
             )
 
-            var messageIDs = Set<KafkaProducerMessageID>()
+            var messageIDs = Set<KafkaProducer.MessageID>()
 
             messageIDs.insert(try producer.send(message1))
             messageIDs.insert(try producer.send(message2))
 
-            var receivedDeliveryReports = Set<KafkaDeliveryReport>()
+            var receivedDeliveryReports = Set<KafkaProducer.DeliveryReport>()
 
             for await event in events {
                 switch event {
@@ -198,7 +198,7 @@ import Foundation
 
             #expect(Set(receivedDeliveryReports.map(\.id)) == messageIDs)
 
-            let acknowledgedMessages: [KafkaAcknowledgedMessage] = receivedDeliveryReports.compactMap {
+            let acknowledgedMessages: [KafkaProducer.AcknowledgedMessage] = receivedDeliveryReports.compactMap {
                 guard case .acknowledged(let receivedMessage) = $0.status else {
                     return nil
                 }
@@ -278,12 +278,12 @@ import Foundation
                 try await serviceGroup.run()
             }
 
-            let message1 = KafkaProducerMessage(
+            let message1 = KafkaProducer.Message(
                 topic: "test-topic1",
                 key: "key1",
                 value: "Hello, Cupertino!"
             )
-            let message2 = KafkaProducerMessage(
+            let message2 = KafkaProducer.Message(
                 topic: "test-topic2",
                 key: "key2",
                 value: "Hello, San Diego!"
@@ -292,7 +292,7 @@ import Foundation
             try producer.send(message1)
 
             // Terminate the events sequence by deallocating its AsyncIterator
-            var iterator: KafkaProducerEvents.AsyncIterator? = events.makeAsyncIterator()
+            var iterator: KafkaProducer.Events.AsyncIterator? = events.makeAsyncIterator()
             _ = iterator
             iterator = nil
 
@@ -307,7 +307,7 @@ import Foundation
 
     @Test func noMemoryLeakAfterShutdown() async throws {
         var producer: KafkaProducer?
-        var events: KafkaProducerEvents?
+        var events: KafkaProducer.Events?
         (producer, events) = try KafkaProducer.makeProducer(config: self.config)
         _ = events
 
@@ -377,11 +377,11 @@ import Foundation
         }
     }
 
-    // MARK: - KafkaProducerEvent.error Tests
+    // MARK: - KafkaProducer.Event.error Tests
 
     @Test func producerEventErrorPatternMatch() {
         let error = KafkaError.config(reason: "Authentication failed")
-        let event = KafkaProducerEvent.error(error)
+        let event = KafkaProducer.Event.error(error)
 
         switch event {
         case .error(let e):

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -35,9 +35,8 @@ import Foundation
     }
 
     @Test func send() async throws {
-        let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-            config: self.config,
-            logger: .kafkaTest
+        let (producer, events) = try KafkaProducer.makeProducer(
+            config: self.config
         )
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [producer], logger: .kafkaTest)
@@ -96,9 +95,8 @@ import Foundation
     }
 
     @Test func sendEmptyMessage() async throws {
-        let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-            config: self.config,
-            logger: .kafkaTest
+        let (producer, events) = try KafkaProducer.makeProducer(
+            config: self.config
         )
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [producer], logger: .kafkaTest)
@@ -152,9 +150,8 @@ import Foundation
     }
 
     @Test func sendTwoTopics() async throws {
-        let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-            config: self.config,
-            logger: .kafkaTest
+        let (producer, events) = try KafkaProducer.makeProducer(
+            config: self.config
         )
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [producer], logger: .kafkaTest)
@@ -230,7 +227,9 @@ import Foundation
         // Set no bootstrap servers to trigger librdkafka configuration warning
         let config = KafkaProducerConfig()
 
-        let producer = try KafkaProducer(config: config, logger: mockLogger)
+        let (producer, _) = try withLogger(mockLogger) { _ in
+            try KafkaProducer.makeProducer(config: config)
+        }
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [producer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
@@ -265,10 +264,9 @@ import Foundation
         #expect(expectedSource == receivedEvent.source)
     }
 
-    @Test func sendFailsAfterTerminatingAcknowledgementSequence() async throws {
-        let (producer, events) = try KafkaProducer.makeProducerWithEvents(
-            config: self.config,
-            logger: .kafkaTest
+    @Test func sendSucceedsAfterTerminatingAcknowledgementSequence() async throws {
+        let (producer, events) = try KafkaProducer.makeProducer(
+            config: self.config
         )
 
         let serviceGroupConfiguration = ServiceGroupConfiguration(services: [producer], logger: .kafkaTest)
@@ -298,11 +296,9 @@ import Foundation
             _ = iterator
             iterator = nil
 
-            // Sending a new message should fail after the events sequence
+            // Sending a new message should succeed even after the events sequence
             // has been terminated
-            #expect(throws: KafkaError.connectionClosed(reason: "reason")) {
-                try producer.send(message2)
-            }
+            try producer.send(message2)
 
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
@@ -312,7 +308,7 @@ import Foundation
     @Test func noMemoryLeakAfterShutdown() async throws {
         var producer: KafkaProducer?
         var events: KafkaProducerEvents?
-        (producer, events) = try KafkaProducer.makeProducerWithEvents(config: self.config, logger: .kafkaTest)
+        (producer, events) = try KafkaProducer.makeProducer(config: self.config)
         _ = events
 
         weak var producerCopy: KafkaProducer?
@@ -342,16 +338,16 @@ import Foundation
         let config = KafkaProducerConfig()
 
         // deinit called before run
-        _ = try KafkaProducer(config: config, logger: .kafkaTest)
+        _ = try KafkaProducer.makeProducer(config: config)
 
         // deinit called before run
-        _ = try KafkaProducer.makeProducerWithEvents(config: config, logger: .kafkaTest)
+        _ = try KafkaProducer.makeProducer(config: config)
     }
 
     @Test func producerEventsReadCancelledBeforeRun() async throws {
         let config = KafkaProducerConfig()
 
-        let (producer, events) = try KafkaProducer.makeProducerWithEvents(config: config, logger: .kafkaTest)
+        let (producer, events) = try KafkaProducer.makeProducer(config: config)
 
         let svcGroupConfig = ServiceGroupConfiguration(services: [producer], logger: .kafkaTest)
         let serviceGroup = ServiceGroup(configuration: svcGroupConfig)

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -48,7 +48,7 @@ import Foundation
                 try await serviceGroup.run()
             }
 
-            let expectedTopic = "test-topic"
+            let expectedTopic: KafkaTopic = "test-topic"
             let headers = [KafkaHeader(key: "some", value: ByteBuffer.init(string: "test"))]
             let message = KafkaProducer.Message(
                 topic: expectedTopic,
@@ -108,7 +108,7 @@ import Foundation
                 try await serviceGroup.run()
             }
 
-            let expectedTopic = "test-topic"
+            let expectedTopic: KafkaTopic = "test-topic"
             let message = KafkaProducer.Message(
                 topic: expectedTopic,
                 value: ByteBuffer()

--- a/Tests/KafkaTests/KafkaProducerTests.swift
+++ b/Tests/KafkaTests/KafkaProducerTests.swift
@@ -49,7 +49,7 @@ import Foundation
             }
 
             let expectedTopic: KafkaTopic = "test-topic"
-            let headers = [KafkaHeader(key: "some", value: ByteBuffer.init(string: "test"))]
+            let headers = [KafkaHeader(key: "some", value: Array("test".utf8))]
             let message = KafkaProducer.Message(
                 topic: expectedTopic,
                 headers: headers,

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -3,3 +3,19 @@ API breakage: enumelement KafkaConsumerEvent.error has been added as a new enum 
 API breakage: enumelement KafkaProducerEvent.error has been added as a new enum case
 API breakage: var KafkaConfiguration.ConsumerMetrics.totalKafkaBrokerMessagesRecieved has been removed
 API breakage: var KafkaConfiguration.ConsumerMetrics.totalKafkaBrokerMessagesBytesRecieved has been removed
+API breakage: constructor KafkaConsumer.init(configuration:logger:) has been removed
+API breakage: func KafkaConsumer.makeConsumerWithEvents(configuration:logger:) has been removed
+API breakage: func KafkaConsumer.commitSync(_:) has been removed
+API breakage: func KafkaConsumer.commit() has been renamed to func commitStoredOffsets()
+API breakage: constructor KafkaProducer.init(configuration:logger:) has been removed
+API breakage: func KafkaProducer.makeProducerWithEvents(configuration:logger:) has been removed
+API breakage: func RDKafkaClient.makeClientForTopics(config:logger:) has been renamed to func makeClientForTopics(config:)
+API breakage: func RDKafkaClient.makeClientForTopics(config:logger:) has been removed
+API breakage: constructor KafkaConsumer.init(config:logger:) has been removed
+API breakage: func KafkaConsumer.scheduleCommit(_:) has been removed
+API breakage: func KafkaConsumer.scheduleCommit() has been removed
+API breakage: func KafkaConsumer.makeConsumerWithEvents(config:logger:) has been renamed to func makeConsumer(config:)
+API breakage: func KafkaConsumer.triggerGracefulShutdown() has been removed
+API breakage: constructor KafkaProducer.init(config:logger:) has been removed
+API breakage: func KafkaProducer.makeProducerWithEvents(config:logger:) has been renamed to func makeProducer(config:)
+API breakage: func KafkaProducer.triggerGracefulShutdown() has been removed

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -43,3 +43,16 @@ API breakage: struct KafkaProducerEvents has been removed
 API breakage: enum KafkaProducerEvent has been removed
 API breakage: struct KafkaProducerMessage has been removed
 API breakage: struct KafkaProducerMessageID has been removed
+API breakage: func KafkaConsumer.subscribe(topics:) has parameter 0 type change from [Swift.String] to [Kafka.KafkaTopic]
+API breakage: func KafkaConsumerConfiguration.ConsumptionStrategy.partition(_:groupID:topic:offset:) has parameter 2 type change from Swift.String to Kafka.KafkaTopic
+API breakage: func KafkaConsumerConfiguration.ConsumptionStrategy.group(id:topics:) has parameter 1 type change from [Swift.String] to [Kafka.KafkaTopic]
+API breakage: var KafkaTopicPartition.topic has declared type change from Swift.String to Kafka.KafkaTopic
+API breakage: accessor KafkaTopicPartition.topic.Get() has return type change from Swift.String to Kafka.KafkaTopic
+API breakage: accessor KafkaTopicPartition.topic.Set() has parameter 0 type change from Swift.String to Kafka.KafkaTopic
+API breakage: constructor KafkaTopicPartition.init(topic:partition:) has parameter 0 type change from Swift.String to Kafka.KafkaTopic
+API breakage: var KafkaTopicPartitionOffset.topic has declared type change from Swift.String to Kafka.KafkaTopic
+API breakage: accessor KafkaTopicPartitionOffset.topic.Get() has return type change from Swift.String to Kafka.KafkaTopic
+API breakage: constructor KafkaTopicPartitionOffset.init(topic:partition:offset:) has parameter 0 type change from Swift.String to Kafka.KafkaTopic
+API breakage: func _createTestMessages(topic:headers:count:) has parameter 0 type change from Swift.String to Kafka.KafkaTopic
+API breakage: func RDKafkaClient._createUniqueTopic(partitions:) has return type change from Swift.String to Kafka.KafkaTopic
+API breakage: func RDKafkaClient._deleteTopic(_:) has parameter 0 type change from Swift.String to Kafka.KafkaTopic

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -19,3 +19,27 @@ API breakage: func KafkaConsumer.triggerGracefulShutdown() has been removed
 API breakage: constructor KafkaProducer.init(config:logger:) has been removed
 API breakage: func KafkaProducer.makeProducerWithEvents(config:logger:) has been renamed to func makeProducer(config:)
 API breakage: func KafkaProducer.triggerGracefulShutdown() has been removed
+API breakage: func _createTestMessages(topic:headers:count:) has return type change from [Kafka.KafkaProducerMessage<Swift.String, Swift.String>] to [Kafka.KafkaProducer.Message<Swift.String, Swift.String>]
+API breakage: func _sendAndAcknowledgeMessages(producer:events:messages:skipConsistencyCheck:) has parameter 1 type change from Kafka.KafkaProducerEvents to Kafka.KafkaProducer.Events
+API breakage: func _sendAndAcknowledgeMessages(producer:events:messages:skipConsistencyCheck:) has parameter 2 type change from [Kafka.KafkaProducerMessage<Swift.String, Swift.String>] to [Kafka.KafkaProducer.Message<Swift.String, Swift.String>]
+API breakage: func KafkaConsumer.storeOffset(_:) has parameter 0 type change from Kafka.KafkaConsumerMessage to Kafka.KafkaConsumer.Message
+API breakage: func KafkaConsumer.commit(_:) has parameter 0 type change from Kafka.KafkaConsumerMessage to Kafka.KafkaConsumer.Message
+API breakage: func KafkaConsumer.makeConsumerWithEvents(config:logger:) has return type change from (Kafka.KafkaConsumer, Kafka.KafkaConsumerEvents) to (consumer: Kafka.KafkaConsumer, messages: Kafka.KafkaConsumer.Messages, events: Kafka.KafkaConsumer.Events)
+API breakage: func KafkaProducer.send(_:) has return type change from Kafka.KafkaProducerMessageID to Kafka.KafkaProducer.MessageID
+API breakage: func KafkaProducer.send(_:) has parameter 0 type change from Kafka.KafkaProducerMessage<Key, Value> to Kafka.KafkaProducer.Message<Key, Value>
+API breakage: func KafkaProducer.sendAndAwait(_:) has return type change from Kafka.KafkaDeliveryReport to Kafka.KafkaProducer.DeliveryReport
+API breakage: func KafkaProducer.sendAndAwait(_:) has parameter 0 type change from Kafka.KafkaProducerMessage<Key, Value> to Kafka.KafkaProducer.Message<Key, Value>
+API breakage: func KafkaProducer.makeProducerWithEvents(config:logger:) has return type change from (Kafka.KafkaProducer, Kafka.KafkaProducerEvents) to (producer: Kafka.KafkaProducer, events: Kafka.KafkaProducer.Events)
+API breakage: struct KafkaAcknowledgedMessage has been removed
+API breakage: struct KafkaConsumerEvents has been removed
+API breakage: struct KafkaConsumerMessages has been removed
+API breakage: var KafkaConsumer.messages has been removed
+API breakage: func KafkaConsumer.subscribedTopics() has been removed
+API breakage: enum KafkaConsumerEvent has been removed
+API breakage: struct KafkaConsumerMessage has been removed
+API breakage: struct KafkaConsumerRebalance has been removed
+API breakage: struct KafkaDeliveryReport has been removed
+API breakage: struct KafkaProducerEvents has been removed
+API breakage: enum KafkaProducerEvent has been removed
+API breakage: struct KafkaProducerMessage has been removed
+API breakage: struct KafkaProducerMessageID has been removed

--- a/api-breakages.txt
+++ b/api-breakages.txt
@@ -56,3 +56,8 @@ API breakage: constructor KafkaTopicPartitionOffset.init(topic:partition:offset:
 API breakage: func _createTestMessages(topic:headers:count:) has parameter 0 type change from Swift.String to Kafka.KafkaTopic
 API breakage: func RDKafkaClient._createUniqueTopic(partitions:) has return type change from Swift.String to Kafka.KafkaTopic
 API breakage: func RDKafkaClient._deleteTopic(_:) has parameter 0 type change from Swift.String to Kafka.KafkaTopic
+API breakage: var KafkaHeader.value has declared type change from NIOCore.ByteBuffer? to [Swift.UInt8]?
+API breakage: accessor KafkaHeader.value.Get() has return type change from NIOCore.ByteBuffer? to [Swift.UInt8]?
+API breakage: accessor KafkaHeader.value.Set() has parameter 0 type change from NIOCore.ByteBuffer? to [Swift.UInt8]?
+API breakage: constructor KafkaHeader.init(key:value:) has parameter 1 type change from NIOCore.ByteBuffer? to [Swift.UInt8]?
+API breakage: constructor KafkaTimestampType.init(rawValue:) has been removed


### PR DESCRIPTION
## 1.0 Beta API changes — consumer and producer

### Consumer

- Single construction path: `makeConsumer(config:logger:) -> (consumer:, events:)`. Removed the plain `init` and `makeConsumerWithEvents`.
- Removed `scheduleCommit(_:)` / `scheduleCommit()` — silently dropped errors. Use `Task { try? await consumer.commit(msg) }` instead.
- Renamed `commit()` → `commitStoredOffsets()`. `commit(_:)` unchanged.
- Removed deprecated pass-throughs: `init(configuration:)`, `makeConsumerWithEvents(configuration:)`, `commitSync(_:)`.

### Producer

- Single construction path: `makeProducer(config:logger:) -> (producer:, events:)`. Removed the plain `init` and `makeProducerWithEvents`.
- Fixed duplicate delivery reports: `sendAndAwait(_:)` reports now resolve only the awaiting call, no longer also emitted on `KafkaProducerEvents`.
- Removed deprecated pass-throughs: `init(configuration:)`, `makeProducerWithEvents(configuration:)`.
