### PR TITLE
Raise minimum Swift toolchain to 6.2.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
     name: Unit tests
     uses: ./.github/workflows/unit_tests.yml
     with:
-      linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -40,6 +40,13 @@ jobs:
         env:
           MATRIX_LINUX_COMMAND: "curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check-cxx-interop-compatibility.sh | bash"
           MATRIX_LINUX_SETUP_COMMAND: "apt-get update -y -q && apt-get install -y -q curl jq libsasl2-dev libssl-dev"
+          # Pin the matrix floor to the major.minor toolchain. Package.swift
+          # declares swift-tools-version:6.2.3, which generate_matrix.sh would
+          # otherwise auto-detect and use to drop the "6.2" image — its coarse
+          # label (6.2.0) is below 6.2.3, even though swift:6.2-noble is 6.2.4 and
+          # satisfies the requirement. A 6.2 floor keeps the 6.2 job and still
+          # excludes 6.1.
+          MATRIX_MIN_SWIFT_VERSION: "6.2"
 
   cxx-interop:
     name: Cxx interop

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,6 @@ jobs:
     name: Unit tests
     uses: ./.github/workflows/unit_tests.yml
     with:
-      linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -6,14 +6,6 @@ permissions:
 on:
   workflow_call:
     inputs:
-      linux_6_1_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 6.1 Swift version matrix job. Defaults to true."
-        default: true
-      linux_6_1_arguments_override:
-        type: string
-        description: "The arguments passed to swift build in the Linux 6.1 Swift version matrix job."
-        default: ""
       linux_6_2_enabled:
         type: boolean
         description: "Boolean to enable the Linux 6.2 Swift version matrix job. Defaults to true."
@@ -56,9 +48,6 @@ jobs:
       matrix:
         # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
         swift:
-          - image: "swift:6.1-jammy"
-            swift_version: "6.1"
-            enabled: ${{ inputs.linux_6_1_enabled }}
           - image: "swift:6.2-noble"
             swift_version: "6.2"
             enabled: ${{ inputs.linux_6_2_enabled }}
@@ -87,7 +76,6 @@ jobs:
         env:
           SWIFT_VERSION: ${{ matrix.swift.swift_version }}
           COMMAND: "swift build -c release"
-          COMMAND_OVERRIDE_6_1: "swift build -c release ${{ inputs.linux_6_1_arguments_override }}"
           COMMAND_OVERRIDE_6_2: "swift build -c release ${{ inputs.linux_6_2_arguments_override }}"
           COMMAND_OVERRIDE_6_3: "swift build -c release ${{ inputs.linux_6_3_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_NEXT: "swift build -c release ${{ inputs.linux_nightly_next_arguments_override }}"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,14 +6,6 @@ permissions:
 on:
   workflow_call:
     inputs:
-      linux_6_1_enabled:
-        type: boolean
-        description: "Boolean to enable the Linux 6.1 Swift version matrix job. Defaults to true."
-        default: true
-      linux_6_1_arguments_override:
-        type: string
-        description: "The arguments passed to swift test in the Linux 6.1 Swift version matrix job."
-        default: ""
       linux_6_2_enabled:
         type: boolean
         description: "Boolean to enable the Linux 6.2 Swift version matrix job. Defaults to true."
@@ -56,9 +48,6 @@ jobs:
       matrix:
         # We are specifying only the major and minor of the docker images to automatically pick up the latest patch release
         swift:
-          - image: "swift:6.1-jammy"
-            swift_version: "6.1"
-            enabled: ${{ inputs.linux_6_1_enabled }}
           - image: "swift:6.2-jammy"
             swift_version: "6.2"
             enabled: ${{ inputs.linux_6_2_enabled }}
@@ -87,7 +76,6 @@ jobs:
         env:
           SWIFT_VERSION: ${{ matrix.swift.swift_version }}
           COMMAND: "swift test"
-          COMMAND_OVERRIDE_6_1: "swift test ${{ inputs.linux_6_1_arguments_override }}"
           COMMAND_OVERRIDE_6_2: "swift test ${{ inputs.linux_6_2_arguments_override }}"
           COMMAND_OVERRIDE_6_3: "swift test ${{ inputs.linux_6_3_arguments_override }}"
           COMMAND_OVERRIDE_NIGHTLY_NEXT: "swift test ${{ inputs.linux_nightly_next_arguments_override }}"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2.3
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the swift-kafka-client open source project

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG swift_version=6.1
+ARG swift_version=6.2
 ARG ubuntu_version=jammy
 FROM swift:${swift_version}-${ubuntu_version}
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,11 +29,11 @@ services:
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   client:
-    image: swift-kafka-client:${IMAGE_TAG:-local-${SWIFT_VERSION:-6.1}-${UBUNTU_VERSION:-jammy}-${IMAGE_PLATFORM:-amd64}}
+    image: swift-kafka-client:${IMAGE_TAG:-local-${SWIFT_VERSION:-6.2}-${UBUNTU_VERSION:-jammy}-${IMAGE_PLATFORM:-amd64}}
     build:
       args:
         ubuntu_version: "${UBUNTU_VERSION:-jammy}"
-        swift_version: "${SWIFT_VERSION:-6.1}"
+        swift_version: "${SWIFT_VERSION:-6.2}"
       platforms:
         - linux/${IMAGE_PLATFORM:-amd64}
     depends_on: [kafka]


### PR DESCRIPTION
Bumps `swift-tools-version` to 6.2.3 and drops the Swift 6.1 matrix jobsfrom the unit-test and release-build workflows (and their callers). Docker dev defaults updated to 6.2.

6.2.3 is required to adopt the `@nonexhaustive` enum attribute (SE-0487) on the consumer/producer event enums. This PR is intentionally scoped to just the toolchain bump so it can land first; the `@nonexhaustive` adoption and the rest of the 1.0 Beta API changes follow in #250.