### PR TITLE
Add pull request benchmarks for allocations and instructions

### DIFF
--- a/.github/workflows/benchmark-mock.yml
+++ b/.github/workflows/benchmark-mock.yml
@@ -1,0 +1,37 @@
+name: Mock-cluster benchmark
+
+permissions:
+  contents: read
+
+# Manual only: the librdkafka mock-cluster produce benchmark. It's a full
+# in-process broker (its own threads, timing-dependent batching), too noisy for
+# threshold gating, so it lives here on a manual trigger to inspect the produce
+# path on demand — it never runs on pull requests. Enabled via
+# KAFKA_MOCK_BENCHMARK; no thresholds are checked.
+on:
+  workflow_dispatch:
+
+jobs:
+  mock-benchmark:
+    name: Mock-cluster produce benchmark
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.2-noble
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          submodules: true
+      - name: Install dependencies
+        run: |
+          apt-get -q update
+          apt-get -y install libjemalloc-dev libsasl2-dev libssl-dev
+      - name: Mark the workspace as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+      - name: Run the mock-cluster produce benchmark
+        env:
+          KAFKA_MOCK_BENCHMARK: "1"
+        run: |
+          cd Benchmarks
+          swift package --disable-sandbox benchmark --target SwiftKafkaMockBenchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,54 @@
+name: Benchmarks
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "**.swift"
+      - "**.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # PR gate: the deterministic, broker-free micro-benchmarks, checked against the
+  # committed per-Swift-version absolute thresholds in Benchmarks/Thresholds/. The
+  # noisy mock-cluster produce benchmark is not gated here; it lives in
+  # benchmark-mock.yml on a manual trigger and never runs on pull requests.
+  construct-benchmark-matrix:
+    name: Construct Benchmarks matrix
+    runs-on: ubuntu-latest
+    outputs:
+      benchmark-matrix: "${{ steps.generate-matrix.outputs.benchmark-matrix }}"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - id: generate-matrix
+        run: echo "benchmark-matrix=$(curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/generate_matrix.sh | bash)" >> "$GITHUB_OUTPUT"
+        env:
+          # Reuse NIO's benchmark threshold-check script. libsasl2-dev/libssl-dev
+          # are needed to build librdkafka; libjemalloc-dev is needed for the
+          # package-benchmark malloc metrics; jq/curl are needed by the scripts.
+          MATRIX_LINUX_COMMAND: "curl -s https://raw.githubusercontent.com/apple/swift-nio/main/scripts/check_benchmark_thresholds.sh | BENCHMARK_PACKAGE_PATH=Benchmarks bash -s -- --disable-sandbox"
+          MATRIX_LINUX_SETUP_COMMAND: "swift --version && apt-get update -y -q && apt-get install -y -q curl jq libjemalloc-dev libsasl2-dev libssl-dev && git config --global --add safe.directory /$(basename ${{ github.workspace }})"
+          # nightly-main is excluded (Swift development trunk, too volatile for
+          # stable baselines) and 6.1 is excluded (no longer supported). The gate
+          # covers 6.2, 6.3, and nightly-next.
+          MATRIX_LINUX_NIGHTLY_MAIN_ENABLED: false
+          MATRIX_LINUX_6_1_ENABLED: false
+
+  benchmarks:
+    name: Benchmarks
+    needs: construct-benchmark-matrix
+    uses: apple/swift-nio/.github/workflows/swift_test_matrix.yml@main
+    with:
+      name: "Benchmarks"
+      matrix_string: "${{ needs.construct-benchmark-matrix.outputs.benchmark-matrix }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /.build
 /Benchmarks/.build
+/Benchmarks/.benchmarkBaselines
 /Packages
 /*.xcodeproj
 xcuserdata/
@@ -9,3 +10,4 @@ DerivedData/
 Package.resolved
 .*.sw?
 .swiftpm
+.idea/

--- a/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/KafkaConsumerBenchmark.swift
+++ b/Benchmarks/Benchmarks/SwiftKafkaConsumerBenchmarks/KafkaConsumerBenchmark.swift
@@ -20,9 +20,18 @@ import Logging
 import ServiceLifecycle
 
 import struct Foundation.Date
+import class Foundation.ProcessInfo
 import struct Foundation.UUID
 
 let benchmarks: @Sendable () -> Void = {
+    // These benchmarks talk to a real Kafka broker (localhost:9092), so they are
+    // opt-in: unless `KAFKA_LIVE_BENCHMARKS` is set they register nothing. This
+    // keeps them out of the benchmark CI (which has no broker) while remaining
+    // runnable locally/nightly against a live broker.
+    guard ProcessInfo.processInfo.environment["KAFKA_LIVE_BENCHMARKS"] != nil else {
+        return
+    }
+
     var uniqueTestTopic: String!
     let messageCount: UInt = 1000
 

--- a/Benchmarks/Benchmarks/SwiftKafkaMicroBenchmarks/MicroBenchmarks.swift
+++ b/Benchmarks/Benchmarks/SwiftKafkaMicroBenchmarks/MicroBenchmarks.swift
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2025 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import Kafka
+import NIOCore
+
+// Deterministic, broker-free micro-benchmarks that measure per-operation
+// allocations and CPU instructions for the library's hot paths. Because these
+// don't touch a broker or the network, their allocation/instruction counts are
+// reproducible, which makes them suitable for gating on every pull request.
+//
+// The threshold tolerances below are compared against the base branch by the
+// benchmark CI workflow; allocation/retain counts are deterministic for
+// pure-Swift paths, so any change is treated as a real regression.
+
+let benchmarks: @Sendable () -> Void = {
+    Benchmark.defaultConfiguration = .init(
+        metrics: [
+            .mallocCountTotal,
+            .objectAllocCount,
+            .instructions,
+        ],
+        warmupIterations: 1,
+        scalingFactor: .kilo,
+        maxDuration: .seconds(5),
+        maxIterations: 100,
+        thresholds: [
+            // Gate only on the allocation counts, with a small *absolute*
+            // tolerance (the swift-nio approach). Absolute rather than relative
+            // because the smallest benchmarks have near-zero counts where a
+            // percentage is meaningless. The retain/release counts are
+            // intentionally not measured: they have run-to-run jitter unrelated to
+            // real allocation changes. Instructions are only recorded where perf
+            // is available (not on the Linux CI runners).
+            .mallocCountTotal: .init(absolute: [.p90: 10]),
+            .objectAllocCount: .init(absolute: [.p90: 10]),
+            .instructions: .init(relative: [.p90: 5]),
+        ]
+    )
+
+    let topic = "benchmark-topic"
+
+    // MARK: - Producer message construction (P1–P3)
+    //
+    // `KafkaProducerMessage` is generic over `KafkaContiguousBytes`, so the same
+    // construction is measured for each supported payload representation. Each
+    // has a different `withUnsafeBytes` cost downstream, but here we isolate the
+    // message-value allocation itself.
+
+    Benchmark("ProducerMessage_build_UInt8_256B") { benchmark in
+        let key: [UInt8] = Array("benchmark-key".utf8)
+        let value = [UInt8](repeating: 0xAB, count: 256)
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            blackHole(KafkaProducerMessage(topic: topic, key: key, value: value))
+        }
+        benchmark.stopMeasurement()
+    }
+
+    Benchmark("ProducerMessage_build_ByteBuffer_256B") { benchmark in
+        let key = ByteBuffer(string: "benchmark-key")
+        let value = ByteBuffer(repeating: 0xAB, count: 256)
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            blackHole(KafkaProducerMessage(topic: topic, key: key, value: value))
+        }
+        benchmark.stopMeasurement()
+    }
+
+    Benchmark("ProducerMessage_build_String_256B") { benchmark in
+        let key = "benchmark-key"
+        let value = String(repeating: "a", count: 256)
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            blackHole(KafkaProducerMessage(topic: topic, key: key, value: value))
+        }
+        benchmark.stopMeasurement()
+    }
+
+    // MARK: - Message with headers (S3)
+
+    Benchmark("ProducerMessage_build_8_headers") { benchmark in
+        let value = [UInt8](repeating: 0xAB, count: 64)
+        let headerKeys = (0..<8).map { "header-\($0)" }
+        let headerValue = ByteBuffer(string: "header-value")
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            var headers: [KafkaHeader] = []
+            headers.reserveCapacity(headerKeys.count)
+            for headerKey in headerKeys {
+                headers.append(KafkaHeader(key: headerKey, value: headerValue))
+            }
+            blackHole(KafkaProducerMessage(topic: topic, headers: headers, value: value))
+        }
+        benchmark.stopMeasurement()
+    }
+
+    // MARK: - Topic-partition input lists (S1–S2)
+    //
+    // Commit/seek/assign build these lists per call, one entry per partition.
+
+    Benchmark("KafkaTopicPartition_list_100") { benchmark in
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            var list: [KafkaTopicPartition] = []
+            list.reserveCapacity(100)
+            for partition in 0..<100 {
+                list.append(KafkaTopicPartition(topic: topic, partition: KafkaPartition(rawValue: partition)))
+            }
+            blackHole(list)
+        }
+        benchmark.stopMeasurement()
+    }
+
+    Benchmark("KafkaTopicPartitionOffset_list_100") { benchmark in
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            var list: [KafkaTopicPartitionOffset] = []
+            list.reserveCapacity(100)
+            for partition in 0..<100 {
+                list.append(
+                    KafkaTopicPartitionOffset(
+                        topic: topic,
+                        partition: KafkaPartition(rawValue: partition),
+                        offset: .end
+                    )
+                )
+            }
+            blackHole(list)
+        }
+        benchmark.stopMeasurement()
+    }
+
+    // MARK: - Configuration construction (C1–C2)
+
+    Benchmark("KafkaProducerConfig_build") { benchmark in
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            var config = KafkaProducerConfig()
+            config.bootstrapServers = ["localhost:9092"]
+            config.brokerAddressFamily = .v4
+            blackHole(config)
+        }
+        benchmark.stopMeasurement()
+    }
+
+    Benchmark("KafkaConsumerConfig_build") { benchmark in
+        benchmark.startMeasurement()
+        for _ in benchmark.scaledIterations {
+            var config = KafkaConsumerConfig()
+            config.consumptionStrategy = .group(id: "benchmark-group", topics: [topic])
+            config.bootstrapServers = ["localhost:9092"]
+            config.brokerAddressFamily = .v4
+            blackHole(config)
+        }
+        benchmark.stopMeasurement()
+    }
+}

--- a/Benchmarks/Benchmarks/SwiftKafkaMockBenchmarks/MockProducerBenchmark.swift
+++ b/Benchmarks/Benchmarks/SwiftKafkaMockBenchmarks/MockProducerBenchmark.swift
@@ -1,0 +1,120 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-client open source project
+//
+// Copyright (c) 2025 Apple Inc. and the swift-kafka-client project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-client project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Benchmark
+import Kafka
+@_spi(Internal) import Kafka
+import Logging
+import ServiceLifecycle
+
+import class Foundation.ProcessInfo
+
+// Benchmark that runs against librdkafka's in-process mock cluster
+// (`test.mock.num.brokers`), exercising the real produce path end-to-end without
+// an external Kafka broker.
+//
+// The mock cluster is a full in-process broker (its own threads, timing-dependent
+// batching), so this benchmark is too noisy for absolute-threshold gating. It is
+// therefore opt-in via `KAFKA_MOCK_BENCHMARK` and only runs on a manual workflow
+// dispatch — never in the PR-gated benchmark set.
+//
+// Note: the mock cluster is per-client, so a message produced by one client is
+// not visible to a different client. That makes the *consumer* decode path
+// impossible to benchmark this way (a real `rd_kafka_message_t` requires a real
+// broker), so only the producer send path is covered here.
+
+// swift-format-ignore: DontRepeatTypeInStaticProperties
+extension Logger {
+    static let benchLogger: Logger = {
+        var logger = Logger(label: "benchmark")
+        logger.logLevel = .critical
+        return logger
+    }()
+}
+
+let benchmarks: @Sendable () -> Void = {
+    // Opt-in only (manual workflow dispatch). Registers nothing otherwise, so it
+    // never runs in the PR-gated benchmark set.
+    guard ProcessInfo.processInfo.environment["KAFKA_MOCK_BENCHMARK"] != nil else {
+        return
+    }
+
+    let messageCount: UInt = 1000
+
+    Benchmark.defaultConfiguration = .init(
+        metrics: [
+            .mallocCountTotal,
+            .instructions,
+            .allocatedResidentMemory,
+            .throughput,
+        ] + .arc,
+        warmupIterations: 1,
+        scalingFactor: .one,
+        maxDuration: .seconds(5),
+        maxIterations: 100,
+        thresholds: [
+            // Swift-level ARC counts are fairly stable for this path.
+            .objectAllocCount: .init(relative: [.p90: 15]),
+            .retainCount: .init(relative: [.p90: 15]),
+            .releaseCount: .init(relative: [.p90: 15]),
+            .retainReleaseDelta: .init(relative: [.p90: 15]),
+            .instructions: .init(relative: [.p90: 20]),
+            // Total mallocs and resident memory include librdkafka's mock-cluster
+            // internals and are noisy, so keep these tolerances wide.
+            .mallocCountTotal: .init(relative: [.p90: 40]),
+            .allocatedResidentMemory: .init(relative: [.p90: 30]),
+            .throughput: .init(relative: [.p90: 40]),
+        ]
+    )
+
+    Benchmark("Producer_sendAck_mockCluster_\(messageCount)") { benchmark in
+        var producerConfig = KafkaProducerConfig()
+        // Spin up an in-process mock broker instead of connecting to a real one.
+        producerConfig.additionalConfig["test.mock.num.brokers"] = "1"
+        producerConfig.brokerAddressFamily = .v4
+
+        let (producer, events) = try KafkaProducer.makeProducerWithEvents(
+            config: producerConfig,
+            logger: .benchLogger
+        )
+        let messages = _createTestMessages(topic: "benchmark-topic", count: messageCount)
+
+        let serviceGroupConfiguration = ServiceGroupConfiguration(
+            services: [producer],
+            gracefulShutdownSignals: [.sigterm, .sigint],
+            logger: .benchLogger
+        )
+        let serviceGroup = ServiceGroup(configuration: serviceGroupConfiguration)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            // Run the producer's poll loop so delivery reports are served.
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            // Send all messages and await their acknowledgements from the mock.
+            // Measured in the parent task so `benchmark` isn't captured by a child task.
+            benchmark.startMeasurement()
+            try await _sendAndAcknowledgeMessages(
+                producer: producer,
+                events: events,
+                messages: messages,
+                skipConsistencyCheck: true
+            )
+            benchmark.stopMeasurement()
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -18,7 +18,7 @@ import PackageDescription
 let package = Package(
     name: "benchmarks",
     platforms: [
-        .macOS(.v13)
+        .macOS(.v15)
     ],
     dependencies: [
         .package(path: "../"),
@@ -43,6 +43,28 @@ let package = Package(
                 .product(name: "Kafka", package: "swift-kafka-client"),
             ],
             path: "Benchmarks/SwiftKafkaProducerBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        ),
+        .executableTarget(
+            name: "SwiftKafkaMicroBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "Kafka", package: "swift-kafka-client"),
+            ],
+            path: "Benchmarks/SwiftKafkaMicroBenchmarks",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        ),
+        .executableTarget(
+            name: "SwiftKafkaMockBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "Kafka", package: "swift-kafka-client"),
+            ],
+            path: "Benchmarks/SwiftKafkaMockBenchmarks",
             plugins: [
                 .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
             ]

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaConsumerConfig_build.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaConsumerConfig_build.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1016
+}

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaProducerConfig_build.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaProducerConfig_build.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 16
+}

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaTopicPartitionOffset_list_100.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaTopicPartitionOffset_list_100.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1016
+}

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaTopicPartition_list_100.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.KafkaTopicPartition_list_100.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1016
+}

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_8_headers.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_8_headers.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1016
+}

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_ByteBuffer_256B.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_ByteBuffer_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 16
+}

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_String_256B.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_String_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 16
+}

--- a/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_UInt8_256B.p90.json
+++ b/Benchmarks/Thresholds/6.2/SwiftKafkaMicroBenchmarks.ProducerMessage_build_UInt8_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 16
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaConsumerConfig_build.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaConsumerConfig_build.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaProducerConfig_build.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaProducerConfig_build.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaTopicPartitionOffset_list_100.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaTopicPartitionOffset_list_100.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaTopicPartition_list_100.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.KafkaTopicPartition_list_100.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_8_headers.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_8_headers.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_ByteBuffer_256B.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_ByteBuffer_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_String_256B.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_String_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_UInt8_256B.p90.json
+++ b/Benchmarks/Thresholds/6.3/SwiftKafkaMicroBenchmarks.ProducerMessage_build_UInt8_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaConsumerConfig_build.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaConsumerConfig_build.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaProducerConfig_build.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaProducerConfig_build.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaTopicPartitionOffset_list_100.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaTopicPartitionOffset_list_100.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaTopicPartition_list_100.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.KafkaTopicPartition_list_100.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_8_headers.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_8_headers.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 1016,
+  "objectAllocCount": 1004
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_ByteBuffer_256B.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_ByteBuffer_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_String_256B.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_String_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_UInt8_256B.p90.json
+++ b/Benchmarks/Thresholds/nightly-next/SwiftKafkaMicroBenchmarks.ProducerMessage_build_UInt8_256B.p90.json
@@ -1,0 +1,4 @@
+{
+  "mallocCountTotal": 16,
+  "objectAllocCount": 4
+}

--- a/Sources/Kafka/Configuration/KafkaConsumerConfig.swift
+++ b/Sources/Kafka/Configuration/KafkaConsumerConfig.swift
@@ -1052,7 +1052,7 @@ public struct KafkaConsumerConfig: Sendable {
     /// - Warning: Properties set here override typed properties above.
     /// Intended for testing (e.g. `test.mock.num.brokers`) or advanced configurations
     /// not explicitly supported by this library.
-    internal var additionalConfig: [String: String] = [:]
+    @_spi(Internal) public var additionalConfig: [String: String] = [:]
 
     public init() {}
 

--- a/Sources/Kafka/Configuration/KafkaProducerConfig.swift
+++ b/Sources/Kafka/Configuration/KafkaProducerConfig.swift
@@ -1041,7 +1041,7 @@ public struct KafkaProducerConfig: Sendable {
     /// - Warning: Properties set here override typed properties above.
     /// Intended for testing (e.g. `test.mock.num.brokers`) or advanced configurations
     /// not explicitly supported by this library.
-    internal var additionalConfig: [String: String] = [:]
+    @_spi(Internal) public var additionalConfig: [String: String] = [:]
 
     public init() {}
 

--- a/Tests/KafkaTests/MockCluster.swift
+++ b/Tests/KafkaTests/MockCluster.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+@_spi(Internal) import Kafka
+
 @testable import Kafka
 
 /// Extensions for configuring librdkafka's built-in mock cluster.


### PR DESCRIPTION
### Motivation

We had no pull-request performance signal: allocations and instruction counts could regress silently. This adds [package-benchmark](https://github.com/ordo-one/package-benchmark)-based micro-benchmarks that run on each PR, reusing the same benchmark framework `swift-nio` provides.

### What this adds

**Deterministic micro-benchmarks** (`SwiftKafkaMicroBenchmarks`) — broker-free, pure-Swift hot paths measured for per-operation allocations (`mallocCountTotal` + `objectAllocCount`):
- `KafkaProducerMessage` construction — one benchmark per supported payload type, plus one carrying headers
- `KafkaTopicPartition` / `KafkaTopicPartitionOffset` input-list construction
- `KafkaProducerConfig` / `KafkaConsumerConfig` construction

**Mock-cluster benchmark** (`SwiftKafkaMockBenchmarks`) — a `send`+ack round-trip against librdkafka's in-process mock broker. It's an end-to-end benchmark through a real (in-process) broker, so it's noisy by nature — it lives in its own manual-only workflow (`benchmark-mock.yml`, `workflow_dispatch` / `KAFKA_MOCK_BENCHMARK`) and never runs on pull requests.

### How it runs

`.github/workflows/benchmark.yml` reuses NIO's benchmark framework — `generate_matrix.sh` + `swift_test_matrix.yml` + `check_benchmark_thresholds.sh` — with `libsasl2-dev`/`libssl-dev`/`libjemalloc-dev` added to the setup so librdkafka builds. It checks against committed per-Swift-version thresholds in `Benchmarks/Thresholds/<version>/`.

The gate is scoped for stability:
- **Only the deterministic micro-benchmarks are gated** — the mock benchmark and the broker-based consumer/producer benchmarks (gated behind `KAFKA_LIVE_BENCHMARKS`) never run in CI.
- **Runs on 6.2 / 6.3 and nightly-next.** nightly-main is excluded (Swift trunk is too volatile for stable baselines) and 6.1 is dropped.
- **Only deterministic allocation counts** (`mallocCountTotal` + `objectAllocCount`) with a small absolute tolerance (the swift-nio approach). The retain/release (ARC-traffic) counts, throughput, and resident memory are noisy and are not gated.

### Library change

`KafkaConsumerConfig`/`KafkaProducerConfig.additionalConfig` is exposed via `@_spi(Internal)` so the mock benchmark can enable `test.mock.num.brokers`. Additive and SPI-only — no stable public API change (API-breakage check passes).

### Notes

- The first benchmark run has no committed thresholds, so it generates them, prints them as a git diff in the job log, and fails once (NIO's bootstrap). Those JSON files are added to `Benchmarks/Thresholds/<version>/` and committed to the branch; subsequent runs then pass. The benchmark job is advisory, not a required check.
- `Benchmarks/Package.swift` deployment target bumped to macOS 15 to match the `Kafka` library floor.